### PR TITLE
feat(ray): add processor safety metadata

### DIFF
--- a/packages/data-designer-config/src/data_designer/config/__init__.py
+++ b/packages/data-designer-config/src/data_designer/config/__init__.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
     )
     from data_designer.config.processors import (  # noqa: F401
         DropColumnsProcessorConfig,
+        ProcessorDistributedSafety,
+        ProcessorSideEffect,
         ProcessorType,
         SchemaTransformProcessorConfig,
     )
@@ -172,6 +174,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "UniformDistributionParams": (_MOD_MODELS, "UniformDistributionParams"),
     # processors
     "DropColumnsProcessorConfig": (_MOD_PROCESSORS, "DropColumnsProcessorConfig"),
+    "ProcessorDistributedSafety": (_MOD_PROCESSORS, "ProcessorDistributedSafety"),
+    "ProcessorSideEffect": (_MOD_PROCESSORS, "ProcessorSideEffect"),
     "ProcessorType": (_MOD_PROCESSORS, "ProcessorType"),
     "SchemaTransformProcessorConfig": (_MOD_PROCESSORS, "SchemaTransformProcessorConfig"),
     # run_config

--- a/packages/data-designer-config/src/data_designer/config/processors.py
+++ b/packages/data-designer-config/src/data_designer/config/processors.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 
 import json
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import Field, field_validator
 
-from data_designer.config.base import ProcessorConfig
+from data_designer.config.base import ConfigBase, ProcessorConfig
 from data_designer.config.errors import InvalidConfigError
 
 
@@ -23,6 +23,38 @@ class ProcessorType(str, Enum):
 
     DROP_COLUMNS = "drop_columns"
     SCHEMA_TRANSFORM = "schema_transform"
+
+
+class ProcessorSideEffect(str, Enum):
+    """Side-effect behavior relevant to distributed processor execution."""
+
+    NONE = "none"
+    BATCH_ARTIFACT = "batch_artifact"
+    DATASET_ARTIFACT = "dataset_artifact"
+    EXTERNAL = "external"
+
+
+class ProcessorDistributedSafety(ConfigBase):
+    """Declarative distributed-execution safety metadata for processor configs.
+
+    Processor configs declare this as class-level metadata so execution backends
+    can fail closed for processors that have not been reviewed for distributed
+    semantics.
+    """
+
+    ray_safe: bool = Field(description="Whether the processor is safe to run independently on Ray Data blocks.")
+    requires_global_order: bool = Field(
+        default=False,
+        description="Whether the processor requires a globally ordered or complete dataset view.",
+    )
+    side_effects: ProcessorSideEffect = Field(
+        default=ProcessorSideEffect.NONE,
+        description="Side-effect behavior the backend must account for when distributing this processor.",
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Human-readable explanation for unsafe or constrained distributed execution.",
+    )
 
 
 def get_processor_config_from_kwargs(processor_type: ProcessorType, **kwargs: Any) -> ProcessorConfig:
@@ -58,6 +90,12 @@ class DropColumnsProcessorConfig(ProcessorConfig):
 
     column_names: list[str] = Field(description="List of column names to drop from the output dataset.")
     processor_type: Literal[ProcessorType.DROP_COLUMNS] = ProcessorType.DROP_COLUMNS
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        ray_safe=True,
+        requires_global_order=False,
+        side_effects=ProcessorSideEffect.BATCH_ARTIFACT,
+        reason="Drops columns independently per batch; dropped-column artifacts are batch-local.",
+    )
 
 
 class SchemaTransformProcessorConfig(ProcessorConfig):
