### PR TITLE
feat(ray): add execution controls

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -16,15 +16,23 @@ from data_designer.integrations.ray.metrics import (
     aggregate_ray_metrics,
     normalize_ray_worker_metrics,
 )
+from data_designer.integrations.ray.options import (
+    RayBlockPlanning,
+    RayExecutionOptions,
+    RayResolvedBlockPlan,
+)
 
 __all__ = [
     "RayBackend",
     "RayBackendConfigurationError",
+    "RayBlockPlanning",
     "RayDatasetCreationResults",
     "RayDatasetGenerationError",
     "RayDatasetMetrics",
+    "RayExecutionOptions",
     "RayIntegrationError",
     "RayMetricsError",
+    "RayResolvedBlockPlan",
     "RayWorkerMetrics",
     "aggregate_ray_metrics",
     "normalize_ray_worker_metrics",

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -13,10 +13,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
 
 import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.column_configs import CustomColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.processors import ProcessorType
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
+from data_designer.engine.column_generators.utils.generator_classification import column_type_is_model_generated
 from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
 from data_designer.engine.model_provider import resolve_model_provider_registry
 from data_designer.engine.resources.person_reader import PersonReader, create_person_reader
@@ -26,6 +28,7 @@ from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, RayMapConcurrency
 
 if TYPE_CHECKING:
     from data_designer.config.mcp import MCPProviderT
@@ -140,6 +143,27 @@ class RayBackend:
         auto_init: bool = False,
         zero_copy_batch: bool = True,
         ray_remote_args: dict[str, Any] | None = None,
+        block_planning: RayBlockPlanning | None = None,
+        override_num_blocks: int | None = None,
+        target_block_size: int | None = None,
+        min_blocks: int | None = None,
+        max_blocks: int | None = None,
+        read_concurrency: int | None = None,
+        execution_options: RayExecutionOptions | None = None,
+        num_cpus: float | None = None,
+        num_gpus: float | None = None,
+        memory: float | None = None,
+        resources: dict[str, float] | None = None,
+        scheduling_strategy: Any | None = None,
+        compute: Any | None = None,
+        map_concurrency: RayMapConcurrency | None = None,
+        ray_remote_args_fn: Any | None = None,
+        use_actor_pool: bool = False,
+        actor_pool_min_size: int | None = None,
+        actor_pool_max_size: int | None = None,
+        actor_pool_initial_size: int | None = None,
+        preflight_model_health_check: bool = True,
+        worker_model_health_checks: bool = False,
         order_column: str | None = None,
         drop_order_column: bool = False,
         preserve_order: bool = False,
@@ -151,12 +175,38 @@ class RayBackend:
             raise ValueError("RayBackend object_ref_format must be 'arrow' or 'pandas'.")
         if order_column is not None and order_column == "":
             raise ValueError("RayBackend order_column must be a non-empty string when provided.")
+        self.block_planning = _resolve_block_planning(
+            block_planning,
+            override_num_blocks=override_num_blocks,
+            target_block_size=target_block_size,
+            min_blocks=min_blocks,
+            max_blocks=max_blocks,
+            read_concurrency=read_concurrency,
+        )
+        self.execution_options = _resolve_execution_options(
+            execution_options,
+            ray_remote_args=ray_remote_args,
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+            memory=memory,
+            resources=resources,
+            scheduling_strategy=scheduling_strategy,
+            compute=compute,
+            map_concurrency=map_concurrency,
+            ray_remote_args_fn=ray_remote_args_fn,
+            use_actor_pool=use_actor_pool,
+            actor_pool_min_size=actor_pool_min_size,
+            actor_pool_max_size=actor_pool_max_size,
+            actor_pool_initial_size=actor_pool_initial_size,
+        )
         self.batch_size = batch_size
         self.output = output
         self.object_ref_format = object_ref_format
         self.auto_init = auto_init
         self.zero_copy_batch = zero_copy_batch
         self.ray_remote_args = ray_remote_args
+        self.preflight_model_health_check = preflight_model_health_check
+        self.worker_model_health_checks = worker_model_health_checks
         self.order_column = order_column
         self.drop_order_column = drop_order_column
         self.preserve_order = preserve_order
@@ -198,13 +248,33 @@ class RayBackend:
                 "RayBackend preserve_order=True requires order_column in this experimental backend. "
                 "Automatic hidden row-id injection is tracked as follow-up hardening work."
             )
