### PR TITLE
fix(ray): preserve row semantics

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import importlib
 import os
+import pickle
 import tempfile
 import time
 from dataclasses import dataclass
@@ -16,6 +17,7 @@ import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.processors import ProcessorType
 from data_designer.config.run_config import RunConfig
+from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy, SeedConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
 from data_designer.engine.model_provider import resolve_model_provider_registry
@@ -34,6 +36,8 @@ if TYPE_CHECKING:
 
 RayOutputMode = Literal["dataset", "arrow_refs"]
 RayObjectRefInputFormat = Literal["arrow", "pandas"]
+_RAY_RANGE_ID_COLUMN = "id"
+_RAY_INTERNAL_ROW_ID_COLUMN = "__data_designer_ray_row_id"
 
 
 @dataclass(frozen=True)
@@ -46,6 +50,12 @@ class _RayWorkerOptions:
     person_reader: PersonReader | None
     mcp_providers: list[MCPProviderT]
     run_config: RunConfig
+
+
+@dataclass(frozen=True)
+class _RaySeedWindow:
+    start: int
+    size: int
 
 
 class RayDatasetCreationResults:
@@ -143,6 +153,7 @@ class RayBackend:
         order_column: str | None = None,
         drop_order_column: bool = False,
         preserve_order: bool = False,
+        keep_internal_order_column: bool = False,
         allow_unsafe_processors: bool = False,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
@@ -160,6 +171,7 @@ class RayBackend:
         self.order_column = order_column
         self.drop_order_column = drop_order_column
         self.preserve_order = preserve_order
