### PR TITLE
test(ray): add validation benchmarks and smoke coverage

### DIFF
--- a/.github/workflows/ray-smoke.yml
+++ b/.github/workflows/ray-smoke.yml
@@ -1,0 +1,37 @@
+name: Ray Smoke
+
+on:
+  schedule:
+    # Every Tuesday at 08:00 UTC
+    - cron: "0 8 * * 2"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  real-ray-smoke:
+    name: Real Ray Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "latest"
+          python-version: "3.11"
+          enable-cache: true
+
+      - name: Install DataDesigner with Ray extra
+        run: uv sync --package data-designer --group dev --extra ray
+
+      - name: Run real-Ray smoke tests
+        env:
+          DATA_DESIGNER_RUN_REAL_RAY_SMOKE: "1"
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+        run: |
+          uv run --package data-designer --group dev --extra ray \
+            pytest -q packages/data-designer/tests/integrations/ray/test_real_smoke.py

--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+
+
+def _load_benchmark_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[5]
+    script_path = repo_root / "scripts" / "benchmarks" / "benchmark_ray_openai.py"
+    spec = importlib.util.spec_from_file_location("benchmark_ray_openai", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load benchmark script from {script_path}.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_backends_supports_full_apples_to_apples_suite() -> None:
+    benchmark = _load_benchmark_module()
+
+    assert benchmark._parse_backends("all") == list(benchmark.ALL_BACKENDS)
+    assert benchmark._parse_backends("local-sync,local-async,ray-dataset,ray-arrow-refs") == [
+        "local-sync",
+        "local-async",
+        "ray-dataset",
+        "ray-arrow-refs",
+    ]
+    assert benchmark._parse_backends("local-sync,local-sync,ray-dataset") == ["local-sync", "ray-dataset"]
+
+
+def test_parse_backends_rejects_unknown_backend() -> None:
+    benchmark = _load_benchmark_module()
+
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        benchmark._parse_backends("local,ray")
+
+
+def test_result_payload_reports_validity_and_provider_counters(tmp_path: Path) -> None:
+    benchmark = _load_benchmark_module()
+    output = lazy.pd.DataFrame(
+        {
+            "instruction": ["write code", "debug code"],
+            "code_implementation": ["print('ok')", "print('debug')"],
+        }
+    )
+    metrics = {
+        "total_rows": 2,
+        "blocks": 1,
+        "elapsed_seconds": 2.0,
+        "model_usage": {
+            "gpt-4.1": {
+                "token_usage": {"input_tokens": 10, "output_tokens": 30, "total_tokens": 40},
+                "request_usage": {"successful_requests": 2, "failed_requests": 1, "total_requests": 3},
+                "retry_count": 4,
+                "rate_limited_requests": 1,
+            }
+        },
+    }
+
+    payload = benchmark._result_payload(
+        backend="local-sync",
+        iteration=1,
+        seed=11,
+        output=output,
+        elapsed_seconds=2.0,
+        metrics=metrics,
+        artifact_path=tmp_path,
+        output_mode="pandas",
+        batch_size=2,
+        max_parallel_requests=2,
+        expected_columns=["instruction", "code_implementation"],
+        expected_rows=2,
+    )
+
+    assert payload["validity"] == {
+        "row_count_matches": True,
+        "expected_columns_present": True,
+        "expected_columns_non_null": True,
+        "all_output_valid": True,
+    }
+    assert payload["throughput"]["requests_per_minute"] == 90
+    assert payload["throughput"]["tokens_per_second"] == 20
+    assert payload["throughput"]["retry_count"] == 4
+    assert payload["throughput"]["throttle_count"] == 1
+
+
+def test_summary_groups_iterations_and_speedups() -> None:
+    benchmark = _load_benchmark_module()
+    results = [
+        _benchmark_result(backend="local-sync", iteration=1, elapsed_seconds=10.0, rows_per_second=10.0),
+        _benchmark_result(backend="local-async", iteration=1, elapsed_seconds=5.0, rows_per_second=20.0),
+        _benchmark_result(backend="ray-dataset", iteration=1, elapsed_seconds=4.0, rows_per_second=25.0),
+        _benchmark_result(backend="local-sync", iteration=2, elapsed_seconds=8.0, rows_per_second=12.5),
+        _benchmark_result(backend="local-async", iteration=2, elapsed_seconds=4.0, rows_per_second=25.0),
+        _benchmark_result(backend="ray-dataset", iteration=2, elapsed_seconds=2.0, rows_per_second=50.0),
+    ]
+
+    summary = benchmark._build_summary(results)
+
+    assert summary["all_output_valid"] is True
+    assert summary["per_backend"]["local-sync"]["iterations"] == 2
+    assert summary["per_backend"]["local-async"]["rows_per_second"]["mean"] == 22.5
+    assert summary["comparisons_vs_local_sync"]["local-async"]["mean"] == 2.0
+    assert summary["comparisons_vs_local_sync"]["ray-dataset"]["mean"] == 3.25
+
+
+def _benchmark_result(
+    *,
+    backend: str,
+    iteration: int,
+    elapsed_seconds: float,
+    rows_per_second: float,
+) -> dict[str, Any]:
+    return {
+        "backend": backend,
+        "iteration": iteration,
+        "elapsed_seconds": elapsed_seconds,
+        "rows_per_second": rows_per_second,
+        "validity": {"all_output_valid": True},
+        "throughput": {
+            "requests_per_minute": 60.0,
+            "tokens_per_second": 120.0,
+            "failed_requests": 0,
+            "retry_count": 0,
+            "throttle_count": 0,
+        },
+    }

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in real-Ray smoke tests for docs/assets recipe paths.
+
+Local command:
+
+    DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 \
+        uv run --package data-designer --group dev --extra ray \
+            pytest -q packages/data-designer/tests/integrations/ray/test_real_smoke.py
+
+The OpenAI-backed test also requires OPENAI_API_KEY and skips cleanly when the
+credential is absent.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.column_configs import ExpressionColumnConfig
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.default_model_settings import (
+    get_builtin_model_configs,
+    get_builtin_model_providers,
+    resolve_seed_default_model_settings,
+)
+from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.integrations.ray import RayBackend
+from data_designer.interface.data_designer import DataDesigner
+
+REAL_RAY_SMOKE_ENV = "DATA_DESIGNER_RUN_REAL_RAY_SMOKE"
+OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
+
+
+def test_real_ray_markdown_seed_recipe_arrow_refs_smoke(
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    ray = _require_real_ray()
+    recipe = _load_recipe("docs/assets/recipes/plugin_development/markdown_seed_reader.py")
+    seed_dir = tmp_path / "markdown"
+    seed_dir.mkdir()
+    recipe.create_sample_markdown_files(seed_dir)
+    input_df = _markdown_sections_dataframe(recipe, seed_dir)
+    input_blocks = [input_df.iloc[:2].reset_index(drop=True), input_df.iloc[2:].reset_index(drop=True)]
+
+    ray.init(num_cpus=2, include_dashboard=False, ignore_reinit_error=True)
+    try:
+        input_dataset = ray.data.from_pandas(input_blocks)
+        config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+        config_builder.add_column(
+            ExpressionColumnConfig(
+                name="section_summary",
+                expr="{{ file_name }} :: {{ section_header }}",
+            )
+        )
+        designer = DataDesigner(
+            artifact_path=tmp_path / "artifacts",
+            model_providers=stub_model_providers,
+            secret_resolver=PlaintextResolver(),
+            managed_assets_path=tmp_path / "managed-assets",
+            backend=RayBackend(batch_size=2, output="arrow_refs"),
+        )
+
+        results = designer.create(config_builder, input_dataset=input_dataset)
+        refs = results.output
+        output_df = results.load_dataset().to_pandas()
+        metrics = results.load_metrics()
+
+        assert results.to_arrow_refs() == refs
+        assert len(refs) == metrics.blocks
+        assert metrics.total_rows == len(input_df)
+        assert metrics.failed_blocks == 0
+        assert output_df["section_summary"].notna().all()
+        assert output_df["section_summary"].str.contains("::").all()
+    finally:
+        ray.shutdown()
+
+
+def test_real_ray_text_to_python_openai_recipe_smoke(tmp_path: Path) -> None:
+    ray = _require_real_ray()
+    if not os.environ.get(OPENAI_API_KEY_ENV):
+        pytest.skip(f"{OPENAI_API_KEY_ENV} is required for the OpenAI-backed Ray smoke test.")
+
+    resolve_seed_default_model_settings()
+    recipe = _load_recipe("docs/assets/recipes/code_generation/text_to_python.py")
+    config_builder = _single_llm_text_to_python_config(recipe)
+    provider = _builtin_provider("openai")
+
+    ray.init(num_cpus=2, include_dashboard=False, ignore_reinit_error=True)
+    try:
+        designer = DataDesigner(
+            artifact_path=tmp_path / "artifacts",
+            model_providers=[provider],
+            managed_assets_path=tmp_path / "managed-assets",
+            backend=RayBackend(batch_size=1, output="arrow_refs"),
+        )
+
+        results = designer.create(config_builder, num_records=1)
+        refs = results.output
+        output_df = results.load_dataset().to_pandas()
+        metrics = results.load_metrics()
+        metrics_payload = metrics.to_dict()
+
+        assert results.to_arrow_refs() == refs
+        assert len(refs) == metrics.blocks
+        assert metrics.total_rows == 1
+        assert metrics.failed_blocks == 0
+        assert output_df["instruction"].notna().all()
+        assert output_df["instruction"].astype(str).str.len().min() > 0
+        assert metrics_payload["model_usage"]
+    finally:
+        ray.shutdown()
+
+
+def _require_real_ray() -> Any:
+    if os.environ.get(REAL_RAY_SMOKE_ENV) != "1":
+        pytest.skip(f"Set {REAL_RAY_SMOKE_ENV}=1 to run real-Ray smoke tests.")
+    return pytest.importorskip("ray")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[5]
+
+
+def _load_recipe(relative_path: str) -> Any:
+    recipe_path = _repo_root() / relative_path
+    spec = importlib.util.spec_from_file_location(f"ray_smoke_{recipe_path.stem}", recipe_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load recipe from {recipe_path}.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _markdown_sections_dataframe(recipe: Any, seed_dir: Path) -> Any:
+    records: list[dict[str, Any]] = []
+    for markdown_path in sorted(seed_dir.glob("*.md")):
+        sections = recipe.extract_markdown_sections(
+            markdown_text=markdown_path.read_text(encoding="utf-8"),
+            fallback_header=markdown_path.name,
+        )
+        for section_index, (section_header, section_content) in enumerate(sections):
+            records.append(
+                {
+                    "relative_path": markdown_path.name,
+                    "file_name": markdown_path.name,
+                    "section_index": section_index,
+                    "section_header": section_header,
+                    "section_content": section_content,
+                }
+            )
+    return lazy.pd.DataFrame(records)
+
+
+def _single_llm_text_to_python_config(recipe: Any) -> DataDesignerConfigBuilder:
+    source_builder = recipe.build_config(model_alias="openai-text")
+    config_builder = DataDesignerConfigBuilder(model_configs=[_builtin_model_config("openai-text")])
+    for column_config in source_builder.get_column_configs():
+        config_builder.add_column(copy.deepcopy(column_config))
+        if column_config.name == "instruction":
+            break
+    return config_builder
+
+
+def _builtin_model_config(alias: str) -> Any:
+    for model_config in get_builtin_model_configs():
+        if model_config.alias != alias:
+            continue
+        inference_parameters = model_config.inference_parameters.model_copy(
+            update={"max_parallel_requests": 1, "max_tokens": 256}
+        )
+        return model_config.model_copy(
+            deep=True,
+            update={"inference_parameters": inference_parameters, "skip_health_check": True},
+        )
+    raise RuntimeError(f"No built-in model config found for {alias!r}.")
+
+
+def _builtin_provider(name: str) -> Any:
+    for provider in get_builtin_model_providers():
+        if provider.name == name:
+            return provider
+    raise RuntimeError(f"No built-in provider found for {name!r}.")

--- a/scripts/benchmarks/benchmark_ray_openai.py
+++ b/scripts/benchmarks/benchmark_ray_openai.py
@@ -3,9 +3,14 @@
 
 """Benchmark local and Ray execution with the configured OpenAI provider.
 
-This benchmark intentionally uses only OpenAI model configs/providers while
-exercising a real docs/assets recipe. It is meant for the experimental Ray
-backend report, not as a stable public benchmark suite.
+Live provider calls are intentionally opt-in:
+
+    DATA_DESIGNER_RUN_LIVE_OPENAI_BENCHMARK=1 \
+        python scripts/benchmarks/benchmark_ray_openai.py --run-live --iterations 3
+
+The suite compares local sync, local async, Ray Dataset, and Ray Arrow-ref paths
+against the same docs/assets recipe, batch size, and model concurrency settings.
+It emits line-delimited JSON for logs and can write a machine-readable report.
 """
 
 from __future__ import annotations
@@ -14,94 +19,196 @@ import argparse
 import copy
 import importlib.util
 import json
+import math
+import os
+import statistics
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.default_model_settings import get_default_providers
+from data_designer.config.default_model_settings import (
+    get_default_providers,
+    resolve_seed_default_model_settings,
+)
 from data_designer.config.models import ModelConfig, ModelProvider
+from data_designer.config.run_config import RunConfig
 from data_designer.integrations.ray import RayBackend
 from data_designer.interface.data_designer import DataDesigner
 
-BackendName = Literal["local", "ray"]
+BackendName = Literal["local-sync", "local-async", "ray-dataset", "ray-arrow-refs"]
+RayOutputMode = Literal["dataset", "arrow_refs"]
 
+ALL_BACKENDS: tuple[BackendName, ...] = ("local-sync", "local-async", "ray-dataset", "ray-arrow-refs")
 RESULT_PREFIX = "RAY_OPENAI_BENCHMARK_RESULT="
+LIVE_RUN_ENV = "DATA_DESIGNER_RUN_LIVE_OPENAI_BENCHMARK"
 DEFAULT_RECIPE_PATH = Path("docs/assets/recipes/code_generation/text_to_python.py")
 DEFAULT_NUM_RECORDS = 256
 DEFAULT_BATCH_SIZE = 16
+DEFAULT_ITERATIONS = 1
 DEFAULT_RAY_CPUS = 4
 DEFAULT_MODEL_ALIAS = "openai-text"
+DEFAULT_PROVIDER_NAME = "openai"
+DEFAULT_SEED = 11
+
+
+@dataclass(frozen=True)
+class MetricStats:
+    mean: float
+    stdev: float
+    minimum: float
+    maximum: float
+    n: int
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "mean": self.mean,
+            "stdev": self.stdev,
+            "min": self.minimum,
+            "max": self.maximum,
+            "n": self.n,
+        }
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--recipe-path", type=Path, default=DEFAULT_RECIPE_PATH)
     parser.add_argument("--model-alias", type=str, default=DEFAULT_MODEL_ALIAS)
+    parser.add_argument("--provider-name", type=str, default=DEFAULT_PROVIDER_NAME)
     parser.add_argument("--num-records", type=int, default=DEFAULT_NUM_RECORDS)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--max-parallel-requests", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--ray-cpus", type=int, default=DEFAULT_RAY_CPUS)
-    parser.add_argument("--backends", type=str, default="local,ray", help="Comma-separated subset of: local,ray")
+    parser.add_argument(
+        "--backends",
+        type=str,
+        default="all",
+        help="Comma-separated subset of: local-sync,local-async,ray-dataset,ray-arrow-refs, or all.",
+    )
     parser.add_argument("--artifact-root", type=Path, default=Path("/tmp/dd-ray-openai-benchmark-artifacts"))
     parser.add_argument("--managed-assets-path", type=Path, default=Path("/tmp/dd-ray-openai-benchmark-managed-assets"))
     parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument(
+        "--run-live",
+        action="store_true",
+        default=False,
+        help=f"Allow live provider calls. Also accepted when {LIVE_RUN_ENV}=1.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
+    _validate_args(args)
+    _require_live_opt_in(run_live=args.run_live)
+
     args.artifact_root.mkdir(parents=True, exist_ok=True)
     args.managed_assets_path.mkdir(parents=True, exist_ok=True)
 
+    resolve_seed_default_model_settings()
     selected_backends = _parse_backends(args.backends)
     recipe = _load_recipe(args.recipe_path)
-    openai_providers = _openai_providers()
+    providers = _provider_configs(args.provider_name)
+    _require_provider_credentials(providers)
+
+    setup_config = _build_openai_config(
+        recipe=recipe,
+        model_alias=args.model_alias,
+        provider_name=args.provider_name,
+        max_parallel_requests=args.max_parallel_requests,
+    )
+    expected_columns = [column.name for column in setup_config.get_column_configs()]
     setup = {
         "recipe_path": str(args.recipe_path),
         "model_alias": args.model_alias,
+        "provider_name": args.provider_name,
         "num_records": args.num_records,
         "batch_size": args.batch_size,
+        "max_parallel_requests": args.max_parallel_requests,
+        "iterations": args.iterations,
+        "seed": args.seed,
         "ray_cpus": args.ray_cpus,
         "backends": selected_backends,
         "skip_health_checks": True,
-        "model_configs": _model_config_summary(_build_openai_config(recipe, args.model_alias).model_configs),
-        "providers": [provider.name for provider in openai_providers],
-        "local_execution": "current local default backend",
-        "ray_execution": "RayBackend async worker path",
+        "model_configs": _model_config_summary(setup_config.model_configs),
+        "providers": [provider.name for provider in providers],
+        "expected_columns": expected_columns,
+        "live_run_env": LIVE_RUN_ENV,
     }
     _emit({"type": "setup", **setup})
 
     results: list[dict[str, Any]] = []
-    for backend in selected_backends:
-        result = _run_backend(
-            backend=backend,
-            recipe=recipe,
-            model_alias=args.model_alias,
-            num_records=args.num_records,
-            batch_size=args.batch_size,
-            ray_cpus=args.ray_cpus,
-            artifact_root=args.artifact_root,
-            managed_assets_path=args.managed_assets_path,
-            model_providers=openai_providers,
-        )
-        results.append(result)
-        _emit({"type": "backend_result", **result})
+    for iteration in range(1, args.iterations + 1):
+        iteration_seed = args.seed + iteration - 1
+        for backend in selected_backends:
+            result = _run_backend(
+                backend=backend,
+                iteration=iteration,
+                seed=iteration_seed,
+                recipe=recipe,
+                model_alias=args.model_alias,
+                provider_name=args.provider_name,
+                num_records=args.num_records,
+                batch_size=args.batch_size,
+                max_parallel_requests=args.max_parallel_requests,
+                ray_cpus=args.ray_cpus,
+                artifact_root=args.artifact_root,
+                managed_assets_path=args.managed_assets_path,
+                model_providers=providers,
+                expected_columns=expected_columns,
+            )
+            results.append(result)
+            _emit({"type": "backend_result", **result})
 
     summary = _build_summary(results)
-    if summary is not None:
-        _emit({"type": "summary", **summary})
+    _emit({"type": "summary", **summary})
     if args.output_json is not None:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
-        args.output_json.write_text(json.dumps({"setup": setup, "results": results, "summary": summary}, indent=2))
+        args.output_json.write_text(
+            json.dumps({"setup": setup, "results": results, "summary": summary}, indent=2, default=_json_default)
+        )
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.num_records < 1:
+        raise ValueError("--num-records must be >= 1.")
+    if args.batch_size < 1:
+        raise ValueError("--batch-size must be >= 1.")
+    if args.max_parallel_requests < 1:
+        raise ValueError("--max-parallel-requests must be >= 1.")
+    if args.iterations < 1:
+        raise ValueError("--iterations must be >= 1.")
+    if args.ray_cpus < 1:
+        raise ValueError("--ray-cpus must be >= 1.")
+
+
+def _require_live_opt_in(*, run_live: bool) -> None:
+    if run_live or os.environ.get(LIVE_RUN_ENV) == "1":
+        return
+    raise SystemExit(
+        f"This benchmark performs live provider calls. Re-run with --run-live or set {LIVE_RUN_ENV}=1 to opt in."
+    )
 
 
 def _parse_backends(value: str) -> list[BackendName]:
+    if value.strip() == "all":
+        return list(ALL_BACKENDS)
+
     backends: list[BackendName] = []
+    seen: set[str] = set()
     for raw_backend in value.split(","):
         backend = raw_backend.strip()
-        if backend not in {"local", "ray"}:
-            raise ValueError(f"Unsupported backend {backend!r}. Expected 'local', 'ray', or both.")
-        backends.append(backend)  # type: ignore[arg-type]
+        if backend not in ALL_BACKENDS:
+            raise ValueError(f"Unsupported backend {backend!r}. Expected one of {', '.join(ALL_BACKENDS)} or all.")
+        if backend not in seen:
+            backends.append(backend)  # type: ignore[arg-type]
+            seen.add(backend)
+    if not backends:
+        raise ValueError("At least one backend must be selected.")
     return backends
 
 
@@ -114,16 +221,42 @@ def _load_recipe(recipe_path: Path) -> Any:
     return module
 
 
-def _openai_providers() -> list[ModelProvider]:
-    providers = [provider for provider in get_default_providers() if provider.name == "openai"]
+def _provider_configs(provider_name: str) -> list[ModelProvider]:
+    providers = [provider for provider in get_default_providers() if provider.name == provider_name]
     if not providers:
-        raise RuntimeError("No configured OpenAI model provider found.")
+        raise RuntimeError(f"No configured {provider_name!r} model provider found.")
     return providers
 
 
-def _build_openai_config(recipe: Any, model_alias: str) -> DataDesignerConfigBuilder:
+def _require_provider_credentials(providers: list[ModelProvider]) -> None:
+    missing_keys = [provider.api_key for provider in providers if not _provider_has_api_key(provider)]
+    if missing_keys:
+        keys = ", ".join(str(key) for key in missing_keys)
+        raise SystemExit(f"Provider credentials are missing for: {keys}.")
+
+
+def _provider_has_api_key(provider: ModelProvider) -> bool:
+    api_key = provider.api_key
+    if api_key is None:
+        return False
+    if api_key.isupper() and "_" in api_key:
+        return bool(os.environ.get(api_key))
+    return True
+
+
+def _build_openai_config(
+    *,
+    recipe: Any,
+    model_alias: str,
+    provider_name: str,
+    max_parallel_requests: int,
+) -> DataDesignerConfigBuilder:
     source_builder = recipe.build_config(model_alias=model_alias)
-    openai_model_configs = _openai_model_configs(source_builder.model_configs)
+    openai_model_configs = _provider_model_configs(
+        source_builder.model_configs,
+        provider_name=provider_name,
+        max_parallel_requests=max_parallel_requests,
+    )
     config_builder = DataDesignerConfigBuilder(
         model_configs=openai_model_configs,
         tool_configs=copy.deepcopy(source_builder.tool_configs),
@@ -135,14 +268,27 @@ def _build_openai_config(recipe: Any, model_alias: str) -> DataDesignerConfigBui
     return config_builder
 
 
-def _openai_model_configs(model_configs: list[ModelConfig]) -> list[ModelConfig]:
-    filtered = [
-        model_config.model_copy(deep=True, update={"skip_health_check": True})
-        for model_config in model_configs
-        if model_config.provider == "openai" or model_config.alias.startswith("openai-")
-    ]
+def _provider_model_configs(
+    model_configs: list[ModelConfig],
+    *,
+    provider_name: str,
+    max_parallel_requests: int,
+) -> list[ModelConfig]:
+    filtered = []
+    for model_config in model_configs:
+        if model_config.provider != provider_name and not model_config.alias.startswith(f"{provider_name}-"):
+            continue
+        inference_parameters = model_config.inference_parameters.model_copy(
+            update={"max_parallel_requests": max_parallel_requests}
+        )
+        filtered.append(
+            model_config.model_copy(
+                deep=True,
+                update={"inference_parameters": inference_parameters, "skip_health_check": True},
+            )
+        )
     if not filtered:
-        raise RuntimeError("No OpenAI model configs found in recipe configuration.")
+        raise RuntimeError(f"No {provider_name!r} model configs found in recipe configuration.")
     return filtered
 
 
@@ -163,139 +309,373 @@ def _model_config_summary(model_configs: list[ModelConfig]) -> list[dict[str, An
 def _run_backend(
     *,
     backend: BackendName,
+    iteration: int,
+    seed: int,
     recipe: Any,
     model_alias: str,
+    provider_name: str,
     num_records: int,
     batch_size: int,
+    max_parallel_requests: int,
     ray_cpus: int,
     artifact_root: Path,
     managed_assets_path: Path,
     model_providers: list[ModelProvider],
+    expected_columns: list[str],
 ) -> dict[str, Any]:
-    config_builder = _build_openai_config(recipe, model_alias)
-    artifact_path = artifact_root / f"{backend}-{num_records}-{int(time.time())}"
-    start = time.perf_counter()
-    if backend == "ray":
-        return _run_ray_backend(
+    config_builder = _build_openai_config(
+        recipe=recipe,
+        model_alias=model_alias,
+        provider_name=provider_name,
+        max_parallel_requests=max_parallel_requests,
+    )
+    artifact_path = artifact_root / f"{backend}-iter-{iteration:02d}"
+    if backend in {"local-sync", "local-async"}:
+        return _run_local_backend(
+            backend=backend,
+            use_async=backend == "local-async",
+            iteration=iteration,
+            seed=seed,
             config_builder=config_builder,
             num_records=num_records,
             batch_size=batch_size,
-            ray_cpus=ray_cpus,
+            max_parallel_requests=max_parallel_requests,
             artifact_path=artifact_path,
             managed_assets_path=managed_assets_path,
             model_providers=model_providers,
-            start=start,
+            expected_columns=expected_columns,
         )
-    return _run_local_backend(
+
+    return _run_ray_backend(
+        backend=backend,
+        ray_output="arrow_refs" if backend == "ray-arrow-refs" else "dataset",
+        iteration=iteration,
+        seed=seed,
         config_builder=config_builder,
         num_records=num_records,
+        batch_size=batch_size,
+        max_parallel_requests=max_parallel_requests,
+        ray_cpus=ray_cpus,
         artifact_path=artifact_path,
         managed_assets_path=managed_assets_path,
         model_providers=model_providers,
-        start=start,
+        expected_columns=expected_columns,
     )
 
 
 def _run_local_backend(
     *,
+    backend: BackendName,
+    use_async: bool,
+    iteration: int,
+    seed: int,
     config_builder: DataDesignerConfigBuilder,
     num_records: int,
+    batch_size: int,
+    max_parallel_requests: int,
     artifact_path: Path,
     managed_assets_path: Path,
     model_providers: list[ModelProvider],
-    start: float,
+    expected_columns: list[str],
 ) -> dict[str, Any]:
+    _seed_everything(seed)
     designer = DataDesigner(
         artifact_path=artifact_path,
         managed_assets_path=managed_assets_path,
         model_providers=model_providers,
     )
-    results = designer.create(config_builder, num_records=num_records)
-    output = results.load_dataset()
+    designer.set_run_config(_run_config(batch_size))
+    resource_provider = designer._create_resource_provider("benchmark", config_builder)
+    builder = designer._create_dataset_builder(config_builder.build(), resource_provider, use_async=use_async)
+
+    start = time.perf_counter()
+    raw_output = builder.build_preview(num_records=num_records)
+    output = builder.process_preview(raw_output)
     elapsed_seconds = time.perf_counter() - start
+    metrics = {
+        "total_rows": len(output),
+        "blocks": math.ceil(num_records / batch_size),
+        "failed_blocks": 0,
+        "elapsed_seconds": elapsed_seconds,
+        "model_usage": resource_provider.model_registry.get_model_usage_stats(elapsed_seconds) or None,
+    }
     return _result_payload(
-        backend="local",
+        backend=backend,
+        iteration=iteration,
+        seed=seed,
         output=output,
         elapsed_seconds=elapsed_seconds,
-        metrics=None,
+        metrics=metrics,
         artifact_path=artifact_path,
+        output_mode="pandas",
+        batch_size=batch_size,
+        max_parallel_requests=max_parallel_requests,
+        expected_columns=expected_columns,
+        expected_rows=num_records,
     )
 
 
 def _run_ray_backend(
     *,
+    backend: BackendName,
+    ray_output: RayOutputMode,
+    iteration: int,
+    seed: int,
     config_builder: DataDesignerConfigBuilder,
     num_records: int,
     batch_size: int,
+    max_parallel_requests: int,
     ray_cpus: int,
     artifact_path: Path,
     managed_assets_path: Path,
     model_providers: list[ModelProvider],
-    start: float,
+    expected_columns: list[str],
 ) -> dict[str, Any]:
+    _seed_everything(seed)
     ray = __import__("ray")
-    ray.init(num_cpus=ray_cpus, ignore_reinit_error=True)
+    ray.init(num_cpus=ray_cpus, ignore_reinit_error=True, include_dashboard=False)
     try:
         designer = DataDesigner(
             artifact_path=artifact_path,
             managed_assets_path=managed_assets_path,
             model_providers=model_providers,
-            backend=RayBackend(batch_size=batch_size),
+            backend=RayBackend(batch_size=batch_size, output=ray_output),
         )
+        designer.set_run_config(_run_config(batch_size))
+        start = time.perf_counter()
         results = designer.create(config_builder, num_records=num_records)
         output = results.load_dataset().to_pandas()
+        metrics = results.load_metrics().to_dict()
         elapsed_seconds = time.perf_counter() - start
-        return _result_payload(
-            backend="ray",
+        payload = _result_payload(
+            backend=backend,
+            iteration=iteration,
+            seed=seed,
             output=output,
             elapsed_seconds=elapsed_seconds,
-            metrics=results.load_metrics().to_dict(),
+            metrics=metrics,
             artifact_path=artifact_path,
+            output_mode=ray_output,
+            batch_size=batch_size,
+            max_parallel_requests=max_parallel_requests,
+            expected_columns=expected_columns,
+            expected_rows=num_records,
         )
+        if ray_output == "arrow_refs":
+            payload["arrow_ref_count"] = len(results.output)
+        return payload
     finally:
         ray.shutdown()
+
+
+def _run_config(batch_size: int) -> RunConfig:
+    return RunConfig(
+        buffer_size=batch_size,
+        disable_early_shutdown=True,
+        max_conversation_restarts=0,
+        max_conversation_correction_steps=0,
+    )
+
+
+def _seed_everything(seed: int) -> None:
+    lazy.np.random.seed(seed)
 
 
 def _result_payload(
     *,
     backend: BackendName,
+    iteration: int,
+    seed: int,
     output: Any,
     elapsed_seconds: float,
     metrics: dict[str, Any] | None,
     artifact_path: Path,
+    output_mode: str,
+    batch_size: int,
+    max_parallel_requests: int,
+    expected_columns: list[str],
+    expected_rows: int,
 ) -> dict[str, Any]:
     rows = len(output)
+    null_counts = {str(key): int(value) for key, value in output.isna().sum().to_dict().items()}
+    empty_string_counts = _empty_string_counts(output)
+    missing_columns = [column for column in expected_columns if column not in output.columns]
+    expected_null_counts = {column: null_counts.get(column, rows) for column in expected_columns}
+    validity = {
+        "row_count_matches": rows == expected_rows,
+        "expected_columns_present": not missing_columns,
+        "expected_columns_non_null": all(count == 0 for count in expected_null_counts.values()),
+        "all_output_valid": rows == expected_rows
+        and not missing_columns
+        and all(count == 0 for count in expected_null_counts.values()),
+    }
+    throughput = _throughput_payload(metrics=metrics, elapsed_seconds=elapsed_seconds, rows=rows)
     return {
         "backend": backend,
+        "iteration": iteration,
+        "seed": seed,
         "elapsed_seconds": elapsed_seconds,
         "rows": rows,
         "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
         "columns": list(output.columns),
-        "null_counts": output.isna().sum().to_dict(),
+        "missing_columns": missing_columns,
+        "null_counts": null_counts,
+        "empty_string_counts": empty_string_counts,
+        "validity": validity,
+        "throughput": throughput,
         "metrics": metrics,
         "artifact_path": str(artifact_path),
+        "output_mode": output_mode,
+        "batch_size": batch_size,
+        "max_parallel_requests": max_parallel_requests,
     }
 
 
-def _build_summary(results: list[dict[str, Any]]) -> dict[str, Any] | None:
-    by_backend = {result["backend"]: result for result in results}
-    local = by_backend.get("local")
-    ray = by_backend.get("ray")
-    if local is None or ray is None:
-        return None
-    local_elapsed = float(local["elapsed_seconds"])
-    ray_elapsed = float(ray["elapsed_seconds"])
+def _empty_string_counts(output: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for column in output.columns:
+        series = output[column]
+        if getattr(series.dtype, "kind", None) in {"O", "U", "S"}:
+            counts[str(column)] = int(series.fillna("").astype(str).eq("").sum())
+    return counts
+
+
+def _throughput_payload(*, metrics: dict[str, Any] | None, elapsed_seconds: float, rows: int) -> dict[str, Any]:
+    model_usage = (metrics or {}).get("model_usage") or {}
+    request_counts = _sum_nested_usage(model_usage, "request_usage")
+    token_counts = _sum_nested_usage(model_usage, "token_usage")
+    total_requests = int(request_counts.get("total_requests", 0))
+    total_tokens = int(token_counts.get("total_tokens", 0))
+    retry_count = _sum_first_available_counter(model_usage, ("retry_count", "retries", "total_retries"))
+    throttle_count = _sum_first_available_counter(
+        model_usage,
+        ("throttle_count", "rate_limited_requests", "throttled_requests"),
+    )
     return {
-        "local_elapsed_seconds": local_elapsed,
-        "ray_elapsed_seconds": ray_elapsed,
-        "ray_speedup_vs_local": local_elapsed / ray_elapsed if ray_elapsed > 0 else None,
-        "local_rows_per_second": local["rows_per_second"],
-        "ray_rows_per_second": ray["rows_per_second"],
+        "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
+        "requests_per_minute": total_requests / elapsed_seconds * 60 if elapsed_seconds > 0 else 0,
+        "tokens_per_second": total_tokens / elapsed_seconds if elapsed_seconds > 0 else 0,
+        "successful_requests": int(request_counts.get("successful_requests", 0)),
+        "failed_requests": int(request_counts.get("failed_requests", 0)),
+        "total_requests": total_requests,
+        "input_tokens": int(token_counts.get("input_tokens", 0)),
+        "output_tokens": int(token_counts.get("output_tokens", 0)),
+        "total_tokens": total_tokens,
+        "retry_count": retry_count if retry_count is not None else 0,
+        "retry_count_available": retry_count is not None,
+        "throttle_count": throttle_count if throttle_count is not None else 0,
+        "throttle_count_available": throttle_count is not None,
     }
+
+
+def _sum_nested_usage(model_usage: dict[str, Any], usage_key: str) -> dict[str, int | float]:
+    totals: dict[str, int | float] = {}
+    for stats in model_usage.values():
+        usage = stats.get(usage_key) if isinstance(stats, dict) else None
+        if not isinstance(usage, dict):
+            continue
+        for key, value in usage.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            totals[key] = totals.get(key, 0) + value
+    return totals
+
+
+def _sum_first_available_counter(model_usage: dict[str, Any], counter_names: tuple[str, ...]) -> int | None:
+    total = 0
+    found = False
+    for stats in model_usage.values():
+        if not isinstance(stats, dict):
+            continue
+        for counter_name in counter_names:
+            value = stats.get(counter_name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            total += int(value)
+            found = True
+            break
+    return total if found else None
+
+
+def _build_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
+    per_backend: dict[str, dict[str, Any]] = {}
+    for backend in ALL_BACKENDS:
+        backend_results = [result for result in results if result["backend"] == backend]
+        if not backend_results:
+            continue
+        per_backend[backend] = {
+            "iterations": len(backend_results),
+            "elapsed_seconds": _compute_stats(
+                [float(result["elapsed_seconds"]) for result in backend_results]
+            ).to_dict(),
+            "rows_per_second": _compute_stats(
+                [float(result["rows_per_second"]) for result in backend_results]
+            ).to_dict(),
+            "requests_per_minute": _compute_stats(
+                [float(result["throughput"]["requests_per_minute"]) for result in backend_results]
+            ).to_dict(),
+            "tokens_per_second": _compute_stats(
+                [float(result["throughput"]["tokens_per_second"]) for result in backend_results]
+            ).to_dict(),
+            "failed_requests": sum(int(result["throughput"]["failed_requests"]) for result in backend_results),
+            "retry_count": sum(int(result["throughput"]["retry_count"]) for result in backend_results),
+            "throttle_count": sum(int(result["throughput"]["throttle_count"]) for result in backend_results),
+            "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in backend_results),
+        }
+
+    comparisons = _speedup_comparisons(results, baseline_backend="local-sync")
+    return {
+        "per_backend": per_backend,
+        "comparisons_vs_local_sync": comparisons,
+        "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in results),
+    }
+
+
+def _speedup_comparisons(results: list[dict[str, Any]], *, baseline_backend: BackendName) -> dict[str, Any]:
+    by_iteration_backend = {(result["iteration"], result["backend"]): result for result in results}
+    comparisons: dict[str, Any] = {}
+    for backend in ALL_BACKENDS:
+        if backend == baseline_backend:
+            continue
+        speedups = []
+        for result in results:
+            if result["backend"] != backend:
+                continue
+            baseline = by_iteration_backend.get((result["iteration"], baseline_backend))
+            if baseline is None:
+                continue
+            elapsed = float(result["elapsed_seconds"])
+            if elapsed > 0:
+                speedups.append(float(baseline["elapsed_seconds"]) / elapsed)
+        if speedups:
+            comparisons[backend] = _compute_stats(speedups).to_dict()
+    return comparisons
+
+
+def _compute_stats(values: list[float]) -> MetricStats:
+    if not values:
+        return MetricStats(mean=0.0, stdev=0.0, minimum=0.0, maximum=0.0, n=0)
+    if len(values) == 1:
+        return MetricStats(mean=values[0], stdev=0.0, minimum=values[0], maximum=values[0], n=1)
+    return MetricStats(
+        mean=statistics.mean(values),
+        stdev=statistics.stdev(values),
+        minimum=min(values),
+        maximum=max(values),
+        n=len(values),
+    )
 
 
 def _emit(payload: dict[str, Any]) -> None:
-    print(f"{RESULT_PREFIX}{json.dumps(payload, sort_keys=True)}", flush=True)
+    print(f"{RESULT_PREFIX}{json.dumps(payload, sort_keys=True, default=_json_default)}", flush=True)
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, lazy.np.generic):
+        return value.item()
+    if isinstance(value, lazy.np.ndarray):
+        return value.tolist()
+    return str(value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📋 Summary
Adds opt-in benchmark and smoke coverage for Ray validation without forcing normal test runs to install Ray or use provider credentials. The benchmark now compares local sync, local async, Ray Dataset, and Ray Arrow-ref execution against the same docs/assets recipe and emits structured metrics for repeated runs.

## 🔗 Related Issue
Closes #14
Closes #15

## 🔄 Changes
- Expands `scripts/benchmarks/benchmark_ray_openai.py` into a live-gated local sync/local async/Ray Dataset/Ray Arrow-ref suite with repeated iterations, seeded setup, JSON output, throughput, request/token, null, and validity metrics.
- Adds non-live tests for benchmark backend parsing, result payload metrics, and summary speedup aggregation.
- Adds opt-in real-Ray docs/assets smoke tests for a markdown seeded recipe path and an OpenAI-gated text-to-Python LLM path.
- Adds a weekly/manual Ray smoke workflow that installs the Ray extra and runs only the gated smoke file.

## 🧪 Testing
- [x] `uv run --group dev ruff format --check scripts/benchmarks/benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_real_smoke.py`
- [x] `uv run --group dev ruff check scripts/benchmarks/benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_real_smoke.py`
- [x] `uv run --group dev pytest -q packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_real_smoke.py` (4 passed, 2 skipped)
- [x] `uv run --group dev pytest -q packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_arrow_refs_load_dataset_uses_materialized_refs_without_rerun`
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray-validation uv run --group dev python scripts/benchmarks/benchmark_ray_openai.py --help`
- [x] Unit tests added/updated
- [x] E2E/smoke tests added with explicit env gating

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A - benchmark JSON and smoke workflow cover the new operational surface)