@@ -100,6 +138,12 @@ class SchemaTransformProcessorConfig(ProcessorConfig):
         """,
     )
     processor_type: Literal[ProcessorType.SCHEMA_TRANSFORM] = ProcessorType.SCHEMA_TRANSFORM
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        ray_safe=False,
+        requires_global_order=False,
+        side_effects=ProcessorSideEffect.DATASET_ARTIFACT,
+        reason="Writes processor output artifacts that RayBackend does not collect from worker-local storage.",
+    )
 
     @field_validator("template")
     def validate_template(cls, v: dict[str, Any]) -> dict[str, Any]:

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.processors import ProcessorType
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
@@ -26,6 +25,7 @@ from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 
 if TYPE_CHECKING:
     from data_designer.config.mcp import MCPProviderT
@@ -199,7 +199,7 @@ class RayBackend:
                 "Automatic hidden row-id injection is tracked as follow-up hardening work."
             )
         if not self.allow_unsafe_processors:
-            _validate_ray_safe_processors(config_builder)
+            validate_ray_safe_processors(config_builder)
 
         dataset = self._resolve_input_dataset(ray, input_dataset=input_dataset, num_records=num_records)
         input_blocks = _get_num_blocks(dataset)
@@ -277,22 +277,6 @@ class RayBackend:
         if self.drop_order_column:
             return ordered.drop_columns([self.order_column])
         return ordered
-
-
-def _validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
-    unsafe_processors = [
-        processor
-        for processor in config_builder.get_processor_configs()
-        if processor.processor_type != ProcessorType.DROP_COLUMNS
-    ]
-    if not unsafe_processors:
-        return
-    processor_names = ", ".join(f"{processor.name} ({processor.processor_type})" for processor in unsafe_processors)
-    raise RayBackendConfigurationError(
-        "RayBackend currently supports only distributed-safe processors. "
-        f"Unsupported processor(s): {processor_names}. "
-        "Pass allow_unsafe_processors=True to bypass this experimental guard."
-    )
 
 
 def _get_num_blocks(dataset: Any) -> int | None:

--- a/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from data_designer.config.base import ProcessorConfig
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.processors import ProcessorDistributedSafety
+from data_designer.integrations.ray.errors import RayBackendConfigurationError
+
+
+def validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
+    """Validate that configured processors are explicitly safe for Ray execution."""
+    unsupported: list[str] = []
+    for processor in config_builder.get_processor_configs():
+        safety = _get_distributed_safety(processor)
+        if safety is None or not safety.ray_safe or safety.requires_global_order:
+            unsupported.append(_format_processor_violation(processor, safety))
+
+    if not unsupported:
+        return
+
+    raise RayBackendConfigurationError(
+        "RayBackend supports only processors explicitly declared distributed-safe. "
+        f"Unsupported processor(s): {'; '.join(unsupported)}. "
+        "Review the processor's distributed_safety metadata, or pass "
+        "allow_unsafe_processors=True to bypass this experimental guard."
+    )
+
+
+def _get_distributed_safety(processor: ProcessorConfig) -> ProcessorDistributedSafety | None:
+    safety = getattr(processor, "distributed_safety", None)
+    if isinstance(safety, ProcessorDistributedSafety):
+        return safety
+    return None
+
+
+def _format_processor_violation(processor: ProcessorConfig, safety: ProcessorDistributedSafety | None) -> str:
+    processor_type = getattr(processor.processor_type, "value", processor.processor_type)
+    label = f"{processor.name} ({processor_type})"
+    if safety is None:
+        return f"{label}: missing distributed_safety metadata"
+
+    reasons: list[str] = []
+    if not safety.ray_safe:
+        reasons.append("ray_safe=False")
+    if safety.requires_global_order:
+        reasons.append("requires_global_order=True")
+    reasons.append(f"side_effects={safety.side_effects}")
+    if safety.reason is not None:
+        reasons.append(f"reason={safety.reason}")
+    return f"{label}: {', '.join(reasons)}"

--- a/packages/data-designer/tests/integrations/ray/test_processor_policy.py
+++ b/packages/data-designer/tests/integrations/ray/test_processor_policy.py
@@ -6,14 +6,20 @@ from __future__ import annotations
 import sys
 import types
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 import pytest
 
 import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.base import ProcessorConfig
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.processors import DropColumnsProcessorConfig, SchemaTransformProcessorConfig
+from data_designer.config.processors import (
+    DropColumnsProcessorConfig,
+    ProcessorDistributedSafety,
+    ProcessorSideEffect,
+    SchemaTransformProcessorConfig,
+)
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError
 from data_designer.integrations.ray import backend as ray_backend_module
@@ -45,6 +51,20 @@ class FakeRayDataModule:
 
     def range(self, num_records: int) -> FakeRayDataset:
         return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+
+
+class MissingSafetyProcessorConfig(ProcessorConfig):
+    processor_type: Literal["missing_safety"] = "missing_safety"
+
+
+class GlobalOrderProcessorConfig(ProcessorConfig):
+    processor_type: Literal["global_order"] = "global_order"
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        ray_safe=True,
+        requires_global_order=True,
+        side_effects=ProcessorSideEffect.NONE,
+        reason="Requires a globally ordered dataset.",
+    )
 
 
 def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -131,9 +151,53 @@ def test_ray_backend_rejects_schema_transform_processor_by_default(
     )
     designer = _designer(tmp_path, stub_model_providers, backend=RayBackend())
 
-    with pytest.raises(RayBackendConfigurationError, match="Unsupported processor"):
+    with pytest.raises(RayBackendConfigurationError, match="Unsupported processor") as exc_info:
         designer.create(config_builder, input_dataset=input_dataset)
 
+    message = str(exc_info.value)
+    assert "schema-transform (schema_transform)" in message
+    assert "ray_safe=False" in message
+    assert "side_effects=dataset_artifact" in message
+    assert "worker-local storage" in message
+    assert "allow_unsafe_processors=True" in message
+    assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_backend_rejects_processor_without_distributed_safety_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    config_builder.add_processor(MissingSafetyProcessorConfig(name="custom-processor"))
+    designer = _designer(tmp_path, stub_model_providers, backend=RayBackend())
+
+    with pytest.raises(RayBackendConfigurationError, match="missing distributed_safety metadata") as exc_info:
+        designer.create(config_builder, input_dataset=input_dataset)
+
+    assert "custom-processor (missing_safety)" in str(exc_info.value)
+    assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_backend_rejects_global_order_processor_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    config_builder.add_processor(GlobalOrderProcessorConfig(name="global-order-processor"))
+    designer = _designer(tmp_path, stub_model_providers, backend=RayBackend())
+
+    with pytest.raises(RayBackendConfigurationError, match="requires_global_order=True") as exc_info:
+        designer.create(config_builder, input_dataset=input_dataset)
+
+    assert "global-order-processor (global_order)" in str(exc_info.value)
     assert input_dataset.map_batches_kwargs is None
 
 


### PR DESCRIPTION
## 📋 Summary

Replace RayBackend's hard-coded processor allowlist with explicit distributed-safety metadata on processor configs. Ray preflight now fails closed for unsafe processors, processors requiring global order, and processors with missing metadata while keeping the existing experimental bypass explicit.

## 🔗 Related Issue

Closes #8

## 🔄 Changes

- Add `ProcessorDistributedSafety` and `ProcessorSideEffect` metadata for processor configs.
- Declare `DropColumnsProcessorConfig` as Ray-safe and `SchemaTransformProcessorConfig` as unsafe because its processor outputs are worker-local side effects under Ray.
- Move Ray processor validation into `data_designer.integrations.ray.processor_policy` and have `RayBackend` consume the metadata instead of checking processor type names.
- Add Ray integration tests for safe processors, unsafe side-effecting processors, missing metadata, global-order metadata, and `allow_unsafe_processors=True`.

## 🧪 Testing

- [ ] `make test` passes (not run; targeted tests below passed)
- [x] Unit tests added/updated
- [x] E2E tests not applicable for this Ray preflight policy change

Targeted commands run:

```bash
UV_CACHE_DIR=.uv-cache uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_processor_policy.py packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_rejects_unsafe_processors_by_default packages/data-designer-config/tests/config/test_processors.py
UV_CACHE_DIR=.uv-cache uv run --group dev ruff check --output-format=full packages/data-designer-config/src/data_designer/config/processors.py packages/data-designer-config/src/data_designer/config/__init__.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/processor_policy.py packages/data-designer/tests/integrations/ray/test_processor_policy.py
UV_CACHE_DIR=.uv-cache uv run --group dev ruff format --check packages/data-designer-config/src/data_designer/config/processors.py packages/data-designer-config/src/data_designer/config/__init__.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/processor_policy.py packages/data-designer/tests/integrations/ray/test_processor_policy.py
```

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs not applicable for this scoped policy change