+        self.keep_internal_order_column = keep_internal_order_column
         self.allow_unsafe_processors = allow_unsafe_processors
 
     def create(
@@ -183,27 +195,28 @@ class RayBackend:
             ray.init()
 
         use_input_dataset = input_dataset is not None
+        seed_config = config_builder.get_seed_config()
         if use_input_dataset and config_builder.get_seed_config() is not None:
             raise RayBackendConfigurationError(
                 "RayBackend input_dataset is used as the seed dataset; remove the existing seed config."
             )
-        if not use_input_dataset and config_builder.get_seed_config() is not None:
-            raise RayBackendConfigurationError(
-                "RayBackend does not yet support seed configs without input_dataset because partition offsets "
-                "are not available. Pass seed data as input_dataset, or use the local backend until "
-                "RayBackend partition-offset support exists."
+        seed_window = (
+            _preflight_seed_window(
+                data_designer=data_designer,
+                seed_config=seed_config,
+                num_records=num_records,
             )
-        if self.preserve_order and self.order_column is None:
-            raise RayBackendConfigurationError(
-                "RayBackend preserve_order=True requires order_column in this experimental backend. "
-                "Automatic hidden row-id injection is tracked as follow-up hardening work."
-            )
+            if not use_input_dataset and seed_config is not None
+            else None
+        )
         if not self.allow_unsafe_processors:
             _validate_ray_safe_processors(config_builder)
 
         dataset = self._resolve_input_dataset(ray, input_dataset=input_dataset, num_records=num_records)
+        hidden_order_column = _RAY_INTERNAL_ROW_ID_COLUMN if self.preserve_order and self.order_column is None else None
+        if hidden_order_column is not None and use_input_dataset:
+            dataset = _attach_hidden_row_id_column(ray, dataset, hidden_order_column=hidden_order_column)
         input_blocks = _get_num_blocks(dataset)
-        metrics_collector = _create_metrics_collector(ray)
         batch_size = self.batch_size or data_designer._run_config.buffer_size
         worker_options = _RayWorkerOptions(
             model_providers=list(data_designer._model_providers),
@@ -215,12 +228,20 @@ class RayBackend:
             mcp_providers=list(data_designer._mcp_providers),
             run_config=data_designer._run_config,
         )
+        worker_payload = {
+            "config_builder": config_builder,
+            "worker_options": worker_options,
+            "use_input_dataset": use_input_dataset,
+            "seed_window": seed_window,
+            "hidden_order_column": hidden_order_column,
+        }
+        _validate_worker_payload_serializable(worker_payload)
+
+        metrics_collector = _create_metrics_collector(ray)
 
         map_batches_kwargs: dict[str, Any] = {
             "fn_kwargs": {
-                "config_builder": config_builder,
-                "worker_options": worker_options,
-                "use_input_dataset": use_input_dataset,
+                **worker_payload,
                 "metrics_collector": metrics_collector,
             },
             "batch_size": batch_size,
@@ -232,13 +253,29 @@ class RayBackend:
 
         try:
             mapped = dataset.map_batches(_generate_batch, **map_batches_kwargs)
-            mapped = self._apply_ordering(mapped)
+        except RayDatasetGenerationError:
+            raise
+        except Exception as exc:
+            raise RayDatasetGenerationError(
+                "RayBackend failed while constructing the Ray map_batches execution plan."
+            ) from exc
+
+        try:
+            mapped = self._apply_ordering(mapped, hidden_order_column=hidden_order_column)
+        except RayDatasetGenerationError:
+            raise
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed while applying Ray output ordering.") from exc
+
+        try:
             output = mapped.to_arrow_refs() if self.output == "arrow_refs" else None
             result_dataset = _dataset_from_arrow_refs(ray, output) if output is not None else mapped
         except RayDatasetGenerationError:
             raise
         except Exception as exc:
-            raise RayDatasetGenerationError("RayBackend failed while constructing the Ray execution plan.") from exc
+            raise RayDatasetGenerationError(
+                "RayBackend failed while materializing Ray output blocks for output='arrow_refs'."
+            ) from exc
 
         output_blocks = len(output) if output is not None else _get_num_blocks(mapped)
         metrics = RayDatasetMetrics(
@@ -270,13 +307,89 @@ class RayBackend:
             "containing PyArrow tables or pandas DataFrames."
         )
 
-    def _apply_ordering(self, dataset: Any) -> Any:
-        if self.order_column is None:
+    def _apply_ordering(self, dataset: Any, *, hidden_order_column: str | None) -> Any:
+        order_column = self.order_column or hidden_order_column
+        if order_column is None:
             return dataset
-        ordered = dataset.sort(self.order_column)
+        ordered = dataset.sort(order_column)
+        if hidden_order_column is not None and order_column == hidden_order_column:
+            if self.keep_internal_order_column:
+                return ordered
+            return ordered.drop_columns([hidden_order_column])
         if self.drop_order_column:
-            return ordered.drop_columns([self.order_column])
+            return ordered.drop_columns([order_column])
         return ordered
+
+
+def _preflight_seed_window(
+    *,
+    data_designer: Any,
+    seed_config: SeedConfig,
+    num_records: int,
+) -> _RaySeedWindow:
+    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
+        raise RayBackendConfigurationError(
+            "RayBackend seed configs without input_dataset currently support only ordered sampling. "
+            "Pass the seed data as input_dataset or use the local backend for shuffled seed sampling."
+        )
+
+    try:
+        seed_reader = SeedReaderRegistry(
+            readers=_clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
+        ).get_reader(seed_config.source, data_designer._secret_resolver)
+        seed_dataset_size = seed_reader.get_seed_dataset_size()
+        index_range = _resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayBackendConfigurationError(
+            "RayBackend failed to preflight the seed config for partition offsets."
+        ) from exc
+
+    if num_records > index_range.size:
+        raise RayBackendConfigurationError(
+            "RayBackend seed configs without input_dataset require num_records to fit inside the selected seed "
+            f"range. Requested {num_records} records from {index_range.size} selected seed rows."
+        )
+    return _RaySeedWindow(start=index_range.start, size=index_range.size)
+
+
+def _resolve_seed_config_index_range(*, seed_config: SeedConfig, seed_dataset_size: int) -> IndexRange:
+    if seed_dataset_size <= 0:
+        raise RayBackendConfigurationError("RayBackend seed config resolved to an empty seed dataset.")
+    if seed_config.selection_strategy is None:
+        return IndexRange(start=0, end=seed_dataset_size - 1)
+    if isinstance(seed_config.selection_strategy, IndexRange):
+        if seed_config.selection_strategy.end >= seed_dataset_size:
+            raise RayBackendConfigurationError(
+                "RayBackend seed config selection_strategy is out of bounds for the seed dataset. "
+                f"Selection end={seed_config.selection_strategy.end}, seed rows={seed_dataset_size}."
+            )
+        return seed_config.selection_strategy
+    if isinstance(seed_config.selection_strategy, PartitionBlock):
+        if seed_config.selection_strategy.num_partitions > seed_dataset_size:
+            raise RayBackendConfigurationError(
+                "RayBackend seed config selection_strategy is out of bounds for the seed dataset. "
+                f"Partition count={seed_config.selection_strategy.num_partitions}, seed rows={seed_dataset_size}."
+            )
+        return seed_config.selection_strategy.to_index_range(seed_dataset_size)
+    raise RayBackendConfigurationError(
+        "RayBackend seed config uses an unsupported selection_strategy for partitioned execution."
+    )
+
+
+def _validate_worker_payload_serializable(payload: dict[str, Any]) -> None:
+    try:
+        serializer = importlib.import_module("cloudpickle")
+    except ImportError:
+        serializer = pickle
+    try:
+        serializer.dumps(payload)
+    except Exception as exc:
+        raise RayBackendConfigurationError(
+            "RayBackend worker payload is not serializable. Check model providers, seed readers, "
+            "secret resolvers, and MCP providers for process-safe state before launching Ray workers."
+        ) from exc
 
 
 def _validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
@@ -306,6 +419,47 @@ def _get_num_blocks(dataset: Any) -> int | None:
     return int(value) if value is not None else None
 
 
+def _count_dataset_rows(dataset: Any) -> int:
+    count = getattr(dataset, "count", None)
+    if not callable(count):
+        raise RayBackendConfigurationError(
+            "RayBackend preserve_order=True for input datasets requires ray.data.Dataset.count()."
+        )
+    try:
+        return int(count())
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend failed to count input rows for hidden order preservation.") from exc
+
+
+def _attach_hidden_row_id_column(ray: Any, dataset: Any, *, hidden_order_column: str) -> Any:
+    row_count = _count_dataset_rows(dataset)
+    try:
+        order_dataset = ray.data.range(row_count).map_batches(
+            _rename_range_id_column,
+            fn_kwargs={"hidden_order_column": hidden_order_column},
+            batch_format="pandas",
+        )
+        zip_dataset = getattr(dataset, "zip", None)
+        if not callable(zip_dataset):
+            raise RayBackendConfigurationError(
+                "RayBackend preserve_order=True for input datasets requires ray.data.Dataset.zip()."
+            )
+        return zip_dataset(order_dataset)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend failed to attach hidden row ids to the input dataset.") from exc
+
+
+def _rename_range_id_column(batch: Any, *, hidden_order_column: str) -> Any:
+    dataframe = _coerce_pandas_dataframe(batch)
+    if _RAY_RANGE_ID_COLUMN not in dataframe.columns:
+        raise RayDatasetGenerationError(
+            f"RayBackend expected ray.data.range() batches to include {_RAY_RANGE_ID_COLUMN!r}."
+        )
+    return lazy.pd.DataFrame({hidden_order_column: dataframe[_RAY_RANGE_ID_COLUMN].tolist()})
+
+
 def _dataset_from_arrow_refs(ray: Any, refs: list[Any]) -> Any:
     from_arrow_refs = getattr(ray.data, "from_arrow_refs", None)
     if not callable(from_arrow_refs):
@@ -313,7 +467,12 @@ def _dataset_from_arrow_refs(ray: Any, refs: list[Any]) -> Any:
             "RayBackend output='arrow_refs' requires ray.data.from_arrow_refs to expose a dataset "
             "backed by the materialized Arrow ObjectRefs."
         )
-    return from_arrow_refs(refs)
+    try:
+        return from_arrow_refs(refs)
+    except Exception as exc:
+        raise RayDatasetGenerationError(
+            "RayBackend failed to rebuild a Ray Dataset from materialized Arrow ObjectRefs."
+        ) from exc
 
 
 class _RayMetricsCollector:
@@ -365,6 +524,8 @@ def _generate_batch(
     config_builder: DataDesignerConfigBuilder,
     worker_options: _RayWorkerOptions,
     use_input_dataset: bool,
+    seed_window: _RaySeedWindow | None = None,
+    hidden_order_column: str | None = None,
     metrics_collector: Any | None = None,
 ) -> Any:
     start_time = time.perf_counter()
@@ -380,8 +541,20 @@ def _generate_batch(
 
     try:
         block_builder = copy.deepcopy(config_builder)
+        order_values = _get_hidden_order_values(dataframe, hidden_order_column=hidden_order_column)
         if use_input_dataset:
-            block_builder.with_seed_dataset(DataFrameSeedSource(df=dataframe.copy()))
+            block_builder.with_seed_dataset(DataFrameSeedSource(df=_strip_internal_columns(dataframe)))
+        elif seed_window is not None:
+            block_builder.with_seed_dataset(
+                DataFrameSeedSource(
+                    df=_read_seed_window_dataframe(
+                        config_builder=block_builder,
+                        worker_options=worker_options,
+                        dataframe=dataframe,
+                        seed_window=seed_window,
+                    )
+                )
+            )
 
         with tempfile.TemporaryDirectory(prefix="data-designer-ray-") as artifact_dir:
             ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
@@ -410,6 +583,12 @@ def _generate_batch(
             )
             raw_dataset = builder.build_preview(num_records=num_records)
             output = builder.process_preview(raw_dataset)
+            if hidden_order_column is not None:
+                output = _append_hidden_order_column(
+                    output,
+                    order_values=order_values,
+                    hidden_order_column=hidden_order_column,
+                )
             elapsed_seconds = time.perf_counter() - start_time
             _record_worker_metrics(
                 metrics_collector,
@@ -421,7 +600,7 @@ def _generate_batch(
                 ),
             )
             return output
-    except Exception:
+    except Exception as exc:
         _record_worker_metrics(
             metrics_collector,
             RayWorkerMetrics(
@@ -431,7 +610,135 @@ def _generate_batch(
                 elapsed_seconds=time.perf_counter() - start_time,
             ),
         )
-        raise
+        raise RayDatasetGenerationError(_format_worker_failure_message(dataframe=dataframe, exc=exc)) from exc
+
+
+def _strip_internal_columns(dataframe: Any) -> Any:
+    columns_to_drop = [column for column in (_RAY_INTERNAL_ROW_ID_COLUMN,) if column in dataframe.columns]
+    if not columns_to_drop:
+        return dataframe.copy()
+    return dataframe.drop(columns=columns_to_drop).copy()
+
+
+def _get_hidden_order_values(dataframe: Any, *, hidden_order_column: str | None) -> list[int]:
+    if hidden_order_column is None:
+        return []
+    if hidden_order_column in dataframe.columns:
+        values = dataframe[hidden_order_column].tolist()
+    elif _RAY_RANGE_ID_COLUMN in dataframe.columns:
+        values = dataframe[_RAY_RANGE_ID_COLUMN].tolist()
+    else:
+        raise RayDatasetGenerationError(
+            "RayBackend preserve_order=True could not find the hidden row-id source column in a Ray worker batch."
+        )
+    return [int(value) for value in values]
+
+
+def _append_hidden_order_column(
+    output: Any,
+    *,
+    order_values: list[int],
+    hidden_order_column: str,
+) -> Any:
+    if len(output) != len(order_values):
+        raise RayDatasetGenerationError(
+            "RayBackend preserve_order=True requires each Ray worker batch to emit one output row for each "
+            f"input row. Input rows={len(order_values)}, output rows={len(output)}."
+        )
+    output = output.copy()
+    output[hidden_order_column] = order_values
+    return output
+
+
+def _read_seed_window_dataframe(
+    *,
+    config_builder: DataDesignerConfigBuilder,
+    worker_options: _RayWorkerOptions,
+    dataframe: Any,
+    seed_window: _RaySeedWindow,
+) -> Any:
+    seed_config = config_builder.get_seed_config()
+    if seed_config is None:
+        raise RayDatasetGenerationError("RayBackend seed window was provided without a seed config.")
+    row_offsets = _get_contiguous_range_offsets(dataframe)
+    index_range = IndexRange(
+        start=seed_window.start + row_offsets[0],
+        end=seed_window.start + row_offsets[-1],
+    )
+    if row_offsets[-1] >= seed_window.size:
+        raise RayDatasetGenerationError(
+            "RayBackend seed partition offset exceeded the selected seed range. "
+            f"Offset={row_offsets[-1]}, selected seed rows={seed_window.size}."
+        )
+
+    seed_reader = SeedReaderRegistry(readers=copy.deepcopy(worker_options.seed_readers)).get_reader(
+        seed_config.source,
+        worker_options.secret_resolver,
+    )
+    batch_reader = seed_reader.create_batch_reader(
+        batch_size=len(row_offsets),
+        index_range=index_range,
+        shuffle=False,
+    )
+    seed_dataframe = batch_reader.read_next_batch().to_pandas().reset_index(drop=True)
+    if len(seed_dataframe) != len(row_offsets):
+        raise RayDatasetGenerationError(
+            "RayBackend seed reader returned an unexpected row count for a partition offset. "
+            f"Expected {len(row_offsets)} rows, got {len(seed_dataframe)}."
+        )
+    return seed_dataframe
+
+
+def _get_contiguous_range_offsets(dataframe: Any) -> list[int]:
+    if _RAY_RANGE_ID_COLUMN not in dataframe.columns:
+        raise RayDatasetGenerationError(
+            f"RayBackend seed partition offsets require {_RAY_RANGE_ID_COLUMN!r} from ray.data.range()."
+        )
+    row_offsets = [int(value) for value in dataframe[_RAY_RANGE_ID_COLUMN].tolist()]
+    if not row_offsets:
+        raise RayDatasetGenerationError("RayBackend seed partition offsets received an empty Ray worker batch.")
+    expected_offsets = list(range(row_offsets[0], row_offsets[0] + len(row_offsets)))
+    if row_offsets != expected_offsets:
+        raise RayDatasetGenerationError(
+            "RayBackend seed partition offsets require contiguous ray.data.range() batches. "
+            f"Received offsets {row_offsets!r}."
+        )
+    return row_offsets
+
+
+def _format_worker_failure_message(*, dataframe: Any, exc: Exception) -> str:
+    context_parts = [f"{len(dataframe)} input row(s)"]
+    if _RAY_INTERNAL_ROW_ID_COLUMN in dataframe.columns:
+        row_ids = [int(value) for value in dataframe[_RAY_INTERNAL_ROW_ID_COLUMN].tolist()]
+        if row_ids:
+            context_parts.append(f"logical rows {min(row_ids)}-{max(row_ids)}")
+    elif _RAY_RANGE_ID_COLUMN in dataframe.columns:
+        row_ids = [int(value) for value in dataframe[_RAY_RANGE_ID_COLUMN].tolist()]
+        if row_ids:
+            context_parts.append(f"range rows {min(row_ids)}-{max(row_ids)}")
+    task_context = _get_ray_task_context()
+    if task_context:
+        context_parts.append(task_context)
+    return f"RayBackend worker failed while generating a Ray block ({', '.join(context_parts)}): {exc}"
+
+
+def _get_ray_task_context() -> str | None:
+    try:
+        ray = importlib.import_module("ray")
+        get_runtime_context = getattr(ray, "get_runtime_context", None)
+        if not callable(get_runtime_context):
+            return None
+        runtime_context = get_runtime_context()
+    except Exception:
+        return None
+
+    context_values: list[str] = []
+    for attr in ("task_id", "actor_id", "worker_id"):
+        value = getattr(runtime_context, attr, None)
+        if value is None:
+            continue
+        context_values.append(f"{attr}={value}")
+    return ", ".join(context_values) if context_values else None
 
 
 def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -18,20 +18,41 @@ from data_designer.config.run_config import RunConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
-from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetMetrics
+from data_designer.integrations.ray import (
+    RayBackend,
+    RayBackendConfigurationError,
+    RayDatasetCreationResults,
+    RayDatasetGenerationError,
+    RayDatasetMetrics,
+)
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
 
 
 class FakeRayDataset:
-    def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
+    def __init__(self, blocks: list[lazy.pd.DataFrame], *, reverse_mapped_blocks: bool = False) -> None:
         self.blocks = blocks
+        self.reverse_mapped_blocks = reverse_mapped_blocks
         self.map_batches_kwargs: dict[str, Any] | None = None
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         self.map_batches_kwargs = kwargs
         fn_kwargs = kwargs.get("fn_kwargs") or {}
-        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+        blocks = [fn(block, **fn_kwargs) for block in self.blocks]
+        if self.reverse_mapped_blocks:
+            blocks.reverse()
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
+
+    def zip(self, other: FakeRayDataset) -> FakeRayDataset:
+        other_df = other.to_pandas()
+        offset = 0
+        blocks: list[lazy.pd.DataFrame] = []
+        for block in self.blocks:
+            block_len = len(block)
+            other_block = other_df.iloc[offset : offset + block_len].reset_index(drop=True)
+            blocks.append(lazy.pd.concat([block.reset_index(drop=True), other_block], axis=1))
+            offset += block_len
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
 
     def to_arrow_refs(self) -> list[str]:
         return [f"arrow-ref-{i}" for i, _ in enumerate(self.blocks)]
@@ -49,6 +70,9 @@ class FakeRayDataset:
     def num_blocks(self) -> int:
         return len(self.blocks)
 
+    def count(self) -> int:
+        return sum(len(block) for block in self.blocks)
+
 
 class FakeRayDataModule:
     Dataset = FakeRayDataset
@@ -56,17 +80,21 @@ class FakeRayDataModule:
     def __init__(self) -> None:
         self.from_arrow_refs_input: list[Any] | None = None
         self.from_pandas_refs_input: list[Any] | None = None
+        self.reverse_mapped_blocks = False
 
     def range(self, num_records: int) -> FakeRayDataset:
         return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
 
     def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_arrow_refs_input = refs
-        return FakeRayDataset([_arrow_ref_to_pandas(ref) for ref in refs])
+        return FakeRayDataset(
+            [_arrow_ref_to_pandas(ref) for ref in refs],
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
 
     def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_pandas_refs_input = refs
-        return FakeRayDataset(list(refs))
+        return FakeRayDataset(list(refs), reverse_mapped_blocks=self.reverse_mapped_blocks)
 
 
 class CountingRayDataset:
@@ -267,22 +295,35 @@ def test_ray_backend_can_sort_by_explicit_order_column(
     ]
 
 
-def test_ray_backend_requires_order_column_for_preserve_order(
+def test_ray_backend_preserve_order_does_not_require_explicit_order_column(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    stub_sampler_only_config_builder: Any,
+    stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
     _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset(
+        [
+            lazy.pd.DataFrame({"x": [1], "label": ["a"]}),
+            lazy.pd.DataFrame({"x": [2], "label": ["b"]}),
+        ],
+        reverse_mapped_blocks=True,
+    )
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
         managed_assets_path=_managed_assets_path(tmp_path),
         backend=RayBackend(preserve_order=True),
     )
+    config_builder = _input_expression_config_builder(stub_model_configs)
 
-    with pytest.raises(RayBackendConfigurationError, match="requires order_column"):
-        designer.create(stub_sampler_only_config_builder, num_records=1)
+    output_df = designer.create(config_builder, input_dataset=input_dataset).load_dataset().to_pandas()
+
+    assert output_df.to_dict(orient="records") == [
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+    ]
 
 
 def test_ray_backend_uses_pandas_object_refs_as_in_memory_seed(
@@ -427,6 +468,25 @@ def test_ray_backend_arrow_refs_load_dataset_uses_materialized_refs_without_reru
         {"id": 1, "generated": 1},
     ]
     assert generate_calls == 1
+
+
+def test_ray_results_to_arrow_refs_wraps_materialization_failures(
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    class FailingArrowDataset:
+        def to_arrow_refs(self) -> list[Any]:
+            raise RuntimeError("object store unavailable")
+
+    results = RayDatasetCreationResults(
+        dataset=FailingArrowDataset(),
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(),
+    )
+
+    with pytest.raises(RayDatasetGenerationError, match="materialize Arrow ObjectRefs") as exc_info:
+        results.to_arrow_refs()
+
+    assert "object store unavailable" in str(exc_info.value.__cause__)
 
 
 def test_ray_backend_dataset_output_wraps_dataset_and_delegates_arrow_refs(

--- a/packages/data-designer/tests/integrations/ray/test_semantics.py
+++ b/packages/data-designer/tests/integrations/ray/test_semantics.py
@@ -13,21 +13,37 @@ import pytest
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend
 from data_designer.interface.data_designer import DataDesigner
 
 
 class FakeRayDataset:
-    def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
+    def __init__(self, blocks: list[lazy.pd.DataFrame], *, reverse_mapped_blocks: bool = False) -> None:
         self.blocks = blocks
+        self.reverse_mapped_blocks = reverse_mapped_blocks
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         fn_kwargs = kwargs.get("fn_kwargs") or {}
-        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+        blocks = [fn(block, **fn_kwargs) for block in self.blocks]
+        if self.reverse_mapped_blocks:
+            blocks.reverse()
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
 
-    def to_arrow_refs(self) -> list[str]:
-        return [f"arrow-ref-{i}" for i, _ in enumerate(self.blocks)]
+    def zip(self, other: FakeRayDataset) -> FakeRayDataset:
+        other_df = other.to_pandas()
+        offset = 0
+        blocks: list[lazy.pd.DataFrame] = []
+        for block in self.blocks:
+            block_len = len(block)
+            other_block = other_df.iloc[offset : offset + block_len].reset_index(drop=True)
+            blocks.append(lazy.pd.concat([block.reset_index(drop=True), other_block], axis=1))
+            offset += block_len
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
+
+    def to_arrow_refs(self) -> list[lazy.pd.DataFrame]:
+        return self.blocks
 
     def to_pandas(self) -> lazy.pd.DataFrame:
         return lazy.pd.concat(self.blocks, ignore_index=True)
@@ -42,6 +58,9 @@ class FakeRayDataset:
     def num_blocks(self) -> int:
         return len(self.blocks)
 
+    def count(self) -> int:
+        return sum(len(block) for block in self.blocks)
+
 
 class FakeRayDataModule:
     Dataset = FakeRayDataset
@@ -49,17 +68,23 @@ class FakeRayDataModule:
     def __init__(self) -> None:
         self.from_arrow_refs_input: list[Any] | None = None
         self.from_pandas_refs_input: list[Any] | None = None
+        self.range_blocks: list[lazy.pd.DataFrame] | None = None
+        self.reverse_mapped_blocks = False
 
     def range(self, num_records: int) -> FakeRayDataset:
-        return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+        blocks = self.range_blocks or [lazy.pd.DataFrame({"id": list(range(num_records))})]
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
 
     def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_arrow_refs_input = refs
-        return FakeRayDataset([_arrow_ref_to_pandas(ref) for ref in refs])
+        return FakeRayDataset(
+            [_arrow_ref_to_pandas(ref) for ref in refs],
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
 
     def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_pandas_refs_input = refs
-        return FakeRayDataset(list(refs))
+        return FakeRayDataset(list(refs), reverse_mapped_blocks=self.reverse_mapped_blocks)
 
 
 def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
@@ -87,7 +112,7 @@ def _designer(
     *,
     tmp_path: Path,
     stub_model_providers: Any,
-    backend: RayBackend,
+    backend: RayBackend | None,
 ) -> DataDesigner:
     return DataDesigner(
         artifact_path=tmp_path,
@@ -106,6 +131,12 @@ def _summary_config_builder(stub_model_configs: Any) -> DataDesignerConfigBuilde
             expr="{{ sku }}:{{ label }}",
         )
     )
+    return config_builder
+
+
+def _summary_seed_config_builder(stub_model_configs: Any, seed_df: lazy.pd.DataFrame) -> DataDesignerConfigBuilder:
+    config_builder = _summary_config_builder(stub_model_configs)
+    config_builder.with_seed_dataset(DataFrameSeedSource(df=seed_df))
     return config_builder
 
 
@@ -150,6 +181,199 @@ def test_explicit_order_column_sorts_stably_and_can_be_dropped(
     assert output_df["summary"].tolist() == ["a:first", "b:second", "c:third", "d:fourth", "e:fifth"]
     if not drop_order_column:
         assert output_df["row_order"].tolist() == [0, 1, 2, 3, 4]
+
+
+def test_hidden_row_id_preserves_input_dataset_order_without_schema_pollution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset(
+        [
+            lazy.pd.DataFrame({"sku": ["a", "b"], "label": ["first", "second"]}),
+            lazy.pd.DataFrame({"sku": ["c"], "label": ["third"]}),
+            lazy.pd.DataFrame({"sku": ["d", "e"], "label": ["fourth", "fifth"]}),
+        ],
+        reverse_mapped_blocks=True,
+    )
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=1, preserve_order=True),
+    )
+
+    output_df = (
+        designer.create(_summary_config_builder(stub_model_configs), input_dataset=input_dataset)
+        .load_dataset()
+        .to_pandas()
+    )
+
+    assert list(output_df.columns) == ["sku", "label", "summary"]
+    assert output_df["sku"].tolist() == ["a", "b", "c", "d", "e"]
+    assert output_df["summary"].tolist() == [
+        "a:first",
+        "b:second",
+        "c:third",
+        "d:fourth",
+        "e:fifth",
+    ]
+    assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+@pytest.mark.parametrize("object_ref_format", ["pandas", "arrow"])
+def test_hidden_row_id_preserves_object_ref_order_without_schema_pollution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+    object_ref_format: str,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray.data.reverse_mapped_blocks = True
+    if object_ref_format == "pandas":
+        input_refs: list[Any] = [
+            lazy.pd.DataFrame({"sku": ["a"], "label": ["first"]}),
+            lazy.pd.DataFrame({"sku": ["b"], "label": ["second"]}),
+            lazy.pd.DataFrame({"sku": ["c"], "label": ["third"]}),
+        ]
+    else:
+        input_refs = [
+            lazy.pa.table({"sku": ["a"], "label": ["first"]}),
+            lazy.pa.table({"sku": ["b"], "label": ["second"]}),
+            lazy.pa.table({"sku": ["c"], "label": ["third"]}),
+        ]
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=1, object_ref_format=object_ref_format, preserve_order=True),
+    )
+
+    output_df = (
+        designer.create(_summary_config_builder(stub_model_configs), input_dataset=input_refs)
+        .load_dataset()
+        .to_pandas()
+    )
+
+    assert output_df.to_dict(orient="records") == [
+        {"sku": "a", "label": "first", "summary": "a:first"},
+        {"sku": "b", "label": "second", "summary": "b:second"},
+        {"sku": "c", "label": "third", "summary": "c:third"},
+    ]
+    assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+def test_hidden_row_id_preserves_arrow_ref_output_order_without_schema_pollution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset(
+        [
+            lazy.pd.DataFrame({"sku": ["a"], "label": ["first"]}),
+            lazy.pd.DataFrame({"sku": ["b"], "label": ["second"]}),
+        ],
+        reverse_mapped_blocks=True,
+    )
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=1, output="arrow_refs", preserve_order=True),
+    )
+
+    results = designer.create(_summary_config_builder(stub_model_configs), input_dataset=input_dataset)
+    output_df = results.load_dataset().to_pandas()
+
+    assert len(results.output) == 1
+    assert output_df.to_dict(orient="records") == [
+        {"sku": "a", "label": "first", "summary": "a:first"},
+        {"sku": "b", "label": "second", "summary": "b:second"},
+    ]
+    assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+def test_hidden_row_id_preserves_from_scratch_order_without_schema_pollution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray.data.range_blocks = [
+        lazy.pd.DataFrame({"id": [0, 1]}),
+        lazy.pd.DataFrame({"id": [2]}),
+        lazy.pd.DataFrame({"id": [3, 4]}),
+    ]
+    fake_ray.data.reverse_mapped_blocks = True
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=1, preserve_order=True),
+    )
+
+    output_df = designer.create(stub_sampler_only_config_builder, num_records=5).load_dataset().to_pandas()
+
+    assert len(output_df) == 5
+    assert list(output_df.columns) == ["uuid", "category", "uniform"]
+    assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+def test_seed_config_without_input_dataset_reads_partition_offsets_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray.data.range_blocks = [
+        lazy.pd.DataFrame({"id": [0, 1]}),
+        lazy.pd.DataFrame({"id": [2, 3]}),
+        lazy.pd.DataFrame({"id": [4]}),
+    ]
+    seed_df = lazy.pd.DataFrame(
+        {
+            "sku": ["a", "b", "c", "d", "e"],
+            "label": ["first", "second", "third", "fourth", "fifth"],
+        }
+    )
+    local_before = _designer(
+        tmp_path=tmp_path / "local-before",
+        stub_model_providers=stub_model_providers,
+        backend=None,
+    )
+    ray_designer = _designer(
+        tmp_path=tmp_path / "ray",
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=2),
+    )
+    local_after = _designer(
+        tmp_path=tmp_path / "local-after",
+        stub_model_providers=stub_model_providers,
+        backend=None,
+    )
+
+    assert (
+        len(local_before.preview(_summary_seed_config_builder(stub_model_configs, seed_df), num_records=1).dataset) == 1
+    )
+    output_df = (
+        ray_designer.create(_summary_seed_config_builder(stub_model_configs, seed_df), num_records=5)
+        .load_dataset()
+        .to_pandas()
+    )
+    assert (
+        len(local_after.preview(_summary_seed_config_builder(stub_model_configs, seed_df), num_records=1).dataset) == 1
+    )
+
+    assert output_df.to_dict(orient="records") == [
+        {"sku": "a", "label": "first", "summary": "a:first"},
+        {"sku": "b", "label": "second", "summary": "b:second"},
+        {"sku": "c", "label": "third", "summary": "c:third"},
+        {"sku": "d", "label": "fourth", "summary": "d:fourth"},
+        {"sku": "e", "label": "fifth", "summary": "e:fifth"},
+    ]
 
 
 def test_pandas_object_refs_preserve_schema_column_order(

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -15,10 +15,11 @@ import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.run_config import RunConfig
+from data_designer.config.seed import SamplingStrategy
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
-from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError
+from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
 
@@ -234,7 +235,7 @@ def test_driver_preflight_rejects_input_dataset_with_existing_seed_config(
     assert input_dataset.map_batches_called is False
 
 
-def test_driver_preflight_rejects_seed_config_without_input_dataset(
+def test_driver_preflight_rejects_shuffled_seed_config_without_input_dataset(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     stub_model_configs: Any,
@@ -242,7 +243,10 @@ def test_driver_preflight_rejects_seed_config_without_input_dataset(
 ) -> None:
     fake_ray = _install_boundary_ray(monkeypatch)
     config_builder = _input_expression_config_builder(stub_model_configs)
-    config_builder.with_seed_dataset(DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [99], "label": ["seed"]})))
+    config_builder.with_seed_dataset(
+        DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [99], "label": ["seed"]})),
+        sampling_strategy=SamplingStrategy.SHUFFLE,
+    )
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -251,7 +255,41 @@ def test_driver_preflight_rejects_seed_config_without_input_dataset(
         backend=RayBackend(batch_size=1),
     )
 