+        if use_input_dataset and self.block_planning.has_explicit_controls:
+            raise RayBackendConfigurationError(
+                "RayBackend block planning controls apply only when RayBackend creates a from-scratch "
+                "range dataset. Remove override_num_blocks, target_block_size, min_blocks, max_blocks, "
+                "and read_concurrency when passing input_dataset."
+            )
         if not self.allow_unsafe_processors:
             _validate_ray_safe_processors(config_builder)
 
-        dataset = self._resolve_input_dataset(ray, input_dataset=input_dataset, num_records=num_records)
+        model_aliases = _model_health_check_aliases(config_builder)
+        if self.preflight_model_health_check:
+            _run_driver_model_health_check(data_designer, config_builder, model_aliases)
+
+        block_plan = self.block_planning.resolve(num_records=num_records) if input_dataset is None else None
+        dataset = self._resolve_input_dataset(
+            ray,
+            input_dataset=input_dataset,
+            num_records=num_records,
+            block_plan=block_plan,
+        )
         input_blocks = _get_num_blocks(dataset)
         metrics_collector = _create_metrics_collector(ray)
         batch_size = self.batch_size or data_designer._run_config.buffer_size
+        worker_config_builder = _clone_config_builder_for_worker(
+            config_builder,
+            worker_model_health_checks=self.worker_model_health_checks,
+        )
         worker_options = _RayWorkerOptions(
             model_providers=list(data_designer._model_providers),
             default_provider_name=data_designer._model_provider_registry.get_default_provider_name(),
@@ -227,11 +297,15 @@ class RayBackend:
             "batch_format": "pandas",
             "zero_copy_batch": self.zero_copy_batch,
         }
-        if self.ray_remote_args is not None:
-            map_batches_kwargs.update(self.ray_remote_args)
+        map_batches_kwargs["fn_kwargs"]["config_builder"] = worker_config_builder
+        map_batches_kwargs.update(self.execution_options.to_map_batches_kwargs(ray))
+        map_function: Any = _generate_batch
+        if self.execution_options.use_actor_pool:
+            map_function = _RayBatchGenerator
+            map_batches_kwargs["fn_constructor_kwargs"] = map_batches_kwargs.pop("fn_kwargs")
 
         try:
-            mapped = dataset.map_batches(_generate_batch, **map_batches_kwargs)
+            mapped = dataset.map_batches(map_function, **map_batches_kwargs)
             mapped = self._apply_ordering(mapped)
             output = mapped.to_arrow_refs() if self.output == "arrow_refs" else None
             result_dataset = _dataset_from_arrow_refs(ray, output) if output is not None else mapped
@@ -243,7 +317,7 @@ class RayBackend:
         output_blocks = len(output) if output is not None else _get_num_blocks(mapped)
         metrics = RayDatasetMetrics(
             total_rows=num_records if input_dataset is None else 0,
-            blocks=output_blocks or input_blocks or 0,
+            blocks=output_blocks or input_blocks or (block_plan.planned_blocks if block_plan is not None else 0) or 0,
             elapsed_seconds=time.perf_counter() - start_time,
         )
         return RayDatasetCreationResults(
@@ -255,9 +329,17 @@ class RayBackend:
             output=output,
         )
 
-    def _resolve_input_dataset(self, ray: Any, *, input_dataset: Any | None, num_records: int) -> Any:
+    def _resolve_input_dataset(
+        self,
+        ray: Any,
+        *,
+        input_dataset: Any | None,
+        num_records: int,
+        block_plan: Any | None,
+    ) -> Any:
         if input_dataset is None:
-            return ray.data.range(num_records)
+            range_kwargs = block_plan.to_range_kwargs() if block_plan is not None else {}
+            return ray.data.range(num_records, **range_kwargs)
         if hasattr(input_dataset, "map_batches"):
             return input_dataset
         if isinstance(input_dataset, (list, tuple)):
@@ -279,6 +361,107 @@ class RayBackend:
         return ordered
 
 
