### PR TITLE
feat(ray): add observability artifacts

### DIFF
--- a/docs/concepts/deployment-options.md
+++ b/docs/concepts/deployment-options.md
@@ -145,6 +145,28 @@ When users can submit configs containing Jinja templates to a shared engine, tem
 
 ---
 
+## Ray Backend Trusted-Cluster Boundary
+
+The optional Ray backend is a library scaling mode for trusted Ray clusters. It serializes the job configuration,
+model provider definitions, secret resolver state, seed-reader state, MCP provider definitions, and runtime settings
+to Ray workers so each worker can construct its local generation engine.
+
+Use Ray only when the driver and workers are inside the same trusted operational boundary, such as a single-tenant
+cluster or a managed cluster with equivalent isolation. A Ray worker may receive provider endpoint configuration and
+may be able to resolve API keys through the configured `SecretResolver` or worker environment. Treat every Ray worker
+that can run the job as trusted with the same access level as the driver process.
+
+Avoid running the Ray backend on shared clusters where untrusted users can inspect task payloads, object-store data,
+worker logs, runtime environments, or process environment variables. If you must use shared infrastructure, add
+platform controls outside Data Designer: tenant-isolated Ray clusters, scoped service accounts, restricted dashboard
+and log access, network policies around provider endpoints, and secret management that grants only the workers for a
+single job access to the required keys.
+
+The Ray backend does not turn Data Designer into a multi-tenant service boundary. For shared service deployments,
+prefer a service architecture with explicit authentication, authorization, audit logging, and request validation.
+
+---
+
 ## 🧭 Decision Flowchart
 
 ```

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -16,6 +16,15 @@ from data_designer.integrations.ray.metrics import (
     aggregate_ray_metrics,
     normalize_ray_worker_metrics,
 )
+from data_designer.integrations.ray.observability import (
+    RayDatasetAnalysis,
+    RayThrottleSnapshot,
+    RayTraceEvent,
+    RayWorkerProfile,
+    normalize_ray_throttle_snapshot,
+    normalize_ray_trace_event,
+    normalize_ray_worker_profile,
+)
 
 __all__ = [
     "RayBackend",
@@ -25,7 +34,14 @@ __all__ = [
     "RayDatasetMetrics",
     "RayIntegrationError",
     "RayMetricsError",
+    "RayDatasetAnalysis",
+    "RayThrottleSnapshot",
+    "RayTraceEvent",
     "RayWorkerMetrics",
+    "RayWorkerProfile",
     "aggregate_ray_metrics",
+    "normalize_ray_throttle_snapshot",
+    "normalize_ray_trace_event",
     "normalize_ray_worker_metrics",
+    "normalize_ray_worker_profile",
 ]

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import copy
 import importlib
 import os
+import socket
 import tempfile
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
@@ -25,7 +27,21 @@ from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderReg
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
-from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.metrics import (
+    RayDatasetMetrics,
+    RayWorkerMetrics,
+    aggregate_ray_metrics,
+    normalize_ray_worker_metrics,
+)
+from data_designer.integrations.ray.observability import (
+    RayDatasetAnalysis,
+    RayThrottleSnapshot,
+    RayTraceEvent,
+    RayWorkerProfile,
+    normalize_ray_throttle_snapshot,
+    normalize_ray_trace_event,
+    normalize_ray_worker_profile,
+)
 
 if TYPE_CHECKING:
     from data_designer.config.mcp import MCPProviderT
@@ -48,6 +64,12 @@ class _RayWorkerOptions:
     run_config: RunConfig
 
 
+@dataclass(frozen=True)
+class _RayObservabilityOptions:
+    profile_workers: bool = False
+    trace_enabled: bool = False
+
+
 class RayDatasetCreationResults:
     """Results wrapper for Ray-resident Data Designer outputs."""
 
@@ -60,22 +82,26 @@ class RayDatasetCreationResults:
         ray: Any | None = None,
         metrics_collector: Any | None = None,
         output: Any | None = None,
+        observability_options: _RayObservabilityOptions | None = None,
     ) -> None:
         self.dataset = dataset
         self._config_builder = config_builder
         self._driver_metrics = metrics
         self._metrics_cache: RayDatasetMetrics | None = None
+        self._worker_metrics_cache: list[RayWorkerMetrics] | None = None
+        self._analysis_cache: RayDatasetAnalysis | None = None
         self._ray = ray
         self._metrics_collector = metrics_collector
         self._output = output
+        self._observability_options = observability_options or _RayObservabilityOptions()
 
     def load_dataset(self) -> Any:
         """Return the Ray Dataset without materializing it on the driver."""
         return self.dataset
 
-    def load_analysis(self) -> None:
-        """Ray-resident jobs do not produce local profiler artifacts."""
-        return None
+    def load_analysis(self) -> RayDatasetAnalysis | None:
+        """Return Ray-native worker profiles and bounded traces when available."""
+        return self.load_observability()
 
     def load_metrics(self) -> RayDatasetMetrics:
         """Return driver-visible Ray execution metrics."""
@@ -84,22 +110,80 @@ class RayDatasetCreationResults:
         if self._ray is None or self._metrics_collector is None:
             return self._driver_metrics
         try:
-            payloads = self._ray.get(self._metrics_collector.snapshot.remote())
-            if not payloads:
-                self._materialize_dataset_for_metrics()
-                payloads = self._ray.get(self._metrics_collector.snapshot.remote())
+            worker_metrics_payloads = self._load_worker_metrics_payloads()
         except Exception as exc:
             raise RayDatasetGenerationError("RayBackend failed to load worker metrics.") from exc
-        if not payloads:
+        if not worker_metrics_payloads:
             return self._driver_metrics
-        worker_metrics = aggregate_ray_metrics(payloads)
+        worker_metrics = aggregate_ray_metrics(worker_metrics_payloads)
         self._metrics_cache = _merge_driver_and_worker_metrics(self._driver_metrics, worker_metrics)
         return self._metrics_cache
+
+    def load_worker_metrics(self) -> list[RayWorkerMetrics]:
+        """Return per-worker metrics payloads before dataset-level aggregation."""
+        if self._ray is None or self._metrics_collector is None:
+            return []
+        try:
+            return list(self._load_worker_metrics_payloads())
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed to load worker metrics.") from exc
+
+    def load_observability(self) -> RayDatasetAnalysis | None:
+        """Return bounded Ray-native profiles, traces, and worker-local throttle snapshots."""
+        if self._analysis_cache is not None:
+            return self._analysis_cache
+        if self._ray is None or self._metrics_collector is None:
+            return None
+        try:
+            payload = self._load_observability_payload()
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed to load Ray observability artifacts.") from exc
+        if not _has_observability_payload(payload):
+            return None
+
+        metrics = self.load_metrics()
+        worker_profiles = [
+            normalize_ray_worker_profile(profile) for profile in payload.get("worker_profiles", []) or []
+        ]
+        trace_events = [normalize_ray_trace_event(event) for event in payload.get("trace_events", []) or []]
+        throttle_snapshots = [
+            normalize_ray_throttle_snapshot(snapshot) for snapshot in payload.get("throttle_snapshots", []) or []
+        ]
+        self._analysis_cache = RayDatasetAnalysis(
+            total_rows=metrics.total_rows,
+            blocks=metrics.blocks,
+            failed_blocks=metrics.failed_blocks,
+            worker_profiles=worker_profiles,
+            trace_events=trace_events,
+            trace_events_dropped=int(payload.get("trace_events_dropped", 0) or 0),
+            throttle_snapshots=throttle_snapshots,
+        )
+        return self._analysis_cache
 
     @property
     def metrics(self) -> RayDatasetMetrics:
         """Return the latest available Ray execution metrics."""
         return self.load_metrics()
+
+    def _load_worker_metrics_payloads(self) -> list[RayWorkerMetrics]:
+        if self._worker_metrics_cache is not None:
+            return self._worker_metrics_cache
+        payloads = self._ray.get(self._metrics_collector.snapshot.remote())
+        if not payloads:
+            self._materialize_dataset_for_metrics()
+            payloads = self._ray.get(self._metrics_collector.snapshot.remote())
+        self._worker_metrics_cache = [normalize_ray_worker_metrics(payload) for payload in payloads]
+        return self._worker_metrics_cache
+
+    def _load_observability_payload(self) -> dict[str, Any]:
+        observability_snapshot = getattr(self._metrics_collector, "observability_snapshot", None)
+        if observability_snapshot is None:
+            return {}
+        payload = self._ray.get(observability_snapshot.remote())
+        if not _has_observability_payload(payload):
+            self._load_worker_metrics_payloads()
+            payload = self._ray.get(observability_snapshot.remote())
+        return dict(payload)
 
     def _materialize_dataset_for_metrics(self) -> None:
         materialize = getattr(self.dataset, "materialize", None)
@@ -144,6 +228,9 @@ class RayBackend:
         drop_order_column: bool = False,
         preserve_order: bool = False,
         allow_unsafe_processors: bool = False,
+        profile_workers: bool = True,
+        trace_enabled: bool = False,
+        max_trace_events: int = 1000,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
             raise ValueError("RayBackend output must be 'dataset' or 'arrow_refs'.")
@@ -151,6 +238,8 @@ class RayBackend:
             raise ValueError("RayBackend object_ref_format must be 'arrow' or 'pandas'.")
         if order_column is not None and order_column == "":
             raise ValueError("RayBackend order_column must be a non-empty string when provided.")
+        if max_trace_events < 0:
+            raise ValueError("RayBackend max_trace_events must be non-negative.")
         self.batch_size = batch_size
         self.output = output
         self.object_ref_format = object_ref_format
@@ -161,6 +250,9 @@ class RayBackend:
         self.drop_order_column = drop_order_column
         self.preserve_order = preserve_order
         self.allow_unsafe_processors = allow_unsafe_processors
+        self.profile_workers = profile_workers
+        self.trace_enabled = trace_enabled
+        self.max_trace_events = max_trace_events
 
     def create(
         self,
@@ -203,8 +295,12 @@ class RayBackend:
 
         dataset = self._resolve_input_dataset(ray, input_dataset=input_dataset, num_records=num_records)
         input_blocks = _get_num_blocks(dataset)
-        metrics_collector = _create_metrics_collector(ray)
+        metrics_collector = _create_metrics_collector(ray, max_trace_events=self.max_trace_events)
         batch_size = self.batch_size or data_designer._run_config.buffer_size
+        observability_options = _RayObservabilityOptions(
+            profile_workers=self.profile_workers,
+            trace_enabled=self.trace_enabled,
+        )
         worker_options = _RayWorkerOptions(
             model_providers=list(data_designer._model_providers),
             default_provider_name=data_designer._model_provider_registry.get_default_provider_name(),
@@ -222,6 +318,7 @@ class RayBackend:
                 "worker_options": worker_options,
                 "use_input_dataset": use_input_dataset,
                 "metrics_collector": metrics_collector,
+                "observability_options": observability_options,
             },
             "batch_size": batch_size,
             "batch_format": "pandas",
@@ -253,6 +350,7 @@ class RayBackend:
             ray=ray,
             metrics_collector=metrics_collector,
             output=output,
+            observability_options=observability_options,
         )
 
     def _resolve_input_dataset(self, ray: Any, *, input_dataset: Any | None, num_records: int) -> Any:
@@ -317,21 +415,48 @@ def _dataset_from_arrow_refs(ray: Any, refs: list[Any]) -> Any:
 
 
 class _RayMetricsCollector:
-    def __init__(self) -> None:
+    def __init__(self, max_trace_events: int = 1000) -> None:
         self._payloads: list[dict[str, Any]] = []
+        self._worker_profiles: list[dict[str, Any]] = []
+        self._trace_events: list[dict[str, Any]] = []
+        self._trace_events_dropped = 0
+        self._throttle_snapshots: list[dict[str, Any]] = []
+        self._max_trace_events = max_trace_events
 
     def record(self, payload: dict[str, Any]) -> None:
         self._payloads.append(payload)
 
+    def record_observability(self, payload: dict[str, Any]) -> None:
+        profile = payload.get("worker_profile")
+        if isinstance(profile, dict):
+            self._worker_profiles.append(profile)
+        for event in payload.get("trace_events", []) or []:
+            if len(self._trace_events) >= self._max_trace_events:
+                self._trace_events_dropped += 1
+                continue
+            if isinstance(event, dict):
+                self._trace_events.append(event)
+        for snapshot in payload.get("throttle_snapshots", []) or []:
+            if isinstance(snapshot, dict):
+                self._throttle_snapshots.append(snapshot)
+
     def snapshot(self) -> list[dict[str, Any]]:
         return list(self._payloads)
 
+    def observability_snapshot(self) -> dict[str, Any]:
+        return {
+            "worker_profiles": list(self._worker_profiles),
+            "trace_events": list(self._trace_events),
+            "trace_events_dropped": self._trace_events_dropped,
+            "throttle_snapshots": list(self._throttle_snapshots),
+        }
 
-def _create_metrics_collector(ray: Any) -> Any | None:
+
+def _create_metrics_collector(ray: Any, *, max_trace_events: int = 1000) -> Any | None:
     remote = getattr(ray, "remote", None)
     if not callable(remote):
         return None
-    return remote(_RayMetricsCollector).remote()
+    return remote(_RayMetricsCollector).remote(max_trace_events=max_trace_events)
 
 
 def _merge_driver_and_worker_metrics(
@@ -366,15 +491,54 @@ def _generate_batch(
     worker_options: _RayWorkerOptions,
     use_input_dataset: bool,
     metrics_collector: Any | None = None,
+    observability_options: _RayObservabilityOptions | None = None,
 ) -> Any:
     start_time = time.perf_counter()
+    block_id = uuid.uuid4().hex
+    observability_options = observability_options or _RayObservabilityOptions()
+    worker_context = _get_ray_worker_context()
+    trace_events: list[RayTraceEvent] = []
     os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1"
     dataframe = _coerce_pandas_dataframe(batch)
     num_records = len(dataframe)
+    if observability_options.trace_enabled:
+        trace_events.append(
+            _create_trace_event(
+                block_id,
+                "block_started",
+                start_time,
+                row_count=num_records,
+                worker_context=worker_context,
+                details={"input_columns": [str(column) for column in dataframe.columns]},
+            )
+        )
     if num_records == 0:
+        elapsed_seconds = time.perf_counter() - start_time
+        profile = (
+            _profile_worker_output(dataframe, block_id=block_id, model_usage=None)
+            if observability_options.profile_workers
+            else None
+        )
+        if observability_options.trace_enabled:
+            trace_events.append(
+                _create_trace_event(
+                    block_id,
+                    "block_completed",
+                    start_time,
+                    row_count=0,
+                    worker_context=worker_context,
+                    details={"empty_batch": True},
+                )
+            )
         _record_worker_metrics(
             metrics_collector,
-            RayWorkerMetrics(total_rows=0, blocks=1, elapsed_seconds=time.perf_counter() - start_time),
+            RayWorkerMetrics(total_rows=0, blocks=1, elapsed_seconds=elapsed_seconds, block_id=block_id),
+        )
+        _record_worker_observability(
+            metrics_collector,
+            worker_profile=profile,
+            trace_events=trace_events,
+            throttle_snapshots=[],
         )
         return dataframe
 
@@ -384,8 +548,21 @@ def _generate_batch(
             block_builder.with_seed_dataset(DataFrameSeedSource(df=dataframe.copy()))
 
         with tempfile.TemporaryDirectory(prefix="data-designer-ray-") as artifact_dir:
+            if observability_options.trace_enabled:
+                trace_events.append(
+                    _create_trace_event(
+                        block_id,
+                        "resource_setup_started",
+                        start_time,
+                        row_count=num_records,
+                        worker_context=worker_context,
+                    )
+                )
             ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
             seed_readers = copy.deepcopy(worker_options.seed_readers)
+            run_config = copy.deepcopy(worker_options.run_config)
+            if observability_options.trace_enabled:
+                run_config.async_trace = True
             resource_provider = create_resource_provider(
                 artifact_storage=ArtifactStorage(artifact_path=artifact_dir, dataset_name="ray-block"),
                 model_configs=block_builder.model_configs,
@@ -399,7 +576,7 @@ def _generate_batch(
                 seed_dataset_source=(
                     block_builder.get_seed_config().source if block_builder.get_seed_config() is not None else None
                 ),
-                run_config=copy.deepcopy(worker_options.run_config),
+                run_config=run_config,
                 mcp_providers=worker_options.mcp_providers,
                 tool_configs=block_builder.tool_configs,
             )
@@ -408,20 +585,81 @@ def _generate_batch(
                 resource_provider=resource_provider,
                 use_async=True,
             )
+            if observability_options.trace_enabled:
+                trace_events.append(
+                    _create_trace_event(
+                        block_id,
+                        "resource_setup_completed",
+                        start_time,
+                        row_count=num_records,
+                        worker_context=worker_context,
+                    )
+                )
+                trace_events.append(
+                    _create_trace_event(
+                        block_id,
+                        "generation_started",
+                        start_time,
+                        row_count=num_records,
+                        worker_context=worker_context,
+                    )
+                )
             raw_dataset = builder.build_preview(num_records=num_records)
             output = builder.process_preview(raw_dataset)
             elapsed_seconds = time.perf_counter() - start_time
+            model_usage = resource_provider.model_registry.get_model_usage_stats(elapsed_seconds)
+            if observability_options.trace_enabled:
+                trace_events.extend(
+                    _task_traces_to_events(
+                        builder.task_traces,
+                        block_id=block_id,
+                        worker_context=worker_context,
+                    )
+                )
+                trace_events.append(
+                    _create_trace_event(
+                        block_id,
+                        "block_completed",
+                        start_time,
+                        row_count=len(output),
+                        worker_context=worker_context,
+                        details={"output_columns": [str(column) for column in output.columns]},
+                    )
+                )
+            throttle_snapshots = _snapshot_worker_throttle(resource_provider.model_registry.throttle_manager)
             _record_worker_metrics(
                 metrics_collector,
                 RayWorkerMetrics(
                     total_rows=len(output),
                     blocks=1,
                     elapsed_seconds=elapsed_seconds,
-                    model_usage=resource_provider.model_registry.get_model_usage_stats(elapsed_seconds),
+                    model_usage=model_usage,
+                    block_id=block_id,
                 ),
             )
+            _record_worker_observability(
+                metrics_collector,
+                worker_profile=(
+                    _profile_worker_output(output, block_id=block_id, model_usage=model_usage)
+                    if observability_options.profile_workers
+                    else None
+                ),
+                trace_events=trace_events,
+                throttle_snapshots=throttle_snapshots,
+            )
             return output
-    except Exception:
+    except Exception as exc:
+        if observability_options.trace_enabled:
+            trace_events.append(
+                _create_trace_event(
+                    block_id,
+                    "block_failed",
+                    start_time,
+                    row_count=num_records,
+                    worker_context=worker_context,
+                    details={"error_type": type(exc).__name__, "error": str(exc)},
+                )
+            )
         _record_worker_metrics(
             metrics_collector,
             RayWorkerMetrics(
@@ -429,15 +667,213 @@ def _generate_batch(
                 blocks=1,
                 failed_blocks=1,
                 elapsed_seconds=time.perf_counter() - start_time,
+                block_id=block_id,
             ),
         )
+        _record_worker_observability(
+            metrics_collector,
+            worker_profile=None,
+            trace_events=trace_events,
+            throttle_snapshots=[],
+        )
         raise
+
+
+def _record_worker_observability(
+    metrics_collector: Any | None,
+    *,
+    worker_profile: RayWorkerProfile | None,
+    trace_events: list[RayTraceEvent],
+    throttle_snapshots: list[RayThrottleSnapshot],
+) -> None:
+    if metrics_collector is None:
+        return
+    payload = {
+        "worker_profile": worker_profile.to_dict() if worker_profile is not None else None,
+        "trace_events": [event.to_dict() for event in trace_events],
+        "throttle_snapshots": [snapshot.to_dict() for snapshot in throttle_snapshots],
+    }
+    importlib.import_module("ray").get(metrics_collector.record_observability.remote(payload))
 
 
 def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:
     if metrics_collector is None:
         return
     importlib.import_module("ray").get(metrics_collector.record.remote(metrics.to_dict()))
+
+
+def _profile_worker_output(
+    output: Any, *, block_id: str, model_usage: dict[str, dict[str, Any]] | None
+) -> RayWorkerProfile:
+    warnings: list[str] = []
+    try:
+        columns = [str(column) for column in output.columns]
+        column_dtypes = {str(column): str(dtype) for column, dtype in output.dtypes.items()}
+        non_null_counts = {str(column): int(value) for column, value in output.notna().sum().to_dict().items()}
+        null_counts = {str(column): int(value) for column, value in output.isna().sum().to_dict().items()}
+        memory_usage_bytes = int(output.memory_usage(deep=True).sum())
+    except Exception as exc:
+        columns = []
+        column_dtypes = {}
+        non_null_counts = {}
+        null_counts = {}
+        memory_usage_bytes = None
+        warnings.append(f"Failed to profile Ray worker output: {type(exc).__name__}: {exc}")
+    return RayWorkerProfile(
+        block_id=block_id,
+        total_rows=len(output),
+        columns=columns,
+        column_dtypes=column_dtypes,
+        non_null_counts=non_null_counts,
+        null_counts=null_counts,
+        memory_usage_bytes=memory_usage_bytes,
+        model_usage=model_usage,
+        warnings=warnings,
+    )
+
+
+def _snapshot_worker_throttle(throttle_manager: Any | None) -> list[RayThrottleSnapshot]:
+    if throttle_manager is None:
+        return []
+    domains = getattr(throttle_manager, "_domains", None)
+    if not isinstance(domains, dict):
+        return []
+    get_effective_max = getattr(throttle_manager, "get_effective_max", None)
+    snapshots: list[RayThrottleSnapshot] = []
+    for key, state in domains.items():
+        if not isinstance(key, tuple) or len(key) != 3:
+            continue
+        provider_name, model_id, domain = key
+        if not all(isinstance(value, str) for value in (provider_name, model_id, domain)):
+            continue
+        effective_max = get_effective_max(provider_name, model_id) if callable(get_effective_max) else None
+        snapshots.append(
+            RayThrottleSnapshot(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                current_limit=_safe_int_attr(state, "current_limit"),
+                effective_max=effective_max,
+                in_flight=_safe_int_attr(state, "in_flight"),
+                waiters=_safe_int_attr(state, "waiters"),
+                rate_limit_ceiling=_safe_int_attr(state, "rate_limit_ceiling"),
+                consecutive_rate_limits=_safe_int_attr(state, "consecutive_429s"),
+            )
+        )
+    return snapshots
+
+
+def _task_traces_to_events(
+    task_traces: list[Any],
+    *,
+    block_id: str,
+    worker_context: dict[str, Any],
+) -> list[RayTraceEvent]:
+    events: list[RayTraceEvent] = []
+    for task_trace in task_traces:
+        dispatched_at = _safe_float_attr(task_trace, "dispatched_at")
+        slot_acquired_at = _safe_float_attr(task_trace, "slot_acquired_at")
+        completed_at = _safe_float_attr(task_trace, "completed_at")
+        elapsed_seconds = max(completed_at - dispatched_at, 0.0) if completed_at > 0 and dispatched_at > 0 else 0.0
+        wait_seconds = max(slot_acquired_at - dispatched_at, 0.0) if slot_acquired_at > 0 and dispatched_at > 0 else 0.0
+        run_seconds = max(completed_at - slot_acquired_at, 0.0) if completed_at > 0 and slot_acquired_at > 0 else 0.0
+        events.append(
+            RayTraceEvent(
+                block_id=block_id,
+                event_type="engine_task",
+                timestamp_seconds=time.time(),
+                elapsed_seconds=elapsed_seconds,
+                row_count=0,
+                worker_hostname=worker_context["worker_hostname"],
+                worker_pid=worker_context["worker_pid"],
+                ray_task_id=worker_context.get("ray_task_id"),
+                ray_node_id=worker_context.get("ray_node_id"),
+                details={
+                    "column": getattr(task_trace, "column", None),
+                    "row_group": getattr(task_trace, "row_group", None),
+                    "row_index": getattr(task_trace, "row_index", None),
+                    "task_type": getattr(task_trace, "task_type", None),
+                    "status": getattr(task_trace, "status", None),
+                    "error": getattr(task_trace, "error", None),
+                    "queue_wait_seconds": wait_seconds,
+                    "run_seconds": run_seconds,
+                },
+            )
+        )
+    return events
+
+
+def _create_trace_event(
+    block_id: str,
+    event_type: str,
+    start_time: float,
+    *,
+    row_count: int,
+    worker_context: dict[str, Any],
+    details: dict[str, Any] | None = None,
+) -> RayTraceEvent:
+    return RayTraceEvent(
+        block_id=block_id,
+        event_type=event_type,
+        timestamp_seconds=time.time(),
+        elapsed_seconds=time.perf_counter() - start_time,
+        row_count=row_count,
+        worker_hostname=worker_context["worker_hostname"],
+        worker_pid=worker_context["worker_pid"],
+        ray_task_id=worker_context.get("ray_task_id"),
+        ray_node_id=worker_context.get("ray_node_id"),
+        details=details,
+    )
+
+
+def _get_ray_worker_context() -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "worker_hostname": socket.gethostname(),
+        "worker_pid": os.getpid(),
+        "ray_task_id": None,
+        "ray_node_id": None,
+    }
+    try:
+        ray = importlib.import_module("ray")
+        get_runtime_context = getattr(ray, "get_runtime_context", None)
+        runtime_context = get_runtime_context() if callable(get_runtime_context) else None
+    except Exception:
+        runtime_context = None
+    if runtime_context is None:
+        return context
+    context["ray_task_id"] = _runtime_context_value(runtime_context, "get_task_id")
+    context["ray_node_id"] = _runtime_context_value(runtime_context, "get_node_id")
+    return context
+
+
+def _runtime_context_value(runtime_context: Any, method_name: str) -> str | None:
+    method = getattr(runtime_context, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        value = method()
+    except Exception:
+        return None
+    return str(value) if value is not None else None
+
+
+def _safe_int_attr(value: Any, attr_name: str) -> int:
+    attr = getattr(value, attr_name, 0)
+    return attr if isinstance(attr, int) and not isinstance(attr, bool) and attr >= 0 else 0
+
+
+def _safe_float_attr(value: Any, attr_name: str) -> float:
+    attr = getattr(value, attr_name, 0.0)
+    return float(attr) if isinstance(attr, (int, float)) and not isinstance(attr, bool) and attr >= 0 else 0.0
+
+
+def _has_observability_payload(payload: dict[str, Any]) -> bool:
+    return bool(
+        payload.get("worker_profiles")
+        or payload.get("trace_events")
+        or payload.get("trace_events_dropped")
+        or payload.get("throttle_snapshots")
+    )
 
 
 def _coerce_pandas_dataframe(batch: Any) -> Any:

--- a/packages/data-designer/src/data_designer/integrations/ray/metrics.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/metrics.py
@@ -22,12 +22,15 @@ class RayWorkerMetrics:
     failed_blocks: int = 0
     elapsed_seconds: float = 0.0
     model_usage: ModelUsageSummary | None = None
+    block_id: str | None = None
 
     def __post_init__(self) -> None:
         _validate_non_negative_int("total_rows", self.total_rows)
         _validate_non_negative_int("blocks", self.blocks)
         _validate_non_negative_int("failed_blocks", self.failed_blocks)
         _validate_non_negative_float("elapsed_seconds", self.elapsed_seconds)
+        if self.block_id is not None and not isinstance(self.block_id, str):
+            raise RayMetricsError("Ray metrics field 'block_id' must be a string when provided.")
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation."""
@@ -113,6 +116,7 @@ def normalize_ray_worker_metrics(payload: RayMetricsPayload) -> RayWorkerMetrics
             failed_blocks=payload.failed_blocks,
             elapsed_seconds=payload.elapsed_seconds,
             model_usage=payload.model_usage,
+            block_id=None,
         )
     if isinstance(payload, RayWorkerMetrics):
         return payload
@@ -125,6 +129,7 @@ def normalize_ray_worker_metrics(payload: RayMetricsPayload) -> RayWorkerMetrics
         failed_blocks=_coerce_int(payload, "failed_blocks", default=0),
         elapsed_seconds=_coerce_float(payload, "elapsed_seconds", default=0.0),
         model_usage=_coerce_model_usage(payload.get("model_usage")),
+        block_id=_coerce_optional_str(payload.get("block_id")),
     )
 
 
@@ -156,6 +161,14 @@ def _coerce_model_usage(value: Any) -> ModelUsageSummary | None:
             raise RayMetricsError(f"Ray metrics model usage for {model_name!r} must be a mapping.")
         model_usage[model_name] = dict(stats)
     return model_usage
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RayMetricsError("Ray metrics field 'block_id' must be a string when provided.")
+    return value
 
 
 def _validate_non_negative_int(field_name: str, value: int) -> None:

--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import html
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from data_designer.integrations.ray.errors import RayMetricsError
+
+ModelUsageSummary = dict[str, dict[str, Any]]
+RayTraceEventPayload: TypeAlias = "RayTraceEvent | Mapping[str, Any]"
+RayWorkerProfilePayload: TypeAlias = "RayWorkerProfile | Mapping[str, Any]"
+RayThrottleSnapshotPayload: TypeAlias = "RayThrottleSnapshot | Mapping[str, Any]"
+
+
+@dataclass(frozen=True, slots=True)
+class RayTraceEvent:
+    """Bounded execution trace event emitted by a Ray worker."""
+
+    block_id: str
+    event_type: str
+    timestamp_seconds: float
+    elapsed_seconds: float = 0.0
+    row_count: int = 0
+    worker_hostname: str | None = None
+    worker_pid: int | None = None
+    ray_task_id: str | None = None
+    ray_node_id: str | None = None
+    details: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str("block_id", self.block_id)
+        _validate_non_empty_str("event_type", self.event_type)
+        _validate_non_negative_float("timestamp_seconds", self.timestamp_seconds)
+        _validate_non_negative_float("elapsed_seconds", self.elapsed_seconds)
+        _validate_non_negative_int("row_count", self.row_count)
+        if self.worker_pid is not None:
+            _validate_non_negative_int("worker_pid", self.worker_pid)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RayWorkerProfile:
+    """Small per-block profiler summary that does not materialize the full dataset on the driver."""
+
+    block_id: str
+    total_rows: int = 0
+    columns: list[str] = field(default_factory=list)
+    column_dtypes: dict[str, str] = field(default_factory=dict)
+    non_null_counts: dict[str, int] = field(default_factory=dict)
+    null_counts: dict[str, int] = field(default_factory=dict)
+    memory_usage_bytes: int | None = None
+    model_usage: ModelUsageSummary | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str("block_id", self.block_id)
+        _validate_non_negative_int("total_rows", self.total_rows)
+        if self.memory_usage_bytes is not None:
+            _validate_non_negative_int("memory_usage_bytes", self.memory_usage_bytes)
+        for column in self.columns:
+            _validate_non_empty_str("columns item", column)
+        for field_name, counts in (("non_null_counts", self.non_null_counts), ("null_counts", self.null_counts)):
+            for column_name, value in counts.items():
+                _validate_non_empty_str(f"{field_name} key", column_name)
+                _validate_non_negative_int(f"{field_name}[{column_name!r}]", value)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RayThrottleSnapshot:
+    """Worker-local throttle state snapshot for provider throttling diagnosis."""
+
+    provider_name: str
+    model_id: str
+    domain: str
+    current_limit: int
+    effective_max: int | None = None
+    in_flight: int = 0
+    waiters: int = 0
+    rate_limit_ceiling: int = 0
+    consecutive_rate_limits: int = 0
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str("provider_name", self.provider_name)
+        _validate_non_empty_str("model_id", self.model_id)
+        _validate_non_empty_str("domain", self.domain)
+        _validate_non_negative_int("current_limit", self.current_limit)
+        if self.effective_max is not None:
+            _validate_non_negative_int("effective_max", self.effective_max)
+        _validate_non_negative_int("in_flight", self.in_flight)
+        _validate_non_negative_int("waiters", self.waiters)
+        _validate_non_negative_int("rate_limit_ceiling", self.rate_limit_ceiling)
+        _validate_non_negative_int("consecutive_rate_limits", self.consecutive_rate_limits)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RayDatasetAnalysis:
+    """Ray-native analysis artifact composed from bounded worker summaries."""
+
+    total_rows: int = 0
+    blocks: int = 0
+    failed_blocks: int = 0
+    worker_profiles: list[RayWorkerProfile] = field(default_factory=list)
+    trace_events: list[RayTraceEvent] = field(default_factory=list)
+    trace_events_dropped: int = 0
+    throttle_snapshots: list[RayThrottleSnapshot] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        _validate_non_negative_int("total_rows", self.total_rows)
+        _validate_non_negative_int("blocks", self.blocks)
+        _validate_non_negative_int("failed_blocks", self.failed_blocks)
+        _validate_non_negative_int("trace_events_dropped", self.trace_events_dropped)
+
+    @property
+    def successful_blocks(self) -> int:
+        """Return completed block count after failed blocks are subtracted."""
+        return max(self.blocks - self.failed_blocks, 0)
+
+    @property
+    def column_names(self) -> list[str]:
+        """Return sorted unique column names observed across worker profiles."""
+        return sorted({column for profile in self.worker_profiles for column in profile.columns})
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+    def to_report(self, save_path: str | Path | None = None, include_sections: list[Any] | None = None) -> None:
+        """Write a compact JSON or HTML report for Ray-native analysis.
+
+        The local profiler's rich report requires driver-materialized data. Ray analysis is intentionally
+        restricted to worker-emitted summaries and bounded trace events.
+        """
+        del include_sections
+        if save_path is None:
+            return
+        path = Path(save_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(self.to_dict(), indent=2, sort_keys=True)
+        if path.suffix.lower() in {".html", ".htm"}:
+            path.write_text(_analysis_payload_to_html(payload), encoding="utf-8")
+            return
+        path.write_text(f"{payload}\n", encoding="utf-8")
+
+
+def normalize_ray_trace_event(payload: RayTraceEventPayload) -> RayTraceEvent:
+    """Normalize a trace dataclass or mapping payload."""
+    if isinstance(payload, RayTraceEvent):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise RayMetricsError(f"Ray trace event payload must be a mapping, got {type(payload)!r}.")
+    return RayTraceEvent(
+        block_id=_coerce_str(payload, "block_id"),
+        event_type=_coerce_str(payload, "event_type"),
+        timestamp_seconds=_coerce_float(payload, "timestamp_seconds", default=0.0),
+        elapsed_seconds=_coerce_float(payload, "elapsed_seconds", default=0.0),
+        row_count=_coerce_int(payload, "row_count", default=0),
+        worker_hostname=_coerce_optional_str(payload.get("worker_hostname")),
+        worker_pid=_coerce_optional_int(payload.get("worker_pid"), "worker_pid"),
+        ray_task_id=_coerce_optional_str(payload.get("ray_task_id")),
+        ray_node_id=_coerce_optional_str(payload.get("ray_node_id")),
+        details=_coerce_optional_mapping(payload.get("details")),
+    )
+
+
+def normalize_ray_worker_profile(payload: RayWorkerProfilePayload) -> RayWorkerProfile:
+    """Normalize a worker profile dataclass or mapping payload."""
+    if isinstance(payload, RayWorkerProfile):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise RayMetricsError(f"Ray worker profile payload must be a mapping, got {type(payload)!r}.")
+    return RayWorkerProfile(
+        block_id=_coerce_str(payload, "block_id"),
+        total_rows=_coerce_int(payload, "total_rows", default=0),
+        columns=_coerce_str_list(payload.get("columns")),
+        column_dtypes=_coerce_str_mapping(payload.get("column_dtypes")),
+        non_null_counts=_coerce_int_mapping(payload.get("non_null_counts")),
+        null_counts=_coerce_int_mapping(payload.get("null_counts")),
+        memory_usage_bytes=_coerce_optional_int(payload.get("memory_usage_bytes"), "memory_usage_bytes"),
+        model_usage=_coerce_model_usage(payload.get("model_usage")),
+        warnings=_coerce_str_list(payload.get("warnings")),
+    )
+
+
+def normalize_ray_throttle_snapshot(payload: RayThrottleSnapshotPayload) -> RayThrottleSnapshot:
+    """Normalize a throttle snapshot dataclass or mapping payload."""
+    if isinstance(payload, RayThrottleSnapshot):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise RayMetricsError(f"Ray throttle snapshot payload must be a mapping, got {type(payload)!r}.")
+    return RayThrottleSnapshot(
+        provider_name=_coerce_str(payload, "provider_name"),
+        model_id=_coerce_str(payload, "model_id"),
+        domain=_coerce_str(payload, "domain"),
+        current_limit=_coerce_int(payload, "current_limit", default=0),
+        effective_max=_coerce_optional_int(payload.get("effective_max"), "effective_max"),
+        in_flight=_coerce_int(payload, "in_flight", default=0),
+        waiters=_coerce_int(payload, "waiters", default=0),
+        rate_limit_ceiling=_coerce_int(payload, "rate_limit_ceiling", default=0),
+        consecutive_rate_limits=_coerce_int(payload, "consecutive_rate_limits", default=0),
+    )
+
+
+def _analysis_payload_to_html(payload: str) -> str:
+    escaped = html.escape(payload)
+    return (
+        "<!doctype html>\n"
+        '<html><head><meta charset="utf-8"><title>Data Designer Ray Analysis</title></head>'
+        "<body><h1>Data Designer Ray Analysis</h1><pre>"
+        f"{escaped}"
+        "</pre></body></html>\n"
+    )
+
+
+def _coerce_str(payload: Mapping[str, Any], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be a string.")
+    return value
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RayMetricsError("Ray observability optional string fields must be strings when provided.")
+    return value
+
+
+def _coerce_int(payload: Mapping[str, Any], field_name: str, *, default: int) -> int:
+    value = payload.get(field_name, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be an integer.")
+    return value
+
+
+def _coerce_optional_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be an integer when provided.")
+    return value
+
+
+def _coerce_float(payload: Mapping[str, Any], field_name: str, *, default: float) -> float:
+    value = payload.get(field_name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be numeric.")
+    return float(value)
+
+
+def _coerce_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RayMetricsError("Ray observability list fields must be lists when provided.")
+    if not all(isinstance(item, str) for item in value):
+        raise RayMetricsError("Ray observability list field values must be strings.")
+    return list(value)
+
+
+def _coerce_str_mapping(value: Any) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise RayMetricsError("Ray observability string mapping fields must be mappings when provided.")
+    output: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise RayMetricsError("Ray observability string mapping keys and values must be strings.")
+        output[key] = item
+    return output
+
+
+def _coerce_int_mapping(value: Any) -> dict[str, int]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise RayMetricsError("Ray observability count mapping fields must be mappings when provided.")
+    output: dict[str, int] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or isinstance(item, bool) or not isinstance(item, int):
+            raise RayMetricsError("Ray observability count mapping keys must be strings and values must be integers.")
+        output[key] = item
+    return output
+
+
+def _coerce_optional_mapping(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise RayMetricsError("Ray observability details must be a mapping when provided.")
+    return dict(value)
+
+
+def _coerce_model_usage(value: Any) -> ModelUsageSummary | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise RayMetricsError("Ray observability model_usage must be a mapping when provided.")
+    model_usage: ModelUsageSummary = {}
+    for model_name, stats in value.items():
+        if not isinstance(model_name, str):
+            raise RayMetricsError("Ray observability model usage keys must be strings.")
+        if not isinstance(stats, Mapping):
+            raise RayMetricsError(f"Ray observability model usage for {model_name!r} must be a mapping.")
+        model_usage[model_name] = dict(stats)
+    return model_usage
+
+
+def _validate_non_empty_str(field_name: str, value: str) -> None:
+    if not isinstance(value, str) or value == "":
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be a non-empty string.")
+
+
+def _validate_non_negative_int(field_name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be an integer.")
+    if value < 0:
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be non-negative.")
+
+
+def _validate_non_negative_float(field_name: str, value: float) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be numeric.")
+    if value < 0:
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be non-negative.")

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+from typing import Any
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.integrations.ray import (
+    RayDatasetCreationResults,
+    RayDatasetMetrics,
+    RayThrottleSnapshot,
+    RayTraceEvent,
+    RayWorkerProfile,
+)
+from data_designer.integrations.ray import backend as ray_backend_module
+
+
+class FakeObjectRef:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+class FakeRemoteMethod:
+    def __init__(self, method: Any) -> None:
+        self._method = method
+
+    def remote(self, *args: Any, **kwargs: Any) -> FakeObjectRef:
+        return FakeObjectRef(self._method(*args, **kwargs))
+
+
+class FakeActorHandle:
+    def __init__(self, actor: Any) -> None:
+        self._actor = actor
+
+    def __getattr__(self, name: str) -> FakeRemoteMethod:
+        return FakeRemoteMethod(getattr(self._actor, name))
+
+
+def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
+    tmp_path: Path,
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    collector = ray_backend_module._RayMetricsCollector(max_trace_events=1)
+    collector.record({"total_rows": 2, "blocks": 1, "elapsed_seconds": 0.5, "block_id": "block-a"})
+    collector.record_observability(
+        {
+            "worker_profile": RayWorkerProfile(
+                block_id="block-a",
+                total_rows=2,
+                columns=["id", "label"],
+                column_dtypes={"id": "int64", "label": "object"},
+                non_null_counts={"id": 2, "label": 1},
+                null_counts={"id": 0, "label": 1},
+                memory_usage_bytes=128,
+            ).to_dict(),
+            "trace_events": [
+                RayTraceEvent(
+                    block_id="block-a",
+                    event_type="block_started",
+                    timestamp_seconds=1.0,
+                    row_count=2,
+                ).to_dict(),
+                RayTraceEvent(
+                    block_id="block-a",
+                    event_type="block_completed",
+                    timestamp_seconds=2.0,
+                    elapsed_seconds=0.5,
+                    row_count=2,
+                ).to_dict(),
+            ],
+            "throttle_snapshots": [
+                RayThrottleSnapshot(
+                    provider_name="stub-provider",
+                    model_id="stub-model",
+                    domain="chat",
+                    current_limit=2,
+                    effective_max=4,
+                    rate_limit_ceiling=3,
+                    consecutive_rate_limits=1,
+                ).to_dict()
+            ],
+        }
+    )
+    results = RayDatasetCreationResults(
+        dataset=lazy.pd.DataFrame({"id": [1, 2]}),
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(total_rows=0, blocks=1),
+        ray=types.SimpleNamespace(get=lambda ref: ref.value),
+        metrics_collector=FakeActorHandle(collector),
+    )
+
+    analysis = results.load_analysis()
+
+    assert analysis is not None
+    assert analysis.total_rows == 2
+    assert analysis.blocks == 1
+    assert analysis.worker_profiles[0].block_id == "block-a"
+    assert analysis.worker_profiles[0].null_counts == {"id": 0, "label": 1}
+    assert analysis.trace_events[0].event_type == "block_started"
+    assert analysis.trace_events_dropped == 1
+    assert analysis.throttle_snapshots[0].rate_limit_ceiling == 3
+    assert results.load_worker_metrics()[0].block_id == analysis.worker_profiles[0].block_id
+
+    report_path = tmp_path / "ray-analysis.json"
+    analysis.to_report(report_path)
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["worker_profiles"][0]["block_id"] == "block-a"
+
+
+def test_ray_results_load_analysis_returns_none_without_observability_payload(
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    collector = ray_backend_module._RayMetricsCollector(max_trace_events=0)
+    collector.record({"total_rows": 0, "blocks": 1, "elapsed_seconds": 0.25})
+    results = RayDatasetCreationResults(
+        dataset=lazy.pd.DataFrame({"id": []}),
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(total_rows=0, blocks=1),
+        ray=types.SimpleNamespace(get=lambda ref: ref.value),
+        metrics_collector=FakeActorHandle(collector),
+    )
+
+    assert results.load_analysis() is None

--- a/reports/ray_backend_architecture_report.html
+++ b/reports/ray_backend_architecture_report.html
@@ -859,12 +859,12 @@ ray_dataset_out = results.load_dataset()</pre>
       <li><strong>Per-block setup cost:</strong> each Ray block currently creates temp artifact storage, resource providers, registries, and a DatasetBuilder.</li>
       <li><strong>Per-block model health checks:</strong> workers may repeat checks that should be a driver preflight or cached per worker.</li>
       <li><strong>No actor reuse:</strong> <code>map_batches</code> uses a function. A callable class or actor-style execution could reuse model clients and resource setup across blocks.</li>
-      <li><strong>Profiler artifact gap:</strong> Ray results are Ray-resident and <code>load_analysis()</code> currently returns <code>None</code>. Full profiler artifact generation remains future distributed/Ray-native work.</li>
+      <li><strong>Profiler artifact scope:</strong> Ray results now expose bounded worker profile summaries, trace events, and worker-local throttle snapshots through <code>load_analysis()</code>. Full local-style <code>DatasetProfilerResults</code> still requires materializing the dataset on the driver and remains unsupported for Ray-resident outputs.</li>
       <li><strong>Automatic ordering:</strong> explicit <code>order_column</code> sorting is supported, but hidden row-id injection for automatic <code>preserve_order=True</code> is still future work.</li>
       <li><strong>Seed configs without input datasets:</strong> Ray now rejects this unsafe mode before execution. Partition-offset-aware seed readers remain future work; use in-memory Ray inputs for seeded Ray jobs today.</li>
       <li><strong>From-scratch partitioning:</strong> <code>ray.data.range(num_records)</code> needs explicit block planning for high throughput.</li>
       <li><strong>Processor side effects:</strong> unsafe processors are now rejected by default, but first-class distributed side-effect semantics are not implemented.</li>
-      <li><strong>Secrets and trust boundary:</strong> provider config and secret resolvers are serialized to workers. That is normal for trusted Ray clusters, but should be documented.</li>
+      <li><strong>Trusted-cluster boundary:</strong> provider config and secret resolvers are serialized to workers. The supported deployment assumption is a trusted single-tenant Ray cluster or equivalent platform isolation.</li>
     </ol>
   </section>
 
@@ -931,16 +931,17 @@ ray_dataset_out = results.load_dataset()</pre>
         </tr>
         <tr>
           <td>Phase D: Error and Metrics Surface</td>
-          <td><span class="good">Metrics done</span></td>
+          <td><span class="good">Metrics and bounded artifacts done</span></td>
           <td>
-            Worker metrics aggregation now uses a Ray-side metrics actor that returns compact usage, row-count,
-            block-count, failed-block, elapsed-time, and model-usage summaries to the Ray result object. Zero-row
-            worker metrics remain zero instead of falling back to requested driver row counts.
+            Worker metrics aggregation now uses a Ray-side actor that returns compact usage, row-count, block-count,
+            failed-block, elapsed-time, model-usage summaries, per-worker profile summaries, bounded trace events,
+            and worker-local throttle snapshots to the Ray result object. Zero-row worker metrics remain zero instead
+            of falling back to requested driver row counts.
           </td>
           <td>
-            Remaining: broader Ray task, serialization, object-store, cancellation, and worker exceptions should carry
-            richer task/block context. Validation counts, retry attribution, and full distributed profiler artifacts
-            remain future work rather than part of the initial Phase D metrics channel.
+            Remaining: broader Ray serialization, object-store, cancellation, and worker exceptions should carry richer
+            task/block context. Validation counts, retry attribution, and full local-style profiler reports remain
+            future work rather than part of the bounded Ray-native artifact channel.
           </td>
         </tr>
         <tr>
@@ -976,9 +977,9 @@ ray_dataset_out = results.load_dataset()</pre>
     <div class="callout warning">
       <strong>Sequence constraint:</strong> performance work should not mask correctness gaps. Worker reuse and block
       planning are high-value optimizations, but they should follow the remaining row-id, seed-offset, error-context,
-      global-throttling, and processor-metadata gates above. Metrics aggregation, no-Ray optional import behavior,
-      Arrow-ref materialization, seeded-mode rejection, and zero-row metrics are no longer open roadmap items in this
-      experimental branch.
+      global-throttling, and processor-metadata gates above. Metrics aggregation, bounded Ray-native observability
+      artifacts, no-Ray optional import behavior, Arrow-ref materialization, seeded-mode rejection, and zero-row
+      metrics are no longer open roadmap items in this experimental branch.
     </div>
   </section>
 
@@ -991,6 +992,7 @@ ray_dataset_out = results.load_dataset()</pre>
           <li><span class="good">Done:</span> reject seed configs without <code>input_dataset</code> instead of duplicating early rows across Ray batches.</li>
           <li><span class="good">Done:</span> rebuild Arrow-ref result datasets from materialized refs so <code>load_dataset()</code> does not re-run generation.</li>
           <li><span class="good">Done:</span> aggregate Ray worker metrics and preserve zero-row worker totals.</li>
+          <li><span class="good">Done:</span> expose bounded Ray worker profile summaries and trace artifacts without driver dataset materialization.</li>
           <li><span class="good">Done:</span> reject unsupported processors by default and cover the bypass path.</li>
           <li><span class="good">Done:</span> add tests for explicit ordering, ObjectRef input formats, same-process local-then-Ray execution, optional-extra behavior, and metrics aggregation.</li>
           <li>Remaining: add automatic hidden row-id preservation for Ray inputs and from-scratch generation.</li>
@@ -1013,9 +1015,17 @@ ray_dataset_out = results.load_dataset()</pre>
           <li>Expose <code>override_num_blocks</code> / block planning controls.</li>
           <li>Coordinate provider throttling globally across Ray workers.</li>
           <li>Support actor placement, CPU/GPU/resource labels, and autoscaling-friendly defaults.</li>
-          <li>Extend Ray-native trace collection beyond the current compact execution metrics actor.</li>
+          <li><span class="good">Done:</span> extend Ray-native trace collection beyond the compact execution metrics actor with bounded worker events.</li>
         </ul>
       </div>
+    </div>
+    <div class="callout warning">
+      <strong>Global throttling design note:</strong> current Ray observability surfaces worker-local
+      <code>ThrottleManager</code> snapshots so rate-limit behavior is visible after a run. Enforcing a true job-level
+      provider cap remains issue #13 because each worker constructs its own <code>ModelRegistry</code> and
+      <code>ThrottleManager</code> through <code>create_resource_provider()</code>. The integration point is to inject
+      an actor-backed throttle manager or proxy before <code>ModelRegistry</code> registers model facades, so
+      <code>ThrottledModelClient</code> acquire/release calls coordinate through one Ray-side state holder.
     </div>
     <div class="diagram" aria-label="Optimization roadmap">
       <svg viewBox="0 0 1100 260" role="img">
@@ -1062,8 +1072,9 @@ ray_dataset_out = results.load_dataset()</pre>
         model clients and DataDesigner resources once per worker process.
       </li>
       <li>
-        <strong>Extend the distributed metrics channel.</strong> Add validation counts, retry attribution, task traces,
-        and profiler artifact summaries on top of the current worker usage and failed-block aggregation.
+        <strong>Extend the distributed metrics channel.</strong> Add validation counts, retry attribution, object-store
+        events, and cancellation context on top of the current worker usage, failed-block, trace, profile, and
+        throttle-snapshot aggregation.
       </li>
     </ol>
   </section>


### PR DESCRIPTION
## Summary

Adds bounded Ray-native observability artifacts so Ray-resident runs can expose worker profiles, trace events, raw worker metric correlation, and worker-local throttle snapshots without materializing the full dataset on the driver. Also documents the trusted-cluster boundary for Ray workers and records the #13 global throttling integration point.

## Related Issue

Closes #16
Closes #19
Closes #21
Refs #13

## Changes

- Added `RayDatasetAnalysis`, `RayWorkerProfile`, `RayTraceEvent`, and `RayThrottleSnapshot` artifacts for bounded Ray observability.
- Extended `RayDatasetCreationResults` with `load_observability()`, `load_worker_metrics()`, and a Ray-native `load_analysis()` result when worker artifacts are available.
- Added worker `block_id` correlation across metrics, profiles, and trace events.
- Added worker-side profile summaries, opt-in trace capture, bounded trace storage, and worker-local throttle snapshots.
- Documented the Ray trusted-cluster boundary and updated the Ray architecture report with the remaining #13 global throttle coordinator design note.

## Testing

- [ ] `make test` passes (not run; targeted suite only)
- [x] Unit tests added/updated
- [x] `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [x] `uv run ruff check packages/data-designer/src/data_designer/integrations/ray/metrics.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/test_observability.py`
- [x] `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/metrics.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/test_observability.py`
- [x] `git diff --check`
- [x] `uv run python` HTML parser for `reports/ray_backend_architecture_report.html`
- [x] `uv run --group docs mkdocs build` (passes with existing docs warnings)
- [ ] `uv run --group docs mkdocs build --strict` (blocked by existing repo-wide docs warnings unrelated to this change)
- [x] E2E tests added/updated (N/A - no E2E surface)

## Attention Areas

- `packages/data-designer/src/data_designer/integrations/ray/backend.py` now returns a Ray-native analysis object when worker artifacts are available; no-actor/fake-Ray paths still return `None`.
- #13 is intentionally not implemented as a global provider throttle coordinator here. This PR exposes worker-local throttle snapshots and documents the integration point: inject a Ray actor-backed throttle manager/proxy before `ModelRegistry` registers throttled model clients.

## Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