-    with pytest.raises(RayBackendConfigurationError):
+    with pytest.raises(RayBackendConfigurationError, match="ordered sampling"):
         designer.create(config_builder, num_records=2)
 
     assert fake_ray.data.range_dataset is None
+
+
+def test_worker_failure_includes_block_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    class FailingDatasetBuilder:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        def build_preview(self, *, num_records: int) -> lazy.pd.DataFrame:
+            del num_records
+            raise RuntimeError("worker boom")
+
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    monkeypatch.setattr(ray_backend_module, "DatasetBuilder", FailingDatasetBuilder)
+
+    with pytest.raises(RayDatasetGenerationError, match="range rows 5-6") as exc_info:
+        ray_backend_module._generate_batch(
+            lazy.pd.DataFrame({"id": [5, 6]}),
+            config_builder=_input_expression_config_builder(stub_model_configs),
+            worker_options=_worker_options_from_designer(designer),
+            use_input_dataset=False,
+        )
+
+    assert "2 input row(s)" in str(exc_info.value)
+    assert "worker boom" in str(exc_info.value)


### PR DESCRIPTION
## 📋 Summary

This PR hardens the experimental Ray backend row semantics. It adds automatic hidden row ids for `preserve_order=True`, reads ordered seed configs by per-partition offsets, and normalizes Ray worker/materialization failures with DataDesigner Ray errors that include row context.

## 🔗 Related Issue

Fixes #6
Fixes #7
Fixes #9

## 🔄 Changes

- Add internal row-id injection for Ray Dataset, pandas ObjectRef, Arrow ObjectRef, and from-scratch preserve-order paths, then sort and drop the hidden column by default.
- Support ordered seed configs without `input_dataset` by preflighting seed bounds and reading per-worker contiguous seed ranges from existing seed readers.
- Reject shuffled or out-of-range seed configs before Ray tasks launch with `RayBackendConfigurationError`.
- Wrap worker, ordering, Arrow materialization, and Arrow-ref dataset rebuild failures in Ray integration errors with stage and row/block context.
- Extend Ray semantics and worker-boundary tests for hidden order columns, seed offsets, serialization/preflight behavior, and materialization error wrapping.

## 🧪 Testing

- [x] `uv run --all-packages --group dev pytest packages/data-designer/tests/integrations/ray`
- [x] `uv run --all-packages --group dev ruff check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_semantics.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [x] `uv run --all-packages --group dev ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_semantics.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [ ] `make test` passes (not run; targeted Ray integration suite run)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A)