+class _RayBatchGenerator:
+    def __init__(
+        self,
+        *,
+        config_builder: DataDesignerConfigBuilder,
+        worker_options: _RayWorkerOptions,
+        use_input_dataset: bool,
+        metrics_collector: Any | None = None,
+    ) -> None:
+        self._config_builder = config_builder
+        self._worker_options = worker_options
+        self._use_input_dataset = use_input_dataset
+        self._metrics_collector = metrics_collector
+
+    def __call__(self, batch: Any) -> Any:
+        return _generate_batch(
+            batch,
+            config_builder=self._config_builder,
+            worker_options=self._worker_options,
+            use_input_dataset=self._use_input_dataset,
+            metrics_collector=self._metrics_collector,
+        )
+
+
+def _resolve_block_planning(
+    block_planning: RayBlockPlanning | None,
+    *,
+    override_num_blocks: int | None,
+    target_block_size: int | None,
+    min_blocks: int | None,
+    max_blocks: int | None,
+    read_concurrency: int | None,
+) -> RayBlockPlanning:
+    if block_planning is not None and any(
+        value is not None
+        for value in (override_num_blocks, target_block_size, min_blocks, max_blocks, read_concurrency)
+    ):
+        raise ValueError("RayBackend block_planning cannot be combined with individual block planning arguments.")
+    if block_planning is not None:
+        return block_planning
+    return RayBlockPlanning(
+        override_num_blocks=override_num_blocks,
+        target_block_size=target_block_size,
+        min_blocks=min_blocks,
+        max_blocks=max_blocks,
+        read_concurrency=read_concurrency,
+    )
+
+
+def _resolve_execution_options(
+    execution_options: RayExecutionOptions | None,
+    *,
+    ray_remote_args: dict[str, Any] | None,
+    num_cpus: float | None,
+    num_gpus: float | None,
+    memory: float | None,
+    resources: dict[str, float] | None,
+    scheduling_strategy: Any | None,
+    compute: Any | None,
+    map_concurrency: RayMapConcurrency | None,
+    ray_remote_args_fn: Any | None,
+    use_actor_pool: bool,
+    actor_pool_min_size: int | None,
+    actor_pool_max_size: int | None,
+    actor_pool_initial_size: int | None,
+) -> RayExecutionOptions:
+    explicit_values = (
+        ray_remote_args,
+        num_cpus,
+        num_gpus,
+        memory,
+        resources,
+        scheduling_strategy,
+        compute,
+        map_concurrency,
+        ray_remote_args_fn,
+        actor_pool_min_size,
+        actor_pool_max_size,
+        actor_pool_initial_size,
+    )
+    if execution_options is not None and (use_actor_pool or any(value is not None for value in explicit_values)):
+        raise ValueError("RayBackend execution_options cannot be combined with individual Ray execution arguments.")
+    if execution_options is not None:
+        return execution_options
+    return RayExecutionOptions(
+        num_cpus=num_cpus,
+        num_gpus=num_gpus,
+        memory=memory,
+        resources=resources,
+        scheduling_strategy=scheduling_strategy,
+        compute=compute,
+        concurrency=map_concurrency,
+        ray_remote_args_fn=ray_remote_args_fn,
+        ray_remote_args=ray_remote_args,
+        use_actor_pool=use_actor_pool,
+        actor_pool_min_size=actor_pool_min_size,
+        actor_pool_max_size=actor_pool_max_size,
+        actor_pool_initial_size=actor_pool_initial_size,
+    )
+
+
 def _validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
     unsafe_processors = [
         processor
@@ -293,6 +476,60 @@ def _validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> 
         f"Unsupported processor(s): {processor_names}. "
         "Pass allow_unsafe_processors=True to bypass this experimental guard."
     )
+
+
+def _model_health_check_aliases(config_builder: DataDesignerConfigBuilder) -> list[str]:
+    model_aliases: set[str] = set()
+    for config in config_builder.get_column_configs():
+        if column_type_is_model_generated(config.column_type):
+            model_alias = getattr(config, "model_alias", None)
+            if model_alias:
+                model_aliases.add(model_alias)
+        if isinstance(config, CustomColumnConfig) and config.model_aliases:
+            model_aliases.update(config.model_aliases)
+    return sorted(model_aliases)
+
+
+def _run_driver_model_health_check(
+    data_designer: Any,
+    config_builder: DataDesignerConfigBuilder,
+    model_aliases: list[str],
+) -> None:
+    if not model_aliases:
+        return
+    try:
+        with tempfile.TemporaryDirectory(prefix="data-designer-ray-preflight-") as artifact_dir:
+            ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
+            resource_provider = create_resource_provider(
+                artifact_storage=ArtifactStorage(artifact_path=artifact_dir, dataset_name="ray-preflight"),
+                model_configs=config_builder.model_configs,
+                secret_resolver=data_designer._secret_resolver,
+                model_provider_registry=data_designer._model_provider_registry,
+                seed_reader_registry=data_designer._seed_reader_registry,
+                person_reader=data_designer._person_reader
+                or create_person_reader(str(data_designer._managed_assets_path)),
+                run_config=data_designer._run_config,
+            )
+            resource_provider.model_registry.run_health_check(model_aliases)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend model health-check preflight failed.") from exc
+
+
+def _clone_config_builder_for_worker(
+    config_builder: DataDesignerConfigBuilder,
+    *,
+    worker_model_health_checks: bool,
+) -> DataDesignerConfigBuilder:
+    worker_config_builder = copy.deepcopy(config_builder)
+    if worker_model_health_checks:
+        return worker_config_builder
+    worker_config_builder._model_configs = [
+        model_config.model_copy(update={"skip_health_check": True})
+        for model_config in worker_config_builder.model_configs
+    ]
+    return worker_config_builder
 
 
 def _get_num_blocks(dataset: Any) -> int | None:

