### PR TITLE
feat(ray): coordinate provider throttling globally

### DIFF
--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/__init__.py
@@ -13,7 +13,7 @@ from data_designer.engine.models.clients.errors import (
 )
 from data_designer.engine.models.clients.factory import create_model_client
 from data_designer.engine.models.clients.retry import RetryConfig
-from data_designer.engine.models.clients.throttle_manager import ThrottleDomain, ThrottleManager
+from data_designer.engine.models.clients.throttle_manager import ThrottleDomain, ThrottleManager, ThrottleManagerLike
 from data_designer.engine.models.clients.throttled import ThrottledModelClient
 from data_designer.engine.models.clients.types import (
     AssistantMessage,
@@ -46,6 +46,7 @@ __all__ = [
     "RetryConfig",
     "ThrottleDomain",
     "ThrottleManager",
+    "ThrottleManagerLike",
     "ThrottledModelClient",
     "ToolCall",
     "Usage",

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/factory.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/factory.py
@@ -11,7 +11,7 @@ from data_designer.engine.models.clients.adapters.http_model_client import Clien
 from data_designer.engine.models.clients.adapters.openai_compatible import OpenAICompatibleClient
 from data_designer.engine.models.clients.base import ModelClient
 from data_designer.engine.models.clients.retry import RetryConfig
-from data_designer.engine.models.clients.throttle_manager import ThrottleManager
+from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
 from data_designer.engine.models.clients.throttled import ThrottledModelClient
 from data_designer.engine.models.errors import FormattedLLMErrorMessage
 from data_designer.engine.secret_resolver import SecretResolver
@@ -26,7 +26,7 @@ def create_model_client(
     *,
     retry_config: RetryConfig | None = None,
     client_concurrency_mode: ClientConcurrencyMode = ClientConcurrencyMode.SYNC,
-    throttle_manager: ThrottleManager | None = None,
+    throttle_manager: ThrottleManagerLike | None = None,
 ) -> ModelClient:
     """Create a ``ModelClient`` for the given model configuration.
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
@@ -10,6 +10,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Protocol
 
 from data_designer.config.run_config import ThrottleConfig
 
@@ -30,6 +31,74 @@ class ThrottleDomain(str, Enum):
 DEFAULT_MIN_LIMIT: int = 1
 DEFAULT_ACQUIRE_TIMEOUT: float = 300.0
 CAPACITY_POLL_INTERVAL: float = 0.05
+
+
+class ThrottleManagerLike(Protocol):
+    """Interface used by model clients for local or distributed throttling."""
+
+    def register(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        alias: str,
+        max_parallel_requests: int,
+    ) -> None: ...
+
+    def try_acquire(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> float: ...
+
+    def acquire_sync(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None: ...
+
+    async def acquire_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None: ...
+
+    def release_success(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None: ...
+
+    def release_rate_limited(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None: ...
+
+    def release_failure(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -429,6 +498,34 @@ class ThrottleManager:
     def get_effective_max(self, provider_name: str, model_id: str) -> int:
         with self._lock:
             return self._effective_max_for(provider_name, model_id)
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a serializable throttle-state snapshot for telemetry."""
+        with self._lock:
+            return {
+                "global_caps": [
+                    {
+                        "provider_name": provider_name,
+                        "model_id": model_id,
+                        "effective_max": cap.effective_max,
+                        "limits_by_alias": dict(cap.limits_by_alias),
+                    }
+                    for (provider_name, model_id), cap in sorted(self._global_caps.items())
+                ],
+                "domains": [
+                    {
+                        "provider_name": provider_name,
+                        "model_id": model_id,
+                        "domain": domain,
+                        "current_limit": state.current_limit,
+                        "in_flight": state.in_flight,
+                        "waiters": state.waiters,
+                        "rate_limit_ceiling": state.rate_limit_ceiling,
+                        "consecutive_429s": state.consecutive_429s,
+                    }
+                    for (provider_name, model_id, domain), state in sorted(self._domains.items())
+                ],
+            }
 
     # -------------------------------------------------------------------
     # Private helpers

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py
@@ -22,7 +22,7 @@ from data_designer.engine.models.clients.types import (
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
-    from data_designer.engine.models.clients.throttle_manager import ThrottleManager
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
 
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ class ThrottledModelClient(ModelClient):
     def __init__(
         self,
         inner: ModelClient,
-        throttle_manager: ThrottleManager,
+        throttle_manager: ThrottleManagerLike,
         provider_name: str,
         model_id: str,
     ) -> None:

--- a/packages/data-designer-engine/src/data_designer/engine/models/factory.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/factory.py
@@ -13,6 +13,7 @@ from data_designer.engine.secret_resolver import SecretResolver
 if TYPE_CHECKING:
     from data_designer.config.run_config import RunConfig
     from data_designer.engine.mcp.registry import MCPRegistry
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
     from data_designer.engine.models.registry import ModelRegistry
 
 
@@ -24,6 +25,7 @@ def create_model_registry(
     mcp_registry: MCPRegistry | None = None,
     client_concurrency_mode: ClientConcurrencyMode = ClientConcurrencyMode.SYNC,
     run_config: RunConfig | None = None,
+    throttle_manager: ThrottleManagerLike | None = None,
 ) -> ModelRegistry:
     """Factory function for creating a ModelRegistry instance.
 
@@ -54,7 +56,7 @@ def create_model_registry(
     from data_designer.engine.models.facade import ModelFacade
     from data_designer.engine.models.registry import ModelRegistry
 
-    throttle_manager = ThrottleManager((run_config or RunConfig()).throttle)
+    effective_throttle_manager = throttle_manager or ThrottleManager((run_config or RunConfig()).throttle)
 
     def model_facade_factory(
         model_config: ModelConfig,
@@ -68,7 +70,7 @@ def create_model_registry(
             model_provider_registry,
             retry_config=retry_config,
             client_concurrency_mode=client_concurrency_mode,
-            throttle_manager=throttle_manager,
+            throttle_manager=effective_throttle_manager,
         )
         return ModelFacade(
             model_config,
@@ -82,6 +84,6 @@ def create_model_registry(
         secret_resolver=secret_resolver,
         model_provider_registry=model_provider_registry,
         model_facade_factory=model_facade_factory,
-        throttle_manager=throttle_manager,
+        throttle_manager=effective_throttle_manager,
         retry_config=RetryConfig(),
     )

--- a/packages/data-designer-engine/src/data_designer/engine/models/registry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/registry.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from data_designer.engine.models.clients.retry import RetryConfig
-    from data_designer.engine.models.clients.throttle_manager import ThrottleManager
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
     from data_designer.engine.models.facade import ModelFacade
 
     ModelFacadeFactory = Callable[
@@ -35,7 +35,7 @@ class ModelRegistry:
         model_provider_registry: ModelProviderRegistry,
         model_configs: list[ModelConfig] | None = None,
         model_facade_factory: ModelFacadeFactory | None = None,
-        throttle_manager: ThrottleManager | None = None,
+        throttle_manager: ThrottleManagerLike | None = None,
         retry_config: RetryConfig | None = None,
     ) -> None:
         self._secret_resolver = secret_resolver
@@ -56,7 +56,7 @@ class ModelRegistry:
         return self._models
 
     @property
-    def throttle_manager(self) -> ThrottleManager | None:
+    def throttle_manager(self) -> ThrottleManagerLike | None:
         return self._throttle_manager
 
     @property

--- a/packages/data-designer-engine/src/data_designer/engine/resources/resource_provider.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/resource_provider.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from data_designer.config.base import ConfigBase
 from data_designer.config.dataset_metadata import DatasetMetadata
@@ -25,6 +26,9 @@ from data_designer.engine.resources.person_reader import PersonReader
 from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderRegistry
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
+
+if TYPE_CHECKING:
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
 
 
 class ResourceType(StrEnum):
@@ -90,6 +94,7 @@ def create_resource_provider(
     run_config: RunConfig | None = None,
     mcp_providers: list[MCPProviderT] | None = None,
     tool_configs: list[ToolConfig] | None = None,
+    throttle_manager: ThrottleManagerLike | None = None,
 ) -> ResourceProvider:
     """Factory function for creating a ResourceProvider instance.
 
@@ -151,6 +156,7 @@ def create_resource_provider(
             mcp_registry=mcp_registry,
             client_concurrency_mode=client_concurrency_mode,
             run_config=effective_run_config,
+            throttle_manager=throttle_manager,
         ),
         person_reader=person_reader,
         mcp_registry=mcp_registry,

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -26,6 +26,7 @@ from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.throttling import create_ray_throttle_manager
 
 if TYPE_CHECKING:
     from data_designer.config.mcp import MCPProviderT
@@ -46,6 +47,7 @@ class _RayWorkerOptions:
     person_reader: PersonReader | None
     mcp_providers: list[MCPProviderT]
     run_config: RunConfig
+    throttle_manager: Any | None = None
 
 
 class RayDatasetCreationResults:
@@ -59,6 +61,7 @@ class RayDatasetCreationResults:
         metrics: RayDatasetMetrics,
         ray: Any | None = None,
         metrics_collector: Any | None = None,
+        throttle_manager: Any | None = None,
         output: Any | None = None,
     ) -> None:
         self.dataset = dataset
@@ -67,6 +70,7 @@ class RayDatasetCreationResults:
         self._metrics_cache: RayDatasetMetrics | None = None
         self._ray = ray
         self._metrics_collector = metrics_collector
+        self._throttle_manager = throttle_manager
         self._output = output
 
     def load_dataset(self) -> Any:
@@ -93,7 +97,11 @@ class RayDatasetCreationResults:
         if not payloads:
             return self._driver_metrics
         worker_metrics = aggregate_ray_metrics(payloads)
-        self._metrics_cache = _merge_driver_and_worker_metrics(self._driver_metrics, worker_metrics)
+        self._metrics_cache = _merge_driver_and_worker_metrics(
+            self._driver_metrics,
+            worker_metrics,
+            throttle_metrics=self._load_throttle_metrics(),
+        )
         return self._metrics_cache
 
     @property
@@ -106,6 +114,14 @@ class RayDatasetCreationResults:
         if not callable(materialize):
             return
         self.dataset = materialize()
+
+    def _load_throttle_metrics(self) -> dict[str, Any] | None:
+        if self._throttle_manager is None:
+            return None
+        snapshot = getattr(self._throttle_manager, "snapshot", None)
+        if not callable(snapshot):
+            return None
+        return snapshot()
 
     def to_arrow_refs(self) -> list[Any]:
         """Return Ray ObjectRefs containing PyArrow tables, one per Ray block."""
@@ -144,6 +160,7 @@ class RayBackend:
         drop_order_column: bool = False,
         preserve_order: bool = False,
         allow_unsafe_processors: bool = False,
+        global_provider_throttling: bool = True,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
             raise ValueError("RayBackend output must be 'dataset' or 'arrow_refs'.")
@@ -161,6 +178,7 @@ class RayBackend:
         self.drop_order_column = drop_order_column
         self.preserve_order = preserve_order
         self.allow_unsafe_processors = allow_unsafe_processors
+        self.global_provider_throttling = global_provider_throttling
 
     def create(
         self,
@@ -205,6 +223,13 @@ class RayBackend:
         input_blocks = _get_num_blocks(dataset)
         metrics_collector = _create_metrics_collector(ray)
         batch_size = self.batch_size or data_designer._run_config.buffer_size
+        throttle_manager = (
+            create_ray_throttle_manager(ray, data_designer._run_config)
+            if self.global_provider_throttling
+            and config_builder.model_configs
+            and callable(getattr(ray, "remote", None))
+            else None
+        )
         worker_options = _RayWorkerOptions(
             model_providers=list(data_designer._model_providers),
             default_provider_name=data_designer._model_provider_registry.get_default_provider_name(),
@@ -214,6 +239,7 @@ class RayBackend:
             person_reader=data_designer._person_reader,
             mcp_providers=list(data_designer._mcp_providers),
             run_config=data_designer._run_config,
+            throttle_manager=throttle_manager,
         )
 
         map_batches_kwargs: dict[str, Any] = {
@@ -252,6 +278,7 @@ class RayBackend:
             metrics=metrics,
             ray=ray,
             metrics_collector=metrics_collector,
+            throttle_manager=throttle_manager,
             output=output,
         )
 
@@ -335,7 +362,10 @@ def _create_metrics_collector(ray: Any) -> Any | None:
 
 
 def _merge_driver_and_worker_metrics(
-    driver_metrics: RayDatasetMetrics, worker_metrics: RayDatasetMetrics
+    driver_metrics: RayDatasetMetrics,
+    worker_metrics: RayDatasetMetrics,
+    *,
+    throttle_metrics: dict[str, Any] | None = None,
 ) -> RayDatasetMetrics:
     return RayDatasetMetrics(
         total_rows=worker_metrics.total_rows,
@@ -343,6 +373,7 @@ def _merge_driver_and_worker_metrics(
         failed_blocks=worker_metrics.failed_blocks,
         elapsed_seconds=worker_metrics.elapsed_seconds,
         model_usage=worker_metrics.model_usage or driver_metrics.model_usage,
+        throttle=throttle_metrics or worker_metrics.throttle or driver_metrics.throttle,
     )
 
 
@@ -402,6 +433,7 @@ def _generate_batch(
                 run_config=copy.deepcopy(worker_options.run_config),
                 mcp_providers=worker_options.mcp_providers,
                 tool_configs=block_builder.tool_configs,
+                throttle_manager=worker_options.throttle_manager,
             )
             builder = DatasetBuilder(
                 data_designer_config=block_builder.build(),

--- a/packages/data-designer/src/data_designer/integrations/ray/metrics.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/metrics.py
@@ -47,6 +47,7 @@ class RayDatasetMetrics:
     failed_blocks: int = 0
     elapsed_seconds: float = 0.0
     model_usage: ModelUsageSummary | None = None
+    throttle: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         _validate_non_negative_int("total_rows", self.total_rows)

--- a/packages/data-designer/src/data_designer/integrations/ray/throttling.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/throttling.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import time
+from typing import Any
+
+from data_designer.config.run_config import RunConfig, ThrottleConfig
+from data_designer.engine.models.clients.throttle_manager import (
+    CAPACITY_POLL_INTERVAL,
+    DEFAULT_ACQUIRE_TIMEOUT,
+    ThrottleDomain,
+    ThrottleManager,
+)
+from data_designer.integrations.ray.errors import RayDatasetGenerationError
+
+
+class RayThrottleCoordinator:
+    """Ray actor payload that owns job-wide provider throttle state."""
+
+    def __init__(self, throttle_config: ThrottleConfig | None = None) -> None:
+        self._manager = ThrottleManager(throttle_config)
+
+    def register(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        alias: str,
+        max_parallel_requests: int,
+    ) -> None:
+        self._manager.register(
+            provider_name=provider_name,
+            model_id=model_id,
+            alias=alias,
+            max_parallel_requests=max_parallel_requests,
+        )
+
+    def try_acquire(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> float:
+        return self._manager.try_acquire(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            now=now,
+        )
+
+    def release_success(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        self._manager.release_success(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            now=now,
+        )
+
+    def release_rate_limited(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None:
+        self._manager.release_rate_limited(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            retry_after=retry_after,
+            now=now,
+        )
+
+    def release_failure(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        self._manager.release_failure(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            now=now,
+        )
+
+    def snapshot(self) -> dict[str, object]:
+        return self._manager.snapshot()
+
+
+class RayThrottleManagerProxy:
+    """Throttle manager interface backed by a Ray actor.
+
+    Acquire loops run in the caller process so the coordinator actor remains
+    available to process release calls from other workers.
+    """
+
+    def __init__(self, coordinator: Any) -> None:
+        self._coordinator = coordinator
+
+    def register(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        alias: str,
+        max_parallel_requests: int,
+    ) -> None:
+        _ray_get(
+            self._coordinator.register.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                alias=alias,
+                max_parallel_requests=max_parallel_requests,
+            )
+        )
+
+    def try_acquire(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> float:
+        return float(
+            _ray_get(
+                self._coordinator.try_acquire.remote(
+                    provider_name=provider_name,
+                    model_id=model_id,
+                    domain=domain,
+                    now=now,
+                )
+            )
+        )
+
+    def acquire_sync(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+        while wait != 0.0:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or wait > remaining:
+                raise TimeoutError(
+                    f"Ray throttle acquire timed out after {timeout:.0f}s "
+                    f"for {provider_name}/{model_id} [{domain.value}]"
+                )
+            time.sleep(min(wait, remaining, CAPACITY_POLL_INTERVAL))
+            wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+
+    async def acquire_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+        while wait != 0.0:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or wait > remaining:
+                raise TimeoutError(
+                    f"Ray throttle acquire timed out after {timeout:.0f}s "
+                    f"for {provider_name}/{model_id} [{domain.value}]"
+                )
+            await asyncio.sleep(min(wait, remaining, CAPACITY_POLL_INTERVAL))
+            wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+
+    def release_success(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        _ray_get(
+            self._coordinator.release_success.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                now=now,
+            )
+        )
+
+    def release_rate_limited(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None:
+        _ray_get(
+            self._coordinator.release_rate_limited.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                retry_after=retry_after,
+                now=now,
+            )
+        )
+
+    def release_failure(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        _ray_get(
+            self._coordinator.release_failure.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                now=now,
+            )
+        )
+
+    def snapshot(self) -> dict[str, object]:
+        return dict(_ray_get(self._coordinator.snapshot.remote()))
+
+
+def create_ray_throttle_manager(ray: Any, run_config: RunConfig) -> RayThrottleManagerProxy:
+    """Create a Ray actor-backed throttle manager for one RayBackend job."""
+    remote = getattr(ray, "remote", None)
+    if not callable(remote):
+        raise RayDatasetGenerationError("RayBackend global provider throttling requires ray.remote.")
+    coordinator = remote(RayThrottleCoordinator).remote(run_config.throttle)
+    return RayThrottleManagerProxy(coordinator)
+
+
+def _ray_get(ref: Any) -> Any:
+    try:
+        return importlib.import_module("ray").get(ref)
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend global provider throttle coordination failed.") from exc

--- a/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
+++ b/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.run_config import RunConfig
+from data_designer.engine.models.clients.throttle_manager import CAPACITY_POLL_INTERVAL, ThrottleDomain
+from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.integrations.ray import RayBackend
+from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray.metrics import RayWorkerMetrics
+from data_designer.integrations.ray.throttling import RayThrottleManagerProxy, create_ray_throttle_manager
+from data_designer.interface.data_designer import DataDesigner
+
+
+class FakeRayDataset:
+    def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
+        self.blocks = blocks
+
+    def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
+        fn_kwargs = kwargs.get("fn_kwargs") or {}
+        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+
+    def to_pandas(self) -> lazy.pd.DataFrame:
+        return lazy.pd.concat(self.blocks, ignore_index=True)
+
+    def num_blocks(self) -> int:
+        return len(self.blocks)
+
+
+class FakeRayDataModule:
+    Dataset = FakeRayDataset
+
+    def range(self, num_records: int) -> FakeRayDataset:
+        return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+
+
+class FakeObjectRef:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+class FakeRemoteMethod:
+    def __init__(self, method: Any) -> None:
+        self._method = method
+
+    def remote(self, *args: Any, **kwargs: Any) -> FakeObjectRef:
+        return FakeObjectRef(self._method(*args, **kwargs))
+
+
+class FakeActorHandle:
+    def __init__(self, actor: Any) -> None:
+        self._actor = actor
+
+    def __getattr__(self, name: str) -> FakeRemoteMethod:
+        return FakeRemoteMethod(getattr(self._actor, name))
+
+
+class FakeRemoteClass:
+    def __init__(self, cls: type) -> None:
+        self._cls = cls
+
+    def remote(self, *args: Any, **kwargs: Any) -> FakeActorHandle:
+        return FakeActorHandle(self._cls(*args, **kwargs))
+
+
+def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    fake_ray = types.ModuleType("ray")
+    fake_ray.data = FakeRayDataModule()
+    fake_ray.is_initialized = lambda: True
+    fake_ray.init = lambda: None
+    fake_ray.remote = lambda cls: FakeRemoteClass(cls)
+    fake_ray.get = lambda ref: ref.value
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    return fake_ray
+
+
+def _managed_assets_path(tmp_path: Path) -> Path:
+    path = tmp_path / "managed-assets"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def test_ray_throttle_proxy_coordinates_shared_provider_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    first_worker = create_ray_throttle_manager(fake_ray, RunConfig())
+    second_worker = RayThrottleManagerProxy(first_worker._coordinator)
+
+    first_worker.register(
+        provider_name="openai",
+        model_id="gpt-4.1",
+        alias="writer",
+        max_parallel_requests=1,
+    )
+
+    assert first_worker.try_acquire(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT) == 0.0
+    assert (
+        second_worker.try_acquire(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+        == CAPACITY_POLL_INTERVAL
+    )
+
+    first_worker.release_success(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+
+    assert second_worker.try_acquire(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT) == 0.0
+    snapshot = second_worker.snapshot()
+    assert snapshot["global_caps"] == [
+        {
+            "provider_name": "openai",
+            "model_id": "gpt-4.1",
+            "effective_max": 1,
+            "limits_by_alias": {"writer": 1},
+        }
+    ]
+
+
+def test_ray_backend_exposes_global_throttle_snapshot_in_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+
+    def generate_batch(
+        batch: lazy.pd.DataFrame,
+        *,
+        worker_options: Any,
+        metrics_collector: Any | None = None,
+        **_: Any,
+    ) -> lazy.pd.DataFrame:
+        throttle_manager = worker_options.throttle_manager
+        assert throttle_manager is not None
+        throttle_manager.register(
+            provider_name="openai",
+            model_id="gpt-4.1",
+            alias="writer",
+            max_parallel_requests=1,
+        )
+        throttle_manager.acquire_sync(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+        throttle_manager.release_success(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+        ray_backend_module._record_worker_metrics(
+            metrics_collector,
+            RayWorkerMetrics(total_rows=len(batch), blocks=1, elapsed_seconds=0.25),
+        )
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2),
+    )
+
+    results = designer.create(stub_sampler_only_config_builder, num_records=2)
+    metrics = results.load_metrics()
+
+    assert results.load_dataset().to_pandas().to_dict(orient="records") == [{"id": 0}, {"id": 1}]
+    assert metrics.total_rows == 2
+    assert metrics.throttle is not None
+    assert metrics.throttle["global_caps"][0]["effective_max"] == 1
+    assert metrics.throttle["domains"][0]["domain"] == ThrottleDomain.CHAT.value


### PR DESCRIPTION
## 📋 Summary

Adds a Ray actor-backed provider throttle coordinator so Ray workers can share provider/model concurrency caps across a single RayBackend job. The engine factory wiring now accepts any throttle-manager-compatible object without importing Ray into engine packages.

## 🔗 Related Issue

Addresses #13

## 🔄 Changes

- Add a `ThrottleManagerLike` protocol and throttle-state snapshots for telemetry.
- Thread optional throttle-manager injection through engine model/resource factory wiring.
- Add `data_designer.integrations.ray.throttling` with a Ray actor coordinator and worker-side proxy.
- Enable RayBackend global provider throttling by default for model-backed jobs and expose throttle snapshots through Ray metrics.
- Add fake-Ray tests for shared provider cap contention and Ray metrics snapshot exposure.

## 🧪 Testing

- [x] `UV_CACHE_DIR=.uv-cache uv run pytest packages/data-designer/tests/integrations/ray -q` - 45 passed, 1 skipped
- [x] `UV_CACHE_DIR=.uv-cache uv run pytest packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py packages/data-designer-engine/tests/engine/models/clients/test_factory.py -q` - 60 passed
- [x] `UV_CACHE_DIR=.uv-cache uv run ruff check ...` on changed Ray/engine files
- [x] `UV_CACHE_DIR=.uv-cache uv run ruff format --check ...` on changed Ray/engine files

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated - not included; this PR focuses on runtime wiring and tests