--- a/packages/data-designer/src/data_designer/integrations/ray/options.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/options.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+RayMapConcurrency = int | tuple[int, int] | tuple[int, int, int]
+
+
+@dataclass(frozen=True, slots=True)
+class RayResolvedBlockPlan:
+    """Resolved Ray Data read planning options for from-scratch generation."""
+
+    override_num_blocks: int | None = None
+    read_concurrency: int | None = None
+    planned_blocks: int | None = None
+
+    def to_range_kwargs(self) -> dict[str, int]:
+        """Return keyword arguments accepted by ``ray.data.range``."""
+        kwargs: dict[str, int] = {}
+        if self.override_num_blocks is not None:
+            kwargs["override_num_blocks"] = self.override_num_blocks
+        if self.read_concurrency is not None:
+            kwargs["concurrency"] = self.read_concurrency
+        return kwargs
+
+
+@dataclass(frozen=True, slots=True)
+class RayBlockPlanning:
+    """Controls for Ray Data block creation when RayBackend creates a range dataset."""
+
+    override_num_blocks: int | None = None
+    target_block_size: int | None = None
+    min_blocks: int | None = None
+    max_blocks: int | None = None
+    read_concurrency: int | None = None
+
+    def __post_init__(self) -> None:
+        _validate_optional_positive_int("override_num_blocks", self.override_num_blocks)
+        _validate_optional_positive_int("target_block_size", self.target_block_size)
+        _validate_optional_positive_int("min_blocks", self.min_blocks)
+        _validate_optional_positive_int("max_blocks", self.max_blocks)
+        _validate_optional_positive_int("read_concurrency", self.read_concurrency)
+        if self.override_num_blocks is not None and any(
+            value is not None for value in (self.target_block_size, self.min_blocks, self.max_blocks)
+        ):
+            raise ValueError(
+                "RayBlockPlanning override_num_blocks cannot be combined with target_block_size, "
+                "min_blocks, or max_blocks."
+            )
+        if self.min_blocks is not None and self.max_blocks is not None and self.min_blocks > self.max_blocks:
+            raise ValueError("RayBlockPlanning min_blocks must be less than or equal to max_blocks.")
+        if self.target_block_size is None and (self.min_blocks is not None or self.max_blocks is not None):
+            raise ValueError("RayBlockPlanning min_blocks and max_blocks require target_block_size.")
+
+    @property
+    def has_explicit_controls(self) -> bool:
+        """Return whether any from-scratch read planning control was configured."""
+        return any(
+            value is not None
+            for value in (
+                self.override_num_blocks,
+                self.target_block_size,
+                self.min_blocks,
+                self.max_blocks,
+                self.read_concurrency,
+            )
+        )
+
+    def resolve(self, *, num_records: int) -> RayResolvedBlockPlan:
+        """Resolve configured planning controls for a concrete record count."""
+        if num_records < 0:
+            raise ValueError("RayBlockPlanning num_records must be non-negative.")
+        if self.override_num_blocks is not None:
+            return RayResolvedBlockPlan(
+                override_num_blocks=self.override_num_blocks,
+                read_concurrency=self.read_concurrency,
+                planned_blocks=self.override_num_blocks,
+            )
+        if self.target_block_size is None:
+            return RayResolvedBlockPlan(read_concurrency=self.read_concurrency)
+
+        planned_blocks = max(math.ceil(max(num_records, 1) / self.target_block_size), 1)
+        if self.min_blocks is not None:
+            planned_blocks = max(planned_blocks, self.min_blocks)
+        if self.max_blocks is not None:
+            planned_blocks = min(planned_blocks, self.max_blocks)
+        if num_records > 0:
+            planned_blocks = min(planned_blocks, num_records)
+        return RayResolvedBlockPlan(
+            override_num_blocks=planned_blocks,
+            read_concurrency=self.read_concurrency,
+            planned_blocks=planned_blocks,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RayExecutionOptions:
+    """Validated Ray Data ``map_batches`` execution options.
+
+    The fields intentionally use only standard-library types so importing this
+    module never requires Ray. Values that are Ray objects, such as a custom
+    scheduling strategy or compute strategy, can be passed through as ``Any``.
+    """
+
+    num_cpus: float | None = None
+    num_gpus: float | None = None
+    memory: float | None = None
+    resources: Mapping[str, float] | None = None
+    scheduling_strategy: Any | None = None
+    compute: Any | None = None
+    concurrency: RayMapConcurrency | None = None
+    ray_remote_args_fn: Any | None = None
+    ray_remote_args: Mapping[str, Any] | None = None
+    use_actor_pool: bool = False
+    actor_pool_min_size: int | None = None
+    actor_pool_max_size: int | None = None
+    actor_pool_initial_size: int | None = None
+
+    def __post_init__(self) -> None:
+        _validate_optional_non_negative_number("num_cpus", self.num_cpus)
+        _validate_optional_non_negative_number("num_gpus", self.num_gpus)
+        _validate_optional_positive_number("memory", self.memory)
+        _validate_resources(self.resources)
+        if isinstance(self.scheduling_strategy, str) and not self.scheduling_strategy:
+            raise ValueError("RayExecutionOptions scheduling_strategy must be non-empty when provided.")
+        if self.compute is not None and self.use_actor_pool:
+            raise ValueError("RayExecutionOptions compute cannot be combined with use_actor_pool=True.")
+        if self.compute is not None and self.concurrency is not None:
+            raise ValueError("RayExecutionOptions compute cannot be combined with concurrency.")
+        _validate_map_concurrency(self.concurrency)
+        _validate_optional_positive_int("actor_pool_min_size", self.actor_pool_min_size)
+        _validate_optional_positive_int("actor_pool_max_size", self.actor_pool_max_size)
+        _validate_optional_positive_int("actor_pool_initial_size", self.actor_pool_initial_size)
+        if self.actor_pool_min_size is not None and not self.use_actor_pool:
+            raise ValueError("RayExecutionOptions actor_pool_min_size requires use_actor_pool=True.")
+        if self.actor_pool_max_size is not None and not self.use_actor_pool:
+            raise ValueError("RayExecutionOptions actor_pool_max_size requires use_actor_pool=True.")
+        if self.actor_pool_initial_size is not None and not self.use_actor_pool:
+            raise ValueError("RayExecutionOptions actor_pool_initial_size requires use_actor_pool=True.")
+        if (
+            self.actor_pool_min_size is not None
+            and self.actor_pool_max_size is not None
+            and self.actor_pool_min_size > self.actor_pool_max_size
+        ):
+            raise ValueError("RayExecutionOptions actor_pool_min_size must be less than or equal to max_size.")
+        if self.actor_pool_initial_size is not None:
+            if self.actor_pool_min_size is not None and self.actor_pool_initial_size < self.actor_pool_min_size:
+                raise ValueError("RayExecutionOptions actor_pool_initial_size must be at least actor_pool_min_size.")
+            if self.actor_pool_max_size is not None and self.actor_pool_initial_size > self.actor_pool_max_size:
+                raise ValueError("RayExecutionOptions actor_pool_initial_size must be at most actor_pool_max_size.")
+        _validate_remote_arg_conflicts(self)
+
+    def to_map_batches_kwargs(self, ray: Any | None = None) -> dict[str, Any]:
+        """Return keyword arguments accepted by ``Dataset.map_batches``."""
+        kwargs: dict[str, Any] = {}
+        _set_if_not_none(kwargs, "num_cpus", self.num_cpus)
+        _set_if_not_none(kwargs, "num_gpus", self.num_gpus)
+        _set_if_not_none(kwargs, "memory", self.memory)
+        if self.resources is not None:
+            kwargs["resources"] = dict(self.resources)
+        _set_if_not_none(kwargs, "scheduling_strategy", self.scheduling_strategy)
+        _set_if_not_none(kwargs, "compute", self.compute)
+        _set_if_not_none(kwargs, "concurrency", self.concurrency)
+        _set_if_not_none(kwargs, "ray_remote_args_fn", self.ray_remote_args_fn)
+        if self.ray_remote_args is not None:
+            kwargs.update(dict(self.ray_remote_args))
+        if self.use_actor_pool:
+            if ray is None:
+                raise ValueError("RayExecutionOptions use_actor_pool=True requires an imported ray module.")
+            kwargs["compute"] = _create_actor_pool_strategy(ray, self)
+        return kwargs
+
+
+def _validate_optional_positive_int(field_name: str, value: int | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"Ray option {field_name} must be a positive integer.")
+
+
+def _validate_optional_non_negative_number(field_name: str, value: float | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise ValueError(f"Ray option {field_name} must be a non-negative number.")
+
+
+def _validate_optional_positive_number(field_name: str, value: float | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ValueError(f"Ray option {field_name} must be a positive number.")
+
+
+def _validate_resources(resources: Mapping[str, float] | None) -> None:
+    if resources is None:
+        return
+    for name, value in resources.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError("RayExecutionOptions resource names must be non-empty strings.")
+        _validate_optional_positive_number(f"resources[{name!r}]", value)
+
+
+def _validate_map_concurrency(value: RayMapConcurrency | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, int):
+        _validate_optional_positive_int("concurrency", value)
+        return
+    if not isinstance(value, tuple) or len(value) not in (2, 3):
+        raise ValueError("RayExecutionOptions concurrency must be a positive integer or a 2/3-item tuple.")
+    for index, item in enumerate(value):
+        _validate_optional_positive_int(f"concurrency[{index}]", item)
+    if value[0] > value[1]:
+        raise ValueError("RayExecutionOptions concurrency minimum must be less than or equal to maximum.")
+    if len(value) == 3 and not value[0] <= value[2] <= value[1]:
+        raise ValueError("RayExecutionOptions concurrency initial size must be within the min/max range.")
+
+
+def _validate_remote_arg_conflicts(options: RayExecutionOptions) -> None:
+    if options.ray_remote_args is None:
+        return
+    explicit_fields = {
+        "num_cpus": options.num_cpus,
+        "num_gpus": options.num_gpus,
+        "memory": options.memory,
+        "resources": options.resources,
+        "scheduling_strategy": options.scheduling_strategy,
+        "compute": options.compute if not options.use_actor_pool else True,
+        "concurrency": options.concurrency,
+        "ray_remote_args_fn": options.ray_remote_args_fn,
+    }
+    conflicts = sorted(
+        name for name, value in explicit_fields.items() if value is not None and name in options.ray_remote_args
+    )
+    if conflicts:
+        conflict_list = ", ".join(conflicts)
+        raise ValueError(
+            f"RayExecutionOptions received duplicate explicit and ray_remote_args values: {conflict_list}."
+        )
+
+
+def _create_actor_pool_strategy(ray: Any, options: RayExecutionOptions) -> Any:
+    actor_pool_strategy = getattr(ray.data, "ActorPoolStrategy", None)
+    if not callable(actor_pool_strategy):
+        raise ValueError("RayExecutionOptions use_actor_pool=True requires ray.data.ActorPoolStrategy.")
+    kwargs: dict[str, int] = {}
+    _set_if_not_none(kwargs, "min_size", options.actor_pool_min_size or 1)
+    _set_if_not_none(kwargs, "max_size", options.actor_pool_max_size)
+    _set_if_not_none(kwargs, "initial_size", options.actor_pool_initial_size)
+    return actor_pool_strategy(**kwargs)
+
+
+def _set_if_not_none(target: dict[str, Any], key: str, value: Any | None) -> None:
+    if value is not None:
+        target[key] = value

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -11,27 +11,41 @@ from typing import Any
 import pytest
 
 import data_designer.lazy_heavy_imports as lazy
-from data_designer.config.column_configs import ExpressionColumnConfig
+from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.processors import SchemaTransformProcessorConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
-from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetMetrics
+from data_designer.integrations.ray import (
+    RayBackend,
+    RayBackendConfigurationError,
+    RayDatasetGenerationError,
+    RayDatasetMetrics,
+)
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
+
+
+class FakeActorPoolStrategy:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
 
 
 class FakeRayDataset:
     def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
         self.blocks = blocks
         self.map_batches_kwargs: dict[str, Any] | None = None
+        self.map_batches_fn: Any | None = None
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         self.map_batches_kwargs = kwargs
-        fn_kwargs = kwargs.get("fn_kwargs") or {}
-        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+        self.map_batches_fn = fn
+        if isinstance(fn, type):
+            actor = fn(**(kwargs.get("fn_constructor_kwargs") or {}))
+            return FakeRayDataset([actor(block) for block in self.blocks])
+        return FakeRayDataset([fn(block, **(kwargs.get("fn_kwargs") or {})) for block in self.blocks])
 
     def to_arrow_refs(self) -> list[str]:
         return [f"arrow-ref-{i}" for i, _ in enumerate(self.blocks)]
@@ -56,9 +70,22 @@ class FakeRayDataModule:
     def __init__(self) -> None:
         self.from_arrow_refs_input: list[Any] | None = None
         self.from_pandas_refs_input: list[Any] | None = None
+        self.range_kwargs: dict[str, Any] | None = None
 
-    def range(self, num_records: int) -> FakeRayDataset:
-        return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+    def ActorPoolStrategy(self, **kwargs: Any) -> FakeActorPoolStrategy:
+        return FakeActorPoolStrategy(**kwargs)
+
+    def range(self, num_records: int, **kwargs: Any) -> FakeRayDataset:
+        self.range_kwargs = kwargs
+        block_count = kwargs.get("override_num_blocks") or 1
+        if num_records > 0:
+            block_count = min(block_count, num_records)
+        blocks = []
+        for index in range(block_count):
+            start = index * num_records // block_count
+            end = (index + 1) * num_records // block_count
+            blocks.append(lazy.pd.DataFrame({"id": list(range(start, end))}))
+        return FakeRayDataset(blocks)
 
     def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_arrow_refs_input = refs
@@ -169,6 +196,18 @@ def _input_expression_config_builder(stub_model_configs: Any) -> DataDesignerCon
     return config_builder
 
 
+def _llm_config_builder(stub_model_configs: Any) -> DataDesignerConfigBuilder:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(
+        LLMTextColumnConfig(
+            name="text",
+            prompt="Say hello.",
+            model_alias="stub-model",
+        )
+    )
+    return config_builder
+
+
 def test_ray_backend_uses_input_dataset_as_in_memory_seed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -198,6 +237,261 @@ def test_ray_backend_uses_input_dataset_as_in_memory_seed(
         {"x": 1, "label": "a", "x_label": "1-a"},
         {"x": 2, "label": "b", "x_label": "2-b"},
     ]
+
+
+def test_ray_backend_uses_override_num_blocks_for_from_scratch_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2, override_num_blocks=3, read_concurrency=2),
+    )
+
+    results = designer.create(stub_sampler_only_config_builder, num_records=5)
+
+    assert fake_ray.data.range_kwargs == {"override_num_blocks": 3, "concurrency": 2}
+    assert results.load_metrics().blocks == 3
+
+
+@pytest.mark.parametrize(
+    ("num_records", "target_block_size", "min_blocks", "max_blocks", "expected_blocks"),
+    [
+        (3, 100, None, None, 1),
+        (20, 4, 2, 3, 3),
+    ],
+)
+def test_ray_backend_resolves_target_block_size_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: Any,
+    stub_model_providers: Any,
+    num_records: int,
+    target_block_size: int,
+    min_blocks: int | None,
+    max_blocks: int | None,
+    expected_blocks: int,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=2,
+            target_block_size=target_block_size,
+            min_blocks=min_blocks,
+            max_blocks=max_blocks,
+        ),
+    )
+
+    results = designer.create(stub_sampler_only_config_builder, num_records=num_records)
+
+    assert fake_ray.data.range_kwargs == {"override_num_blocks": expected_blocks}
+    assert results.load_metrics().blocks == expected_blocks
+
+
+def test_ray_backend_rejects_block_planning_with_input_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(override_num_blocks=2),
+    )
+
+    with pytest.raises(RayBackendConfigurationError, match="block planning controls"):
+        designer.create(stub_sampler_only_config_builder, input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is None
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"override_num_blocks": 0}, "positive integer"),
+        ({"target_block_size": 10, "min_blocks": 4, "max_blocks": 2}, "min_blocks"),
+        ({"min_blocks": 2}, "require target_block_size"),
+    ],
+)
+def test_ray_backend_validates_invalid_block_planning_options(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        RayBackend(**kwargs)
+
+
+def test_ray_backend_propagates_execution_resource_options(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            num_cpus=0.5,
+            num_gpus=1,
+            memory=1024,
+            resources={"model_client": 1},
+            scheduling_strategy="SPREAD",
+            map_concurrency=2,
+        ),
+    )
+
+    designer.create(_input_expression_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_kwargs["num_cpus"] == 0.5
+    assert input_dataset.map_batches_kwargs["num_gpus"] == 1
+    assert input_dataset.map_batches_kwargs["memory"] == 1024
+    assert input_dataset.map_batches_kwargs["resources"] == {"model_client": 1}
+    assert input_dataset.map_batches_kwargs["scheduling_strategy"] == "SPREAD"
+    assert input_dataset.map_batches_kwargs["concurrency"] == 2
+
+
+def test_ray_backend_actor_pool_uses_autoscaling_strategy_and_constructor_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            use_actor_pool=True,
+            actor_pool_min_size=1,
+            actor_pool_max_size=4,
+            actor_pool_initial_size=2,
+            scheduling_strategy="DEFAULT",
+        ),
+    )
+
+    designer.create(_input_expression_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_fn is ray_backend_module._RayBatchGenerator
+    assert "fn_kwargs" not in input_dataset.map_batches_kwargs
+    assert "fn_constructor_kwargs" in input_dataset.map_batches_kwargs
+    assert input_dataset.map_batches_kwargs["scheduling_strategy"] == "DEFAULT"
+    assert input_dataset.map_batches_kwargs["compute"].kwargs == {
+        "min_size": 1,
+        "max_size": 4,
+        "initial_size": 2,
+    }
+
+
+def test_ray_backend_driver_model_health_check_runs_once_and_workers_skip_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+    preflight_aliases: list[list[str]] = []
+    worker_skip_flags: list[list[bool]] = []
+
+    def run_driver_model_health_check(_: Any, __: DataDesignerConfigBuilder, model_aliases: list[str]) -> None:
+        preflight_aliases.append(model_aliases)
+
+    def generate_batch(batch: lazy.pd.DataFrame, *, config_builder: DataDesignerConfigBuilder, **_: Any) -> Any:
+        worker_skip_flags.append([model_config.skip_health_check for model_config in config_builder.model_configs])
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_run_driver_model_health_check", run_driver_model_health_check)
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    config_builder = _llm_config_builder(stub_model_configs)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1),
+    )
+
+    designer.create(config_builder, input_dataset=input_dataset)
+
+    assert preflight_aliases == [["stub-model"]]
+    assert worker_skip_flags == [[True]]
+    assert [model_config.skip_health_check for model_config in config_builder.model_configs] == [False]
+
+
+def test_ray_backend_worker_model_health_checks_can_be_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+    worker_skip_flags: list[list[bool]] = []
+
+    def generate_batch(batch: lazy.pd.DataFrame, *, config_builder: DataDesignerConfigBuilder, **_: Any) -> Any:
+        worker_skip_flags.append([model_config.skip_health_check for model_config in config_builder.model_configs])
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_run_driver_model_health_check", lambda *_: None)
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1, worker_model_health_checks=True),
+    )
+
+    designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert worker_skip_flags == [[False]]
+
+
+def test_ray_backend_driver_model_health_check_failure_stops_before_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+
+    def fail_preflight(_: Any, __: DataDesignerConfigBuilder, ___: list[str]) -> None:
+        raise RayDatasetGenerationError("preflight failed")
+
+    monkeypatch.setattr(ray_backend_module, "_run_driver_model_health_check", fail_preflight)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1),
+    )
+
+    with pytest.raises(RayDatasetGenerationError, match="preflight failed"):
+        designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is None
 
 
 def test_ray_backend_preserves_input_dataset_order_across_blocks(


### PR DESCRIPTION
## 📋 Summary

Adds RayBackend execution controls for driver-side model health-check preflight, explicit from-scratch block planning, and Ray Data resource/placement options. The defaults keep local Ray behavior lightweight while letting cluster users opt into block counts, resource labels, scheduling strategy, and autoscaling actor pools without importing Ray at package import time.

## 🔗 Related Issue

Refs #10, #12, #20

## 🔄 Changes

- Added `RayBlockPlanning` and `RayExecutionOptions` dataclasses for validated block planning, map resources, scheduling strategy, custom resources, and actor-pool controls.
- Wired `RayBackend` to run model health checks once on the driver before scheduling Ray work, then send worker-cloned model configs with health checks disabled by default unless `worker_model_health_checks=True`.
- Added from-scratch `ray.data.range(...)` planning controls via `override_num_blocks`, target block sizing, min/max block bounds, and read concurrency.
- Added Ray Data map execution controls for CPU, GPU, memory, custom resources, scheduling strategy, compute/concurrency, dynamic remote args, and optional autoscaling actor-pool execution.
- Expanded Ray backend tests for preflight success/failure, worker config propagation, block planning, invalid options, resource propagation, and actor-pool wiring.

## 🧪 Testing

- [x] `uv run --all-packages pytest packages/data-designer/tests/integrations/ray`
- [x] `uv run --all-packages pytest packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py`
- [x] `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [x] `uv run ruff check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [ ] `make test` passes (not run; targeted Ray integration coverage above)
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A - no E2E surface changed)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable for this merge-train scope; docs were intentionally left untouched)