### PR TITLE
feat(ray): integrate robust Ray backend epics

### DIFF
--- a/.github/workflows/ray-smoke.yml
+++ b/.github/workflows/ray-smoke.yml
@@ -1,0 +1,37 @@
+name: Ray Smoke
+
+on:
+  schedule:
+    # Every Tuesday at 08:00 UTC
+    - cron: "0 8 * * 2"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  real-ray-smoke:
+    name: Real Ray Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "latest"
+          python-version: "3.11"
+          enable-cache: true
+
+      - name: Install DataDesigner with Ray extra
+        run: uv sync --package data-designer --group dev --extra ray
+
+      - name: Run real-Ray smoke tests
+        env:
+          DATA_DESIGNER_RUN_REAL_RAY_SMOKE: "1"
+          OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+        run: |
+          uv run --package data-designer --group dev --extra ray \
+            pytest -q packages/data-designer/tests/integrations/ray/test_real_smoke.py

--- a/docs/concepts/deployment-options.md
+++ b/docs/concepts/deployment-options.md
@@ -145,6 +145,28 @@ When users can submit configs containing Jinja templates to a shared engine, tem
 
 ---
 
+## Ray Backend Trusted-Cluster Boundary
+
+The optional Ray backend is a library scaling mode for trusted Ray clusters. It serializes the job configuration,
+model provider definitions, secret resolver state, seed-reader state, MCP provider definitions, and runtime settings
+to Ray workers so each worker can construct its local generation engine.
+
+Use Ray only when the driver and workers are inside the same trusted operational boundary, such as a single-tenant
+cluster or a managed cluster with equivalent isolation. A Ray worker may receive provider endpoint configuration and
+may be able to resolve API keys through the configured `SecretResolver` or worker environment. Treat every Ray worker
+that can run the job as trusted with the same access level as the driver process.
+
+Avoid running the Ray backend on shared clusters where untrusted users can inspect task payloads, object-store data,
+worker logs, runtime environments, or process environment variables. If you must use shared infrastructure, add
+platform controls outside Data Designer: tenant-isolated Ray clusters, scoped service accounts, restricted dashboard
+and log access, network policies around provider endpoints, and secret management that grants only the workers for a
+single job access to the required keys.
+
+The Ray backend does not turn Data Designer into a multi-tenant service boundary. For shared service deployments,
+prefer a service architecture with explicit authentication, authorization, audit logging, and request validation.
+
+---
+
 ## 🧭 Decision Flowchart
 
 ```

--- a/packages/data-designer-config/src/data_designer/config/__init__.py
+++ b/packages/data-designer-config/src/data_designer/config/__init__.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
     )
     from data_designer.config.processors import (  # noqa: F401
         DropColumnsProcessorConfig,
+        ProcessorDistributedSafety,
+        ProcessorSideEffect,
         ProcessorType,
         SchemaTransformProcessorConfig,
     )
@@ -172,6 +174,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "UniformDistributionParams": (_MOD_MODELS, "UniformDistributionParams"),
     # processors
     "DropColumnsProcessorConfig": (_MOD_PROCESSORS, "DropColumnsProcessorConfig"),
+    "ProcessorDistributedSafety": (_MOD_PROCESSORS, "ProcessorDistributedSafety"),
+    "ProcessorSideEffect": (_MOD_PROCESSORS, "ProcessorSideEffect"),
     "ProcessorType": (_MOD_PROCESSORS, "ProcessorType"),
     "SchemaTransformProcessorConfig": (_MOD_PROCESSORS, "SchemaTransformProcessorConfig"),
     # run_config

--- a/packages/data-designer-config/src/data_designer/config/processors.py
+++ b/packages/data-designer-config/src/data_designer/config/processors.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 
 import json
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import Field, field_validator
 
-from data_designer.config.base import ProcessorConfig
+from data_designer.config.base import ConfigBase, ProcessorConfig
 from data_designer.config.errors import InvalidConfigError
 
 
@@ -23,6 +23,38 @@ class ProcessorType(str, Enum):
 
     DROP_COLUMNS = "drop_columns"
     SCHEMA_TRANSFORM = "schema_transform"
+
+
+class ProcessorSideEffect(str, Enum):
+    """Side-effect behavior relevant to distributed processor execution."""
+
+    NONE = "none"
+    BATCH_ARTIFACT = "batch_artifact"
+    DATASET_ARTIFACT = "dataset_artifact"
+    EXTERNAL = "external"
+
+
+class ProcessorDistributedSafety(ConfigBase):
+    """Declarative distributed-execution safety metadata for processor configs.
+
+    Processor configs declare this as class-level metadata so execution backends
+    can fail closed for processors that have not been reviewed for distributed
+    semantics.
+    """
+
+    ray_safe: bool = Field(description="Whether the processor is safe to run independently on Ray Data blocks.")
+    requires_global_order: bool = Field(
+        default=False,
+        description="Whether the processor requires a globally ordered or complete dataset view.",
+    )
+    side_effects: ProcessorSideEffect = Field(
+        default=ProcessorSideEffect.NONE,
+        description="Side-effect behavior the backend must account for when distributing this processor.",
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Human-readable explanation for unsafe or constrained distributed execution.",
+    )
 
 
 def get_processor_config_from_kwargs(processor_type: ProcessorType, **kwargs: Any) -> ProcessorConfig:
@@ -58,6 +90,12 @@ class DropColumnsProcessorConfig(ProcessorConfig):
 
     column_names: list[str] = Field(description="List of column names to drop from the output dataset.")
     processor_type: Literal[ProcessorType.DROP_COLUMNS] = ProcessorType.DROP_COLUMNS
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        ray_safe=True,
+        requires_global_order=False,
+        side_effects=ProcessorSideEffect.BATCH_ARTIFACT,
+        reason="Drops columns independently per batch; dropped-column artifacts are batch-local.",
+    )
 
 
 class SchemaTransformProcessorConfig(ProcessorConfig):
@@ -100,6 +138,12 @@ class SchemaTransformProcessorConfig(ProcessorConfig):
         """,
     )
     processor_type: Literal[ProcessorType.SCHEMA_TRANSFORM] = ProcessorType.SCHEMA_TRANSFORM
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        ray_safe=False,
+        requires_global_order=False,
+        side_effects=ProcessorSideEffect.DATASET_ARTIFACT,
+        reason="Writes processor output artifacts that RayBackend does not collect from worker-local storage.",
+    )
 
     @field_validator("template")
     def validate_template(cls, v: dict[str, Any]) -> dict[str, Any]:

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/__init__.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/__init__.py
@@ -13,7 +13,7 @@ from data_designer.engine.models.clients.errors import (
 )
 from data_designer.engine.models.clients.factory import create_model_client
 from data_designer.engine.models.clients.retry import RetryConfig
-from data_designer.engine.models.clients.throttle_manager import ThrottleDomain, ThrottleManager
+from data_designer.engine.models.clients.throttle_manager import ThrottleDomain, ThrottleManager, ThrottleManagerLike
 from data_designer.engine.models.clients.throttled import ThrottledModelClient
 from data_designer.engine.models.clients.types import (
     AssistantMessage,
@@ -46,6 +46,7 @@ __all__ = [
     "RetryConfig",
     "ThrottleDomain",
     "ThrottleManager",
+    "ThrottleManagerLike",
     "ThrottledModelClient",
     "ToolCall",
     "Usage",

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/factory.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/factory.py
@@ -11,7 +11,7 @@ from data_designer.engine.models.clients.adapters.http_model_client import Clien
 from data_designer.engine.models.clients.adapters.openai_compatible import OpenAICompatibleClient
 from data_designer.engine.models.clients.base import ModelClient
 from data_designer.engine.models.clients.retry import RetryConfig
-from data_designer.engine.models.clients.throttle_manager import ThrottleManager
+from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
 from data_designer.engine.models.clients.throttled import ThrottledModelClient
 from data_designer.engine.models.errors import FormattedLLMErrorMessage
 from data_designer.engine.secret_resolver import SecretResolver
@@ -26,7 +26,7 @@ def create_model_client(
     *,
     retry_config: RetryConfig | None = None,
     client_concurrency_mode: ClientConcurrencyMode = ClientConcurrencyMode.SYNC,
-    throttle_manager: ThrottleManager | None = None,
+    throttle_manager: ThrottleManagerLike | None = None,
 ) -> ModelClient:
     """Create a ``ModelClient`` for the given model configuration.
 

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
@@ -10,6 +10,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Protocol
 
 from data_designer.config.run_config import ThrottleConfig
 
@@ -30,6 +31,74 @@ class ThrottleDomain(str, Enum):
 DEFAULT_MIN_LIMIT: int = 1
 DEFAULT_ACQUIRE_TIMEOUT: float = 300.0
 CAPACITY_POLL_INTERVAL: float = 0.05
+
+
+class ThrottleManagerLike(Protocol):
+    """Interface used by model clients for local or distributed throttling."""
+
+    def register(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        alias: str,
+        max_parallel_requests: int,
+    ) -> None: ...
+
+    def try_acquire(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> float: ...
+
+    def acquire_sync(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None: ...
+
+    async def acquire_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None: ...
+
+    def release_success(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None: ...
+
+    def release_rate_limited(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None: ...
+
+    def release_failure(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -429,6 +498,34 @@ class ThrottleManager:
     def get_effective_max(self, provider_name: str, model_id: str) -> int:
         with self._lock:
             return self._effective_max_for(provider_name, model_id)
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a serializable throttle-state snapshot for telemetry."""
+        with self._lock:
+            return {
+                "global_caps": [
+                    {
+                        "provider_name": provider_name,
+                        "model_id": model_id,
+                        "effective_max": cap.effective_max,
+                        "limits_by_alias": dict(cap.limits_by_alias),
+                    }
+                    for (provider_name, model_id), cap in sorted(self._global_caps.items())
+                ],
+                "domains": [
+                    {
+                        "provider_name": provider_name,
+                        "model_id": model_id,
+                        "domain": domain,
+                        "current_limit": state.current_limit,
+                        "in_flight": state.in_flight,
+                        "waiters": state.waiters,
+                        "rate_limit_ceiling": state.rate_limit_ceiling,
+                        "consecutive_429s": state.consecutive_429s,
+                    }
+                    for (provider_name, model_id, domain), state in sorted(self._domains.items())
+                ],
+            }
 
     # -------------------------------------------------------------------
     # Private helpers

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py
@@ -22,7 +22,7 @@ from data_designer.engine.models.clients.types import (
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
-    from data_designer.engine.models.clients.throttle_manager import ThrottleManager
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
 
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ class ThrottledModelClient(ModelClient):
     def __init__(
         self,
         inner: ModelClient,
-        throttle_manager: ThrottleManager,
+        throttle_manager: ThrottleManagerLike,
         provider_name: str,
         model_id: str,
     ) -> None:

--- a/packages/data-designer-engine/src/data_designer/engine/models/factory.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/factory.py
@@ -13,6 +13,7 @@ from data_designer.engine.secret_resolver import SecretResolver
 if TYPE_CHECKING:
     from data_designer.config.run_config import RunConfig
     from data_designer.engine.mcp.registry import MCPRegistry
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
     from data_designer.engine.models.registry import ModelRegistry
 
 
@@ -24,6 +25,7 @@ def create_model_registry(
     mcp_registry: MCPRegistry | None = None,
     client_concurrency_mode: ClientConcurrencyMode = ClientConcurrencyMode.SYNC,
     run_config: RunConfig | None = None,
+    throttle_manager: ThrottleManagerLike | None = None,
 ) -> ModelRegistry:
     """Factory function for creating a ModelRegistry instance.
 
@@ -54,7 +56,7 @@ def create_model_registry(
     from data_designer.engine.models.facade import ModelFacade
     from data_designer.engine.models.registry import ModelRegistry
 
-    throttle_manager = ThrottleManager((run_config or RunConfig()).throttle)
+    effective_throttle_manager = throttle_manager or ThrottleManager((run_config or RunConfig()).throttle)
 
     def model_facade_factory(
         model_config: ModelConfig,
@@ -68,7 +70,7 @@ def create_model_registry(
             model_provider_registry,
             retry_config=retry_config,
             client_concurrency_mode=client_concurrency_mode,
-            throttle_manager=throttle_manager,
+            throttle_manager=effective_throttle_manager,
         )
         return ModelFacade(
             model_config,
@@ -82,6 +84,6 @@ def create_model_registry(
         secret_resolver=secret_resolver,
         model_provider_registry=model_provider_registry,
         model_facade_factory=model_facade_factory,
-        throttle_manager=throttle_manager,
+        throttle_manager=effective_throttle_manager,
         retry_config=RetryConfig(),
     )

--- a/packages/data-designer-engine/src/data_designer/engine/models/registry.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/registry.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from data_designer.engine.models.clients.retry import RetryConfig
-    from data_designer.engine.models.clients.throttle_manager import ThrottleManager
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
     from data_designer.engine.models.facade import ModelFacade
 
     ModelFacadeFactory = Callable[
@@ -35,7 +35,7 @@ class ModelRegistry:
         model_provider_registry: ModelProviderRegistry,
         model_configs: list[ModelConfig] | None = None,
         model_facade_factory: ModelFacadeFactory | None = None,
-        throttle_manager: ThrottleManager | None = None,
+        throttle_manager: ThrottleManagerLike | None = None,
         retry_config: RetryConfig | None = None,
     ) -> None:
         self._secret_resolver = secret_resolver
@@ -56,7 +56,7 @@ class ModelRegistry:
         return self._models
 
     @property
-    def throttle_manager(self) -> ThrottleManager | None:
+    def throttle_manager(self) -> ThrottleManagerLike | None:
         return self._throttle_manager
 
     @property

--- a/packages/data-designer-engine/src/data_designer/engine/resources/resource_provider.py
+++ b/packages/data-designer-engine/src/data_designer/engine/resources/resource_provider.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from data_designer.config.base import ConfigBase
 from data_designer.config.dataset_metadata import DatasetMetadata
@@ -25,6 +26,9 @@ from data_designer.engine.resources.person_reader import PersonReader
 from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderRegistry
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
+
+if TYPE_CHECKING:
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
 
 
 class ResourceType(StrEnum):
@@ -90,6 +94,7 @@ def create_resource_provider(
     run_config: RunConfig | None = None,
     mcp_providers: list[MCPProviderT] | None = None,
     tool_configs: list[ToolConfig] | None = None,
+    throttle_manager: ThrottleManagerLike | None = None,
 ) -> ResourceProvider:
     """Factory function for creating a ResourceProvider instance.
 
@@ -151,6 +156,7 @@ def create_resource_provider(
             mcp_registry=mcp_registry,
             client_concurrency_mode=client_concurrency_mode,
             run_config=effective_run_config,
+            throttle_manager=throttle_manager,
         ),
         person_reader=person_reader,
         mcp_registry=mcp_registry,

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -16,6 +16,15 @@ from data_designer.integrations.ray.metrics import (
     aggregate_ray_metrics,
     normalize_ray_worker_metrics,
 )
+from data_designer.integrations.ray.observability import (
+    RayDatasetAnalysis,
+    RayThrottleSnapshot,
+    RayTraceEvent,
+    RayWorkerProfile,
+    normalize_ray_throttle_snapshot,
+    normalize_ray_trace_event,
+    normalize_ray_worker_profile,
+)
 from data_designer.integrations.ray.options import (
     RayBlockPlanning,
     RayExecutionOptions,
@@ -26,6 +35,7 @@ __all__ = [
     "RayBackend",
     "RayBackendConfigurationError",
     "RayBlockPlanning",
+    "RayDatasetAnalysis",
     "RayDatasetCreationResults",
     "RayDatasetGenerationError",
     "RayDatasetMetrics",
@@ -33,7 +43,13 @@ __all__ = [
     "RayIntegrationError",
     "RayMetricsError",
     "RayResolvedBlockPlan",
+    "RayThrottleSnapshot",
+    "RayTraceEvent",
     "RayWorkerMetrics",
+    "RayWorkerProfile",
     "aggregate_ray_metrics",
+    "normalize_ray_throttle_snapshot",
+    "normalize_ray_trace_event",
     "normalize_ray_worker_metrics",
+    "normalize_ray_worker_profile",
 ]

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -16,15 +16,23 @@ from data_designer.integrations.ray.metrics import (
     aggregate_ray_metrics,
     normalize_ray_worker_metrics,
 )
+from data_designer.integrations.ray.options import (
+    RayBlockPlanning,
+    RayExecutionOptions,
+    RayResolvedBlockPlan,
+)
 
 __all__ = [
     "RayBackend",
     "RayBackendConfigurationError",
+    "RayBlockPlanning",
     "RayDatasetCreationResults",
     "RayDatasetGenerationError",
     "RayDatasetMetrics",
+    "RayExecutionOptions",
     "RayIntegrationError",
     "RayMetricsError",
+    "RayResolvedBlockPlan",
     "RayWorkerMetrics",
     "aggregate_ray_metrics",
     "normalize_ray_worker_metrics",

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -6,16 +6,19 @@ from __future__ import annotations
 import copy
 import importlib
 import os
-import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
 
+from pydantic import PrivateAttr
+
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.processors import ProcessorType
 from data_designer.config.run_config import RunConfig
+from data_designer.config.seed import SeedConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
 from data_designer.engine.model_provider import resolve_model_provider_registry
@@ -23,7 +26,8 @@ from data_designer.engine.resources.person_reader import PersonReader, create_pe
 from data_designer.engine.resources.resource_provider import create_resource_provider
 from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderRegistry
 from data_designer.engine.secret_resolver import SecretResolver
-from data_designer.engine.storage.artifact_storage import ArtifactStorage
+from data_designer.engine.storage.artifact_storage import ArtifactStorage, BatchStage
+from data_designer.engine.storage.media_storage import StorageMode
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
 
@@ -46,6 +50,13 @@ class _RayWorkerOptions:
     person_reader: PersonReader | None
     mcp_providers: list[MCPProviderT]
     run_config: RunConfig
+
+
+@dataclass(frozen=True)
+class _RayExecutionPayload:
+    config_json: str
+    worker_options: _RayWorkerOptions
+    use_input_dataset: bool
 
 
 class RayDatasetCreationResults:
@@ -215,12 +226,15 @@ class RayBackend:
             mcp_providers=list(data_designer._mcp_providers),
             run_config=data_designer._run_config,
         )
+        execution_payload = _compile_ray_execution_payload(
+            config_builder=config_builder,
+            worker_options=worker_options,
+            use_input_dataset=use_input_dataset,
+        )
 
         map_batches_kwargs: dict[str, Any] = {
-            "fn_kwargs": {
-                "config_builder": config_builder,
-                "worker_options": worker_options,
-                "use_input_dataset": use_input_dataset,
+            "fn_constructor_kwargs": {
+                "execution_payload": execution_payload,
                 "metrics_collector": metrics_collector,
             },
             "batch_size": batch_size,
@@ -231,7 +245,7 @@ class RayBackend:
             map_batches_kwargs.update(self.ray_remote_args)
 
         try:
-            mapped = dataset.map_batches(_generate_batch, **map_batches_kwargs)
+            mapped = dataset.map_batches(_RayBatchWorker, **map_batches_kwargs)
             mapped = self._apply_ordering(mapped)
             output = mapped.to_arrow_refs() if self.output == "arrow_refs" else None
             result_dataset = _dataset_from_arrow_refs(ray, output) if output is not None else mapped
@@ -316,6 +330,22 @@ def _dataset_from_arrow_refs(ray: Any, refs: list[Any]) -> Any:
     return from_arrow_refs(refs)
 
 
+def _compile_ray_execution_payload(
+    *,
+    config_builder: DataDesignerConfigBuilder,
+    worker_options: _RayWorkerOptions,
+    use_input_dataset: bool,
+) -> _RayExecutionPayload:
+    config_json = config_builder.build().to_json(indent=None)
+    if config_json is None:
+        raise RayBackendConfigurationError("RayBackend failed to serialize the Data Designer configuration.")
+    return _RayExecutionPayload(
+        config_json=config_json,
+        worker_options=worker_options,
+        use_input_dataset=use_input_dataset,
+    )
+
+
 class _RayMetricsCollector:
     def __init__(self) -> None:
         self._payloads: list[dict[str, Any]] = []
@@ -359,79 +389,293 @@ def _clone_seed_reader_for_worker(reader: SeedReader) -> SeedReader:
     return clone
 
 
-def _generate_batch(
-    batch: Any,
-    *,
-    config_builder: DataDesignerConfigBuilder,
-    worker_options: _RayWorkerOptions,
-    use_input_dataset: bool,
-    metrics_collector: Any | None = None,
-) -> Any:
-    start_time = time.perf_counter()
-    os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1"
-    dataframe = _coerce_pandas_dataframe(batch)
-    num_records = len(dataframe)
-    if num_records == 0:
-        _record_worker_metrics(
-            metrics_collector,
-            RayWorkerMetrics(total_rows=0, blocks=1, elapsed_seconds=time.perf_counter() - start_time),
+class _InMemoryPreviewArtifactStorage(ArtifactStorage):
+    """ArtifactStorage implementation for Ray preview batches.
+
+    Ray workers use ``DatasetBuilder.build_preview()``, which returns the main
+    dataset in memory. Processor preview artifacts may still be written through
+    the storage interface, so this class keeps those frames in memory and avoids
+    per-block temporary filesystem setup.
+    """
+
+    _frames: dict[tuple[str, str, str], Any] = PrivateAttr(default_factory=dict)
+    _metadata: dict[str, Any] = PrivateAttr(default_factory=dict)
+
+    def __init__(self, *, dataset_name: str = "ray-block") -> None:
+        super().__init__(artifact_path=Path.cwd(), dataset_name=dataset_name)
+        self.set_media_storage_mode(StorageMode.DATAFRAME)
+
+    def clear(self) -> None:
+        self._frames.clear()
+        self._metadata.clear()
+
+    def load_dataset(self, batch_stage: BatchStage = BatchStage.FINAL_RESULT) -> Any:
+        frames = [self._copy_dataframe(frame) for _, frame in self._iter_stage_frames(batch_stage)]
+        if not frames:
+            return lazy.pd.DataFrame()
+        return lazy.pd.concat(frames, ignore_index=True)
+
+    def load_processor_dataset(self, processor_name: str) -> Any:
+        frames = [
+            self._copy_dataframe(frame)
+            for (stage, subfolder, parquet_file_name), frame in self._frames.items()
+            if stage == BatchStage.PROCESSORS_OUTPUTS.value
+            and (subfolder == processor_name or (not subfolder and Path(parquet_file_name).stem == processor_name))
+        ]
+        if not frames:
+            return lazy.pd.DataFrame()
+        return lazy.pd.concat(frames, ignore_index=True)
+
+    def list_processor_names(self) -> list[str]:
+        names = {
+            subfolder or Path(parquet_file_name).stem
+            for (stage, subfolder, parquet_file_name) in self._frames
+            if stage == BatchStage.PROCESSORS_OUTPUTS.value
+        }
+        return sorted(names)
+
+    def load_dataset_with_dropped_columns(self) -> Any:
+        dataset = self.load_dataset()
+        dropped = self.load_dataset(BatchStage.DROPPED_COLUMNS)
+        if len(dropped) == 0:
+            return dataset
+        return lazy.pd.concat([dataset, dropped], axis=1)
+
+    def move_partial_result_to_final_file_path(self, batch_number: int) -> Path:
+        partial_file_name = self.create_batch_file_path(batch_number, BatchStage.PARTIAL_RESULT).name
+        partial_key = (BatchStage.PARTIAL_RESULT.value, "", partial_file_name)
+        final_key = (BatchStage.FINAL_RESULT.value, "", partial_file_name)
+        frame = self._frames.pop(partial_key)
+        self._frames[final_key] = frame
+        return self.create_batch_file_path(batch_number, BatchStage.FINAL_RESULT)
+
+    def write_batch_to_parquet_file(
+        self,
+        batch_number: int,
+        dataframe: Any,
+        batch_stage: BatchStage,
+        subfolder: str | None = None,
+    ) -> Path:
+        file_path = self.create_batch_file_path(batch_number, batch_stage)
+        self.write_parquet_file(file_path.name, dataframe, batch_stage, subfolder=subfolder)
+        return file_path
+
+    def write_parquet_file(
+        self,
+        parquet_file_name: str,
+        dataframe: Any,
+        batch_stage: BatchStage,
+        subfolder: str | None = None,
+    ) -> Path:
+        subfolder = subfolder or ""
+        stage = self._stage_value(batch_stage)
+        self._frames[(stage, subfolder, parquet_file_name)] = self._copy_dataframe(dataframe)
+        stage_path = self._get_stage_path(batch_stage)
+        return stage_path / subfolder / parquet_file_name if subfolder else stage_path / parquet_file_name
+
+    def get_parquet_file_paths(self) -> list[str]:
+        return [
+            str(Path(self.final_dataset_folder_name) / parquet_file_name)
+            for (stage, _, parquet_file_name) in sorted(self._frames)
+            if stage == BatchStage.FINAL_RESULT.value
+        ]
+
+    def get_processor_file_paths(self) -> dict[str, list[str]]:
+        processor_files: dict[str, list[str]] = {}
+        for stage, subfolder, parquet_file_name in sorted(self._frames):
+            if stage != BatchStage.PROCESSORS_OUTPUTS.value:
+                continue
+            processor_name = subfolder or Path(parquet_file_name).stem
+            path_parts = [self.processors_outputs_folder_name]
+            if subfolder:
+                path_parts.append(subfolder)
+            path_parts.append(parquet_file_name)
+            processor_files.setdefault(processor_name, []).append(str(Path(*path_parts)))
+        return processor_files
+
+    def get_file_paths(self) -> dict[str, list[str] | dict[str, list[str]]]:
+        file_paths: dict[str, list[str] | dict[str, list[str]]] = {
+            "parquet-files": self.get_parquet_file_paths(),
+        }
+        processor_file_paths = self.get_processor_file_paths()
+        if processor_file_paths:
+            file_paths["processor-files"] = processor_file_paths
+        return file_paths
+
+    def read_metadata(self) -> dict[str, Any]:
+        return dict(self._metadata)
+
+    def write_metadata(self, metadata: dict[str, Any]) -> Path:
+        self._metadata = dict(metadata)
+        return self.metadata_file_path
+
+    def update_metadata(self, updates: dict[str, Any]) -> Path:
+        self._metadata.update(updates)
+        return self.metadata_file_path
+
+    def _iter_stage_frames(self, batch_stage: BatchStage) -> list[tuple[tuple[str, str, str], Any]]:
+        stage = self._stage_value(batch_stage)
+        return sorted((key, frame) for key, frame in self._frames.items() if key[0] == stage)
+
+    def _stage_value(self, batch_stage: BatchStage) -> str:
+        return BatchStage(batch_stage).value
+
+    def _copy_dataframe(self, dataframe: Any) -> Any:
+        copy_method = getattr(dataframe, "copy", None)
+        if not callable(copy_method):
+            return dataframe
+        try:
+            return copy_method(deep=True)
+        except TypeError:
+            return copy_method()
+
+
+class _RayBatchWorker:
+    def __init__(
+        self,
+        *,
+        execution_payload: _RayExecutionPayload,
+        metrics_collector: Any | None = None,
+    ) -> None:
+        os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1"
+        self._execution_payload: _RayExecutionPayload = execution_payload
+        self._metrics_collector: Any | None = metrics_collector
+        self._base_config: DataDesignerConfig = DataDesignerConfig.model_validate_json(execution_payload.config_json)
+        self._artifact_storage: _InMemoryPreviewArtifactStorage = _InMemoryPreviewArtifactStorage()
+        worker_options = execution_payload.worker_options
+        self._seed_reader_registry: SeedReaderRegistry = SeedReaderRegistry(
+            readers=copy.deepcopy(worker_options.seed_readers)
         )
-        return dataframe
+        self._resource_provider: Any = create_resource_provider(
+            artifact_storage=self._artifact_storage,
+            model_configs=self._base_config.model_configs or [],
+            secret_resolver=worker_options.secret_resolver,
+            model_provider_registry=resolve_model_provider_registry(
+                worker_options.model_providers,
+                worker_options.default_provider_name,
+            ),
+            seed_reader_registry=self._seed_reader_registry,
+            person_reader=worker_options.person_reader or create_person_reader(worker_options.managed_assets_path),
+            seed_dataset_source=None,
+            run_config=copy.deepcopy(worker_options.run_config),
+            mcp_providers=worker_options.mcp_providers,
+            tool_configs=self._base_config.tool_configs or [],
+        )
 
-    try:
-        block_builder = copy.deepcopy(config_builder)
-        if use_input_dataset:
-            block_builder.with_seed_dataset(DataFrameSeedSource(df=dataframe.copy()))
+    def __call__(self, batch: Any) -> Any:
+        return _generate_batch(batch, worker=self, metrics_collector=self._metrics_collector)
 
-        with tempfile.TemporaryDirectory(prefix="data-designer-ray-") as artifact_dir:
-            ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
-            seed_readers = copy.deepcopy(worker_options.seed_readers)
-            resource_provider = create_resource_provider(
-                artifact_storage=ArtifactStorage(artifact_path=artifact_dir, dataset_name="ray-block"),
-                model_configs=block_builder.model_configs,
-                secret_resolver=worker_options.secret_resolver,
-                model_provider_registry=resolve_model_provider_registry(
-                    worker_options.model_providers,
-                    worker_options.default_provider_name,
-                ),
-                seed_reader_registry=SeedReaderRegistry(readers=seed_readers),
-                person_reader=worker_options.person_reader or create_person_reader(worker_options.managed_assets_path),
-                seed_dataset_source=(
-                    block_builder.get_seed_config().source if block_builder.get_seed_config() is not None else None
-                ),
-                run_config=copy.deepcopy(worker_options.run_config),
-                mcp_providers=worker_options.mcp_providers,
-                tool_configs=block_builder.tool_configs,
+    def close(self) -> None:
+        self._release_block_state()
+
+    def generate_batch(self, batch: Any) -> Any:
+        start_time = time.perf_counter()
+        dataframe = _coerce_pandas_dataframe(batch)
+        num_records = len(dataframe)
+        if num_records == 0:
+            _record_worker_metrics(
+                self._metrics_collector,
+                RayWorkerMetrics(total_rows=0, blocks=1, elapsed_seconds=time.perf_counter() - start_time),
             )
+            return dataframe
+
+        try:
+            block_config = self._create_block_config(dataframe)
+            self._attach_seed_reader(block_config)
+            model_usage_snapshot = self._resource_provider.model_registry.get_model_usage_snapshot()
             builder = DatasetBuilder(
-                data_designer_config=block_builder.build(),
-                resource_provider=resource_provider,
+                data_designer_config=block_config,
+                resource_provider=self._resource_provider,
                 use_async=True,
             )
             raw_dataset = builder.build_preview(num_records=num_records)
             output = builder.process_preview(raw_dataset)
             elapsed_seconds = time.perf_counter() - start_time
             _record_worker_metrics(
-                metrics_collector,
+                self._metrics_collector,
                 RayWorkerMetrics(
                     total_rows=len(output),
                     blocks=1,
                     elapsed_seconds=elapsed_seconds,
-                    model_usage=resource_provider.model_registry.get_model_usage_stats(elapsed_seconds),
+                    model_usage=self._get_model_usage_delta(model_usage_snapshot, elapsed_seconds),
                 ),
             )
             return output
-    except Exception:
-        _record_worker_metrics(
-            metrics_collector,
-            RayWorkerMetrics(
-                total_rows=0,
-                blocks=1,
-                failed_blocks=1,
-                elapsed_seconds=time.perf_counter() - start_time,
-            ),
+        except Exception:
+            _record_worker_metrics(
+                self._metrics_collector,
+                RayWorkerMetrics(
+                    total_rows=0,
+                    blocks=1,
+                    failed_blocks=1,
+                    elapsed_seconds=time.perf_counter() - start_time,
+                ),
+            )
+            raise
+        finally:
+            self._release_block_state()
+
+    def _create_block_config(self, dataframe: Any) -> DataDesignerConfig:
+        block_config = DataDesignerConfig.model_validate_json(self._execution_payload.config_json)
+        if self._execution_payload.use_input_dataset:
+            block_config.seed_config = SeedConfig(source=DataFrameSeedSource(df=dataframe.copy()))
+        return block_config
+
+    def _attach_seed_reader(self, block_config: DataDesignerConfig) -> None:
+        if block_config.seed_config is None:
+            self._resource_provider.seed_reader = None
+            return
+        self._resource_provider.seed_reader = self._seed_reader_registry.get_reader(
+            block_config.seed_config.source,
+            self._execution_payload.worker_options.secret_resolver,
         )
-        raise
+
+    def _get_model_usage_delta(
+        self,
+        model_usage_snapshot: Any,
+        elapsed_seconds: float,
+    ) -> dict[str, dict[str, Any]] | None:
+        usage_deltas = self._resource_provider.model_registry.get_usage_deltas(model_usage_snapshot)
+        if not usage_deltas:
+            return None
+        return {
+            model_name: usage_stats.get_usage_stats(total_time_elapsed=elapsed_seconds)
+            for model_name, usage_stats in usage_deltas.items()
+        }
+
+    def _release_block_state(self) -> None:
+        self._resource_provider.seed_reader = None
+        self._artifact_storage.clear()
+        _detach_seed_readers(self._seed_reader_registry._readers.values())
+
+
+def _detach_seed_readers(readers: Iterable[SeedReader]) -> None:
+    for reader in readers:
+        reader._reset_attachment_state()
+        for attr in ("source", "secret_resolver"):
+            if hasattr(reader, attr):
+                delattr(reader, attr)
+
+
+def _generate_batch(
+    batch: Any,
+    *,
+    worker: _RayBatchWorker | None = None,
+    config_builder: DataDesignerConfigBuilder | None = None,
+    worker_options: _RayWorkerOptions | None = None,
+    use_input_dataset: bool | None = None,
+    metrics_collector: Any | None = None,
+) -> Any:
+    if worker is not None:
+        return worker.generate_batch(batch)
+    if config_builder is None or worker_options is None or use_input_dataset is None:
+        raise TypeError("_generate_batch requires a worker or legacy config_builder/worker_options arguments.")
+    execution_payload = _compile_ray_execution_payload(
+        config_builder=config_builder,
+        worker_options=worker_options,
+        use_input_dataset=use_input_dataset,
+    )
+    return _RayBatchWorker(execution_payload=execution_payload, metrics_collector=metrics_collector)(batch)
 
 
 def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -26,6 +26,7 @@ from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.throttling import create_ray_throttle_manager
 
 if TYPE_CHECKING:
     from data_designer.config.mcp import MCPProviderT
@@ -46,6 +47,7 @@ class _RayWorkerOptions:
     person_reader: PersonReader | None
     mcp_providers: list[MCPProviderT]
     run_config: RunConfig
+    throttle_manager: Any | None = None
 
 
 class RayDatasetCreationResults:
@@ -59,6 +61,7 @@ class RayDatasetCreationResults:
         metrics: RayDatasetMetrics,
         ray: Any | None = None,
         metrics_collector: Any | None = None,
+        throttle_manager: Any | None = None,
         output: Any | None = None,
     ) -> None:
         self.dataset = dataset
@@ -67,6 +70,7 @@ class RayDatasetCreationResults:
         self._metrics_cache: RayDatasetMetrics | None = None
         self._ray = ray
         self._metrics_collector = metrics_collector
+        self._throttle_manager = throttle_manager
         self._output = output
 
     def load_dataset(self) -> Any:
@@ -93,7 +97,11 @@ class RayDatasetCreationResults:
         if not payloads:
             return self._driver_metrics
         worker_metrics = aggregate_ray_metrics(payloads)
-        self._metrics_cache = _merge_driver_and_worker_metrics(self._driver_metrics, worker_metrics)
+        self._metrics_cache = _merge_driver_and_worker_metrics(
+            self._driver_metrics,
+            worker_metrics,
+            throttle_metrics=self._load_throttle_metrics(),
+        )
         return self._metrics_cache
 
     @property
@@ -106,6 +114,14 @@ class RayDatasetCreationResults:
         if not callable(materialize):
             return
         self.dataset = materialize()
+
+    def _load_throttle_metrics(self) -> dict[str, Any] | None:
+        if self._throttle_manager is None:
+            return None
+        snapshot = getattr(self._throttle_manager, "snapshot", None)
+        if not callable(snapshot):
+            return None
+        return snapshot()
 
     def to_arrow_refs(self) -> list[Any]:
         """Return Ray ObjectRefs containing PyArrow tables, one per Ray block."""
@@ -144,6 +160,7 @@ class RayBackend:
         drop_order_column: bool = False,
         preserve_order: bool = False,
         allow_unsafe_processors: bool = False,
+        global_provider_throttling: bool = True,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
             raise ValueError("RayBackend output must be 'dataset' or 'arrow_refs'.")
@@ -161,6 +178,7 @@ class RayBackend:
         self.drop_order_column = drop_order_column
         self.preserve_order = preserve_order
         self.allow_unsafe_processors = allow_unsafe_processors
+        self.global_provider_throttling = global_provider_throttling
 
     def create(
         self,
@@ -205,6 +223,13 @@ class RayBackend:
         input_blocks = _get_num_blocks(dataset)
         metrics_collector = _create_metrics_collector(ray)
         batch_size = self.batch_size or data_designer._run_config.buffer_size
+        throttle_manager = (
+            create_ray_throttle_manager(ray, data_designer._run_config)
+            if self.global_provider_throttling
+            and config_builder.model_configs
+            and callable(getattr(ray, "remote", None))
+            else None
+        )
         worker_options = _RayWorkerOptions(
             model_providers=list(data_designer._model_providers),
             default_provider_name=data_designer._model_provider_registry.get_default_provider_name(),
@@ -214,6 +239,7 @@ class RayBackend:
             person_reader=data_designer._person_reader,
             mcp_providers=list(data_designer._mcp_providers),
             run_config=data_designer._run_config,
+            throttle_manager=throttle_manager,
         )
 
         map_batches_kwargs: dict[str, Any] = {
@@ -252,6 +278,7 @@ class RayBackend:
             metrics=metrics,
             ray=ray,
             metrics_collector=metrics_collector,
+            throttle_manager=throttle_manager,
             output=output,
         )
 
@@ -335,7 +362,10 @@ def _create_metrics_collector(ray: Any) -> Any | None:
 
 
 def _merge_driver_and_worker_metrics(
-    driver_metrics: RayDatasetMetrics, worker_metrics: RayDatasetMetrics
+    driver_metrics: RayDatasetMetrics,
+    worker_metrics: RayDatasetMetrics,
+    *,
+    throttle_metrics: dict[str, Any] | None = None,
 ) -> RayDatasetMetrics:
     return RayDatasetMetrics(
         total_rows=worker_metrics.total_rows,
@@ -343,6 +373,7 @@ def _merge_driver_and_worker_metrics(
         failed_blocks=worker_metrics.failed_blocks,
         elapsed_seconds=worker_metrics.elapsed_seconds,
         model_usage=worker_metrics.model_usage or driver_metrics.model_usage,
+        throttle=throttle_metrics or worker_metrics.throttle or driver_metrics.throttle,
     )
 
 
@@ -402,6 +433,7 @@ def _generate_batch(
                 run_config=copy.deepcopy(worker_options.run_config),
                 mcp_providers=worker_options.mcp_providers,
                 tool_configs=block_builder.tool_configs,
+                throttle_manager=worker_options.throttle_manager,
             )
             builder = DatasetBuilder(
                 data_designer_config=block_builder.build(),

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import importlib
 import os
+import pickle
 import tempfile
 import time
 from dataclasses import dataclass
@@ -16,6 +17,7 @@ import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.processors import ProcessorType
 from data_designer.config.run_config import RunConfig
+from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy, SeedConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
 from data_designer.engine.model_provider import resolve_model_provider_registry
@@ -34,6 +36,8 @@ if TYPE_CHECKING:
 
 RayOutputMode = Literal["dataset", "arrow_refs"]
 RayObjectRefInputFormat = Literal["arrow", "pandas"]
+_RAY_RANGE_ID_COLUMN = "id"
+_RAY_INTERNAL_ROW_ID_COLUMN = "__data_designer_ray_row_id"
 
 
 @dataclass(frozen=True)
@@ -46,6 +50,12 @@ class _RayWorkerOptions:
     person_reader: PersonReader | None
     mcp_providers: list[MCPProviderT]
     run_config: RunConfig
+
+
+@dataclass(frozen=True)
+class _RaySeedWindow:
+    start: int
+    size: int
 
 
 class RayDatasetCreationResults:
@@ -143,6 +153,7 @@ class RayBackend:
         order_column: str | None = None,
         drop_order_column: bool = False,
         preserve_order: bool = False,
+        keep_internal_order_column: bool = False,
         allow_unsafe_processors: bool = False,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
@@ -160,6 +171,7 @@ class RayBackend:
         self.order_column = order_column
         self.drop_order_column = drop_order_column
         self.preserve_order = preserve_order
+        self.keep_internal_order_column = keep_internal_order_column
         self.allow_unsafe_processors = allow_unsafe_processors
 
     def create(
@@ -183,27 +195,28 @@ class RayBackend:
             ray.init()
 
         use_input_dataset = input_dataset is not None
+        seed_config = config_builder.get_seed_config()
         if use_input_dataset and config_builder.get_seed_config() is not None:
             raise RayBackendConfigurationError(
                 "RayBackend input_dataset is used as the seed dataset; remove the existing seed config."
             )
-        if not use_input_dataset and config_builder.get_seed_config() is not None:
-            raise RayBackendConfigurationError(
-                "RayBackend does not yet support seed configs without input_dataset because partition offsets "
-                "are not available. Pass seed data as input_dataset, or use the local backend until "
-                "RayBackend partition-offset support exists."
+        seed_window = (
+            _preflight_seed_window(
+                data_designer=data_designer,
+                seed_config=seed_config,
+                num_records=num_records,
             )
-        if self.preserve_order and self.order_column is None:
-            raise RayBackendConfigurationError(
-                "RayBackend preserve_order=True requires order_column in this experimental backend. "
-                "Automatic hidden row-id injection is tracked as follow-up hardening work."
-            )
+            if not use_input_dataset and seed_config is not None
+            else None
+        )
         if not self.allow_unsafe_processors:
             _validate_ray_safe_processors(config_builder)
 
         dataset = self._resolve_input_dataset(ray, input_dataset=input_dataset, num_records=num_records)
+        hidden_order_column = _RAY_INTERNAL_ROW_ID_COLUMN if self.preserve_order and self.order_column is None else None
+        if hidden_order_column is not None and use_input_dataset:
+            dataset = _attach_hidden_row_id_column(ray, dataset, hidden_order_column=hidden_order_column)
         input_blocks = _get_num_blocks(dataset)
-        metrics_collector = _create_metrics_collector(ray)
         batch_size = self.batch_size or data_designer._run_config.buffer_size
         worker_options = _RayWorkerOptions(
             model_providers=list(data_designer._model_providers),
@@ -215,12 +228,20 @@ class RayBackend:
             mcp_providers=list(data_designer._mcp_providers),
             run_config=data_designer._run_config,
         )
+        worker_payload = {
+            "config_builder": config_builder,
+            "worker_options": worker_options,
+            "use_input_dataset": use_input_dataset,
+            "seed_window": seed_window,
+            "hidden_order_column": hidden_order_column,
+        }
+        _validate_worker_payload_serializable(worker_payload)
+
+        metrics_collector = _create_metrics_collector(ray)
 
         map_batches_kwargs: dict[str, Any] = {
             "fn_kwargs": {
-                "config_builder": config_builder,
-                "worker_options": worker_options,
-                "use_input_dataset": use_input_dataset,
+                **worker_payload,
                 "metrics_collector": metrics_collector,
             },
             "batch_size": batch_size,
@@ -232,13 +253,29 @@ class RayBackend:
 
         try:
             mapped = dataset.map_batches(_generate_batch, **map_batches_kwargs)
-            mapped = self._apply_ordering(mapped)
+        except RayDatasetGenerationError:
+            raise
+        except Exception as exc:
+            raise RayDatasetGenerationError(
+                "RayBackend failed while constructing the Ray map_batches execution plan."
+            ) from exc
+
+        try:
+            mapped = self._apply_ordering(mapped, hidden_order_column=hidden_order_column)
+        except RayDatasetGenerationError:
+            raise
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed while applying Ray output ordering.") from exc
+
+        try:
             output = mapped.to_arrow_refs() if self.output == "arrow_refs" else None
             result_dataset = _dataset_from_arrow_refs(ray, output) if output is not None else mapped
         except RayDatasetGenerationError:
             raise
         except Exception as exc:
-            raise RayDatasetGenerationError("RayBackend failed while constructing the Ray execution plan.") from exc
+            raise RayDatasetGenerationError(
+                "RayBackend failed while materializing Ray output blocks for output='arrow_refs'."
+            ) from exc
 
         output_blocks = len(output) if output is not None else _get_num_blocks(mapped)
         metrics = RayDatasetMetrics(
@@ -270,13 +307,89 @@ class RayBackend:
             "containing PyArrow tables or pandas DataFrames."
         )
 
-    def _apply_ordering(self, dataset: Any) -> Any:
-        if self.order_column is None:
+    def _apply_ordering(self, dataset: Any, *, hidden_order_column: str | None) -> Any:
+        order_column = self.order_column or hidden_order_column
+        if order_column is None:
             return dataset
-        ordered = dataset.sort(self.order_column)
+        ordered = dataset.sort(order_column)
+        if hidden_order_column is not None and order_column == hidden_order_column:
+            if self.keep_internal_order_column:
+                return ordered
+            return ordered.drop_columns([hidden_order_column])
         if self.drop_order_column:
-            return ordered.drop_columns([self.order_column])
+            return ordered.drop_columns([order_column])
         return ordered
+
+
+def _preflight_seed_window(
+    *,
+    data_designer: Any,
+    seed_config: SeedConfig,
+    num_records: int,
+) -> _RaySeedWindow:
+    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
+        raise RayBackendConfigurationError(
+            "RayBackend seed configs without input_dataset currently support only ordered sampling. "
+            "Pass the seed data as input_dataset or use the local backend for shuffled seed sampling."
+        )
+
+    try:
+        seed_reader = SeedReaderRegistry(
+            readers=_clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
+        ).get_reader(seed_config.source, data_designer._secret_resolver)
+        seed_dataset_size = seed_reader.get_seed_dataset_size()
+        index_range = _resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayBackendConfigurationError(
+            "RayBackend failed to preflight the seed config for partition offsets."
+        ) from exc
+
+    if num_records > index_range.size:
+        raise RayBackendConfigurationError(
+            "RayBackend seed configs without input_dataset require num_records to fit inside the selected seed "
+            f"range. Requested {num_records} records from {index_range.size} selected seed rows."
+        )
+    return _RaySeedWindow(start=index_range.start, size=index_range.size)
+
+
+def _resolve_seed_config_index_range(*, seed_config: SeedConfig, seed_dataset_size: int) -> IndexRange:
+    if seed_dataset_size <= 0:
+        raise RayBackendConfigurationError("RayBackend seed config resolved to an empty seed dataset.")
+    if seed_config.selection_strategy is None:
+        return IndexRange(start=0, end=seed_dataset_size - 1)
+    if isinstance(seed_config.selection_strategy, IndexRange):
+        if seed_config.selection_strategy.end >= seed_dataset_size:
+            raise RayBackendConfigurationError(
+                "RayBackend seed config selection_strategy is out of bounds for the seed dataset. "
+                f"Selection end={seed_config.selection_strategy.end}, seed rows={seed_dataset_size}."
+            )
+        return seed_config.selection_strategy
+    if isinstance(seed_config.selection_strategy, PartitionBlock):
+        if seed_config.selection_strategy.num_partitions > seed_dataset_size:
+            raise RayBackendConfigurationError(
+                "RayBackend seed config selection_strategy is out of bounds for the seed dataset. "
+                f"Partition count={seed_config.selection_strategy.num_partitions}, seed rows={seed_dataset_size}."
+            )
+        return seed_config.selection_strategy.to_index_range(seed_dataset_size)
+    raise RayBackendConfigurationError(
+        "RayBackend seed config uses an unsupported selection_strategy for partitioned execution."
+    )
+
+
+def _validate_worker_payload_serializable(payload: dict[str, Any]) -> None:
+    try:
+        serializer = importlib.import_module("cloudpickle")
+    except ImportError:
+        serializer = pickle
+    try:
+        serializer.dumps(payload)
+    except Exception as exc:
+        raise RayBackendConfigurationError(
+            "RayBackend worker payload is not serializable. Check model providers, seed readers, "
+            "secret resolvers, and MCP providers for process-safe state before launching Ray workers."
+        ) from exc
 
 
 def _validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
@@ -306,6 +419,47 @@ def _get_num_blocks(dataset: Any) -> int | None:
     return int(value) if value is not None else None
 
 
+def _count_dataset_rows(dataset: Any) -> int:
+    count = getattr(dataset, "count", None)
+    if not callable(count):
+        raise RayBackendConfigurationError(
+            "RayBackend preserve_order=True for input datasets requires ray.data.Dataset.count()."
+        )
+    try:
+        return int(count())
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend failed to count input rows for hidden order preservation.") from exc
+
+
+def _attach_hidden_row_id_column(ray: Any, dataset: Any, *, hidden_order_column: str) -> Any:
+    row_count = _count_dataset_rows(dataset)
+    try:
+        order_dataset = ray.data.range(row_count).map_batches(
+            _rename_range_id_column,
+            fn_kwargs={"hidden_order_column": hidden_order_column},
+            batch_format="pandas",
+        )
+        zip_dataset = getattr(dataset, "zip", None)
+        if not callable(zip_dataset):
+            raise RayBackendConfigurationError(
+                "RayBackend preserve_order=True for input datasets requires ray.data.Dataset.zip()."
+            )
+        return zip_dataset(order_dataset)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend failed to attach hidden row ids to the input dataset.") from exc
+
+
+def _rename_range_id_column(batch: Any, *, hidden_order_column: str) -> Any:
+    dataframe = _coerce_pandas_dataframe(batch)
+    if _RAY_RANGE_ID_COLUMN not in dataframe.columns:
+        raise RayDatasetGenerationError(
+            f"RayBackend expected ray.data.range() batches to include {_RAY_RANGE_ID_COLUMN!r}."
+        )
+    return lazy.pd.DataFrame({hidden_order_column: dataframe[_RAY_RANGE_ID_COLUMN].tolist()})
+
+
 def _dataset_from_arrow_refs(ray: Any, refs: list[Any]) -> Any:
     from_arrow_refs = getattr(ray.data, "from_arrow_refs", None)
     if not callable(from_arrow_refs):
@@ -313,7 +467,12 @@ def _dataset_from_arrow_refs(ray: Any, refs: list[Any]) -> Any:
             "RayBackend output='arrow_refs' requires ray.data.from_arrow_refs to expose a dataset "
             "backed by the materialized Arrow ObjectRefs."
         )
-    return from_arrow_refs(refs)
+    try:
+        return from_arrow_refs(refs)
+    except Exception as exc:
+        raise RayDatasetGenerationError(
+            "RayBackend failed to rebuild a Ray Dataset from materialized Arrow ObjectRefs."
+        ) from exc
 
 
 class _RayMetricsCollector:
@@ -365,6 +524,8 @@ def _generate_batch(
     config_builder: DataDesignerConfigBuilder,
     worker_options: _RayWorkerOptions,
     use_input_dataset: bool,
+    seed_window: _RaySeedWindow | None = None,
+    hidden_order_column: str | None = None,
     metrics_collector: Any | None = None,
 ) -> Any:
     start_time = time.perf_counter()
@@ -380,8 +541,20 @@ def _generate_batch(
 
     try:
         block_builder = copy.deepcopy(config_builder)
+        order_values = _get_hidden_order_values(dataframe, hidden_order_column=hidden_order_column)
         if use_input_dataset:
-            block_builder.with_seed_dataset(DataFrameSeedSource(df=dataframe.copy()))
+            block_builder.with_seed_dataset(DataFrameSeedSource(df=_strip_internal_columns(dataframe)))
+        elif seed_window is not None:
+            block_builder.with_seed_dataset(
+                DataFrameSeedSource(
+                    df=_read_seed_window_dataframe(
+                        config_builder=block_builder,
+                        worker_options=worker_options,
+                        dataframe=dataframe,
+                        seed_window=seed_window,
+                    )
+                )
+            )
 
         with tempfile.TemporaryDirectory(prefix="data-designer-ray-") as artifact_dir:
             ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
@@ -410,6 +583,12 @@ def _generate_batch(
             )
             raw_dataset = builder.build_preview(num_records=num_records)
             output = builder.process_preview(raw_dataset)
+            if hidden_order_column is not None:
+                output = _append_hidden_order_column(
+                    output,
+                    order_values=order_values,
+                    hidden_order_column=hidden_order_column,
+                )
             elapsed_seconds = time.perf_counter() - start_time
             _record_worker_metrics(
                 metrics_collector,
@@ -421,7 +600,7 @@ def _generate_batch(
                 ),
             )
             return output
-    except Exception:
+    except Exception as exc:
         _record_worker_metrics(
             metrics_collector,
             RayWorkerMetrics(
@@ -431,7 +610,135 @@ def _generate_batch(
                 elapsed_seconds=time.perf_counter() - start_time,
             ),
         )
-        raise
+        raise RayDatasetGenerationError(_format_worker_failure_message(dataframe=dataframe, exc=exc)) from exc
+
+
+def _strip_internal_columns(dataframe: Any) -> Any:
+    columns_to_drop = [column for column in (_RAY_INTERNAL_ROW_ID_COLUMN,) if column in dataframe.columns]
+    if not columns_to_drop:
+        return dataframe.copy()
+    return dataframe.drop(columns=columns_to_drop).copy()
+
+
+def _get_hidden_order_values(dataframe: Any, *, hidden_order_column: str | None) -> list[int]:
+    if hidden_order_column is None:
+        return []
+    if hidden_order_column in dataframe.columns:
+        values = dataframe[hidden_order_column].tolist()
+    elif _RAY_RANGE_ID_COLUMN in dataframe.columns:
+        values = dataframe[_RAY_RANGE_ID_COLUMN].tolist()
+    else:
+        raise RayDatasetGenerationError(
+            "RayBackend preserve_order=True could not find the hidden row-id source column in a Ray worker batch."
+        )
+    return [int(value) for value in values]
+
+
+def _append_hidden_order_column(
+    output: Any,
+    *,
+    order_values: list[int],
+    hidden_order_column: str,
+) -> Any:
+    if len(output) != len(order_values):
+        raise RayDatasetGenerationError(
+            "RayBackend preserve_order=True requires each Ray worker batch to emit one output row for each "
+            f"input row. Input rows={len(order_values)}, output rows={len(output)}."
+        )
+    output = output.copy()
+    output[hidden_order_column] = order_values
+    return output
+
+
+def _read_seed_window_dataframe(
+    *,
+    config_builder: DataDesignerConfigBuilder,
+    worker_options: _RayWorkerOptions,
+    dataframe: Any,
+    seed_window: _RaySeedWindow,
+) -> Any:
+    seed_config = config_builder.get_seed_config()
+    if seed_config is None:
+        raise RayDatasetGenerationError("RayBackend seed window was provided without a seed config.")
+    row_offsets = _get_contiguous_range_offsets(dataframe)
+    index_range = IndexRange(
+        start=seed_window.start + row_offsets[0],
+        end=seed_window.start + row_offsets[-1],
+    )
+    if row_offsets[-1] >= seed_window.size:
+        raise RayDatasetGenerationError(
+            "RayBackend seed partition offset exceeded the selected seed range. "
+            f"Offset={row_offsets[-1]}, selected seed rows={seed_window.size}."
+        )
+
+    seed_reader = SeedReaderRegistry(readers=copy.deepcopy(worker_options.seed_readers)).get_reader(
+        seed_config.source,
+        worker_options.secret_resolver,
+    )
+    batch_reader = seed_reader.create_batch_reader(
+        batch_size=len(row_offsets),
+        index_range=index_range,
+        shuffle=False,
+    )
+    seed_dataframe = batch_reader.read_next_batch().to_pandas().reset_index(drop=True)
+    if len(seed_dataframe) != len(row_offsets):
+        raise RayDatasetGenerationError(
+            "RayBackend seed reader returned an unexpected row count for a partition offset. "
+            f"Expected {len(row_offsets)} rows, got {len(seed_dataframe)}."
+        )
+    return seed_dataframe
+
+
+def _get_contiguous_range_offsets(dataframe: Any) -> list[int]:
+    if _RAY_RANGE_ID_COLUMN not in dataframe.columns:
+        raise RayDatasetGenerationError(
+            f"RayBackend seed partition offsets require {_RAY_RANGE_ID_COLUMN!r} from ray.data.range()."
+        )
+    row_offsets = [int(value) for value in dataframe[_RAY_RANGE_ID_COLUMN].tolist()]
+    if not row_offsets:
+        raise RayDatasetGenerationError("RayBackend seed partition offsets received an empty Ray worker batch.")
+    expected_offsets = list(range(row_offsets[0], row_offsets[0] + len(row_offsets)))
+    if row_offsets != expected_offsets:
+        raise RayDatasetGenerationError(
+            "RayBackend seed partition offsets require contiguous ray.data.range() batches. "
+            f"Received offsets {row_offsets!r}."
+        )
+    return row_offsets
+
+
+def _format_worker_failure_message(*, dataframe: Any, exc: Exception) -> str:
+    context_parts = [f"{len(dataframe)} input row(s)"]
+    if _RAY_INTERNAL_ROW_ID_COLUMN in dataframe.columns:
+        row_ids = [int(value) for value in dataframe[_RAY_INTERNAL_ROW_ID_COLUMN].tolist()]
+        if row_ids:
+            context_parts.append(f"logical rows {min(row_ids)}-{max(row_ids)}")
+    elif _RAY_RANGE_ID_COLUMN in dataframe.columns:
+        row_ids = [int(value) for value in dataframe[_RAY_RANGE_ID_COLUMN].tolist()]
+        if row_ids:
+            context_parts.append(f"range rows {min(row_ids)}-{max(row_ids)}")
+    task_context = _get_ray_task_context()
+    if task_context:
+        context_parts.append(task_context)
+    return f"RayBackend worker failed while generating a Ray block ({', '.join(context_parts)}): {exc}"
+
+
+def _get_ray_task_context() -> str | None:
+    try:
+        ray = importlib.import_module("ray")
+        get_runtime_context = getattr(ray, "get_runtime_context", None)
+        if not callable(get_runtime_context):
+            return None
+        runtime_context = get_runtime_context()
+    except Exception:
+        return None
+
+    context_values: list[str] = []
+    for attr in ("task_id", "actor_id", "worker_id"):
+        value = getattr(runtime_context, attr, None)
+        if value is None:
+            continue
+        context_values.append(f"{attr}={value}")
+    return ", ".join(context_values) if context_values else None
 
 
 def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -7,6 +7,7 @@ import copy
 import importlib
 import os
 import pickle
+import tempfile
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -15,11 +16,13 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal
 from pydantic import PrivateAttr
 
 import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.column_configs import CustomColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy, SeedConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
+from data_designer.engine.column_generators.utils.generator_classification import column_type_is_model_generated
 from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
 from data_designer.engine.model_provider import resolve_model_provider_registry
 from data_designer.engine.resources.person_reader import PersonReader, create_person_reader
@@ -30,6 +33,7 @@ from data_designer.engine.storage.artifact_storage import ArtifactStorage, Batch
 from data_designer.engine.storage.media_storage import StorageMode
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, RayMapConcurrency
 from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 from data_designer.integrations.ray.throttling import create_ray_throttle_manager
 
@@ -179,6 +183,27 @@ class RayBackend:
         auto_init: bool = False,
         zero_copy_batch: bool = True,
         ray_remote_args: dict[str, Any] | None = None,
+        block_planning: RayBlockPlanning | None = None,
+        override_num_blocks: int | None = None,
+        target_block_size: int | None = None,
+        min_blocks: int | None = None,
+        max_blocks: int | None = None,
+        read_concurrency: int | None = None,
+        execution_options: RayExecutionOptions | None = None,
+        num_cpus: float | None = None,
+        num_gpus: float | None = None,
+        memory: float | None = None,
+        resources: dict[str, float] | None = None,
+        scheduling_strategy: Any | None = None,
+        compute: Any | None = None,
+        map_concurrency: RayMapConcurrency | None = None,
+        ray_remote_args_fn: Any | None = None,
+        use_actor_pool: bool = False,
+        actor_pool_min_size: int | None = None,
+        actor_pool_max_size: int | None = None,
+        actor_pool_initial_size: int | None = None,
+        preflight_model_health_check: bool = True,
+        worker_model_health_checks: bool = False,
         order_column: str | None = None,
         drop_order_column: bool = False,
         preserve_order: bool = False,
@@ -192,12 +217,38 @@ class RayBackend:
             raise ValueError("RayBackend object_ref_format must be 'arrow' or 'pandas'.")
         if order_column is not None and order_column == "":
             raise ValueError("RayBackend order_column must be a non-empty string when provided.")
+        self.block_planning = _resolve_block_planning(
+            block_planning,
+            override_num_blocks=override_num_blocks,
+            target_block_size=target_block_size,
+            min_blocks=min_blocks,
+            max_blocks=max_blocks,
+            read_concurrency=read_concurrency,
+        )
+        self.execution_options = _resolve_execution_options(
+            execution_options,
+            ray_remote_args=ray_remote_args,
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+            memory=memory,
+            resources=resources,
+            scheduling_strategy=scheduling_strategy,
+            compute=compute,
+            map_concurrency=map_concurrency,
+            ray_remote_args_fn=ray_remote_args_fn,
+            use_actor_pool=use_actor_pool,
+            actor_pool_min_size=actor_pool_min_size,
+            actor_pool_max_size=actor_pool_max_size,
+            actor_pool_initial_size=actor_pool_initial_size,
+        )
         self.batch_size = batch_size
         self.output = output
         self.object_ref_format = object_ref_format
         self.auto_init = auto_init
         self.zero_copy_batch = zero_copy_batch
         self.ray_remote_args = ray_remote_args
+        self.preflight_model_health_check = preflight_model_health_check
+        self.worker_model_health_checks = worker_model_health_checks
         self.order_column = order_column
         self.drop_order_column = drop_order_column
         self.preserve_order = preserve_order
@@ -231,6 +282,12 @@ class RayBackend:
             raise RayBackendConfigurationError(
                 "RayBackend input_dataset is used as the seed dataset; remove the existing seed config."
             )
+        if use_input_dataset and self.block_planning.has_explicit_controls:
+            raise RayBackendConfigurationError(
+                "RayBackend block planning controls apply only when RayBackend creates a from-scratch "
+                "range dataset. Remove override_num_blocks, target_block_size, min_blocks, max_blocks, "
+                "and read_concurrency when passing input_dataset."
+            )
         seed_window = (
             _preflight_seed_window(data_designer=data_designer, seed_config=seed_config, num_records=num_records)
             if not use_input_dataset and seed_config is not None
@@ -239,7 +296,17 @@ class RayBackend:
         if not self.allow_unsafe_processors:
             validate_ray_safe_processors(config_builder)
 
-        dataset = self._resolve_input_dataset(ray, input_dataset=input_dataset, num_records=num_records)
+        model_aliases = _model_health_check_aliases(config_builder)
+        if self.preflight_model_health_check:
+            _run_driver_model_health_check(data_designer, config_builder, model_aliases)
+
+        block_plan = self.block_planning.resolve(num_records=num_records) if input_dataset is None else None
+        dataset = self._resolve_input_dataset(
+            ray,
+            input_dataset=input_dataset,
+            num_records=num_records,
+            block_plan=block_plan,
+        )
         hidden_order_column = _RAY_INTERNAL_ROW_ID_COLUMN if self.preserve_order and self.order_column is None else None
         if hidden_order_column is not None and use_input_dataset:
             dataset = _attach_hidden_row_id_column(ray, dataset, hidden_order_column=hidden_order_column)
@@ -253,6 +320,10 @@ class RayBackend:
             and callable(getattr(ray, "remote", None))
             else None
         )
+        worker_config_builder = _clone_config_builder_for_worker(
+            config_builder,
+            worker_model_health_checks=self.worker_model_health_checks,
+        )
         worker_options = _RayWorkerOptions(
             model_providers=list(data_designer._model_providers),
             default_provider_name=data_designer._model_provider_registry.get_default_provider_name(),
@@ -265,7 +336,7 @@ class RayBackend:
             throttle_manager=throttle_manager,
         )
         execution_payload = _compile_ray_execution_payload(
-            config_builder=config_builder,
+            config_builder=worker_config_builder,
             worker_options=worker_options,
             use_input_dataset=use_input_dataset,
             seed_window=seed_window,
@@ -281,8 +352,7 @@ class RayBackend:
             "batch_format": "pandas",
             "zero_copy_batch": self.zero_copy_batch,
         }
-        if self.ray_remote_args is not None:
-            map_batches_kwargs.update(self.ray_remote_args)
+        map_batches_kwargs.update(self.execution_options.to_map_batches_kwargs(ray))
 
         try:
             mapped = dataset.map_batches(_RayBatchWorker, **map_batches_kwargs)
@@ -313,7 +383,7 @@ class RayBackend:
         output_blocks = len(output) if output is not None else _get_num_blocks(mapped)
         metrics = RayDatasetMetrics(
             total_rows=num_records if input_dataset is None else 0,
-            blocks=output_blocks or input_blocks or 0,
+            blocks=output_blocks or input_blocks or (block_plan.planned_blocks if block_plan is not None else 0) or 0,
             elapsed_seconds=time.perf_counter() - start_time,
         )
         return RayDatasetCreationResults(
@@ -326,9 +396,17 @@ class RayBackend:
             output=output,
         )
 
-    def _resolve_input_dataset(self, ray: Any, *, input_dataset: Any | None, num_records: int) -> Any:
+    def _resolve_input_dataset(
+        self,
+        ray: Any,
+        *,
+        input_dataset: Any | None,
+        num_records: int,
+        block_plan: Any | None,
+    ) -> Any:
         if input_dataset is None:
-            return ray.data.range(num_records)
+            range_kwargs = block_plan.to_range_kwargs() if block_plan is not None else {}
+            return ray.data.range(num_records, **range_kwargs)
         if hasattr(input_dataset, "map_batches"):
             return input_dataset
         if isinstance(input_dataset, (list, tuple)):
@@ -353,6 +431,140 @@ class RayBackend:
         if self.drop_order_column:
             return ordered.drop_columns([order_column])
         return ordered
+
+
+def _resolve_block_planning(
+    block_planning: RayBlockPlanning | None,
+    *,
+    override_num_blocks: int | None,
+    target_block_size: int | None,
+    min_blocks: int | None,
+    max_blocks: int | None,
+    read_concurrency: int | None,
+) -> RayBlockPlanning:
+    if block_planning is not None and any(
+        value is not None
+        for value in (override_num_blocks, target_block_size, min_blocks, max_blocks, read_concurrency)
+    ):
+        raise ValueError("RayBackend block_planning cannot be combined with individual block planning arguments.")
+    if block_planning is not None:
+        return block_planning
+    return RayBlockPlanning(
+        override_num_blocks=override_num_blocks,
+        target_block_size=target_block_size,
+        min_blocks=min_blocks,
+        max_blocks=max_blocks,
+        read_concurrency=read_concurrency,
+    )
+
+
+def _resolve_execution_options(
+    execution_options: RayExecutionOptions | None,
+    *,
+    ray_remote_args: dict[str, Any] | None,
+    num_cpus: float | None,
+    num_gpus: float | None,
+    memory: float | None,
+    resources: dict[str, float] | None,
+    scheduling_strategy: Any | None,
+    compute: Any | None,
+    map_concurrency: RayMapConcurrency | None,
+    ray_remote_args_fn: Any | None,
+    use_actor_pool: bool,
+    actor_pool_min_size: int | None,
+    actor_pool_max_size: int | None,
+    actor_pool_initial_size: int | None,
+) -> RayExecutionOptions:
+    explicit_values = (
+        ray_remote_args,
+        num_cpus,
+        num_gpus,
+        memory,
+        resources,
+        scheduling_strategy,
+        compute,
+        map_concurrency,
+        ray_remote_args_fn,
+        actor_pool_min_size,
+        actor_pool_max_size,
+        actor_pool_initial_size,
+    )
+    if execution_options is not None and (use_actor_pool or any(value is not None for value in explicit_values)):
+        raise ValueError("RayBackend execution_options cannot be combined with individual Ray execution arguments.")
+    if execution_options is not None:
+        return execution_options
+    return RayExecutionOptions(
+        num_cpus=num_cpus,
+        num_gpus=num_gpus,
+        memory=memory,
+        resources=resources,
+        scheduling_strategy=scheduling_strategy,
+        compute=compute,
+        concurrency=map_concurrency,
+        ray_remote_args_fn=ray_remote_args_fn,
+        ray_remote_args=ray_remote_args,
+        use_actor_pool=use_actor_pool,
+        actor_pool_min_size=actor_pool_min_size,
+        actor_pool_max_size=actor_pool_max_size,
+        actor_pool_initial_size=actor_pool_initial_size,
+    )
+
+
+def _model_health_check_aliases(config_builder: DataDesignerConfigBuilder) -> list[str]:
+    model_aliases: set[str] = set()
+    for config in config_builder.get_column_configs():
+        if column_type_is_model_generated(config.column_type):
+            model_alias = getattr(config, "model_alias", None)
+            if model_alias:
+                model_aliases.add(model_alias)
+        if isinstance(config, CustomColumnConfig) and config.model_aliases:
+            model_aliases.update(config.model_aliases)
+    return sorted(model_aliases)
+
+
+def _run_driver_model_health_check(
+    data_designer: Any,
+    config_builder: DataDesignerConfigBuilder,
+    model_aliases: list[str],
+) -> None:
+    if not model_aliases:
+        return
+    try:
+        with tempfile.TemporaryDirectory(prefix="data-designer-ray-preflight-") as artifact_dir:
+            ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
+            resource_provider = create_resource_provider(
+                artifact_storage=ArtifactStorage(artifact_path=artifact_dir, dataset_name="ray-preflight"),
+                model_configs=config_builder.model_configs,
+                secret_resolver=data_designer._secret_resolver,
+                model_provider_registry=data_designer._model_provider_registry,
+                seed_reader_registry=data_designer._seed_reader_registry,
+                person_reader=data_designer._person_reader
+                or create_person_reader(str(data_designer._managed_assets_path)),
+                run_config=data_designer._run_config,
+                mcp_providers=list(data_designer._mcp_providers),
+                tool_configs=config_builder.tool_configs,
+            )
+            resource_provider.model_registry.run_health_check(model_aliases)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend model health-check preflight failed.") from exc
+
+
+def _clone_config_builder_for_worker(
+    config_builder: DataDesignerConfigBuilder,
+    *,
+    worker_model_health_checks: bool,
+) -> DataDesignerConfigBuilder:
+    worker_config_builder = copy.deepcopy(config_builder)
+    if worker_model_health_checks:
+        return worker_config_builder
+    worker_config_builder._model_configs = [
+        model_config.model_copy(update={"skip_health_check": True})
+        for model_config in worker_config_builder.model_configs
+    ]
+    return worker_config_builder
+
 
 def _preflight_seed_window(
     *,

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.processors import ProcessorType
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
@@ -26,6 +25,7 @@ from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 
 if TYPE_CHECKING:
     from data_designer.config.mcp import MCPProviderT
@@ -199,7 +199,7 @@ class RayBackend:
                 "Automatic hidden row-id injection is tracked as follow-up hardening work."
             )
         if not self.allow_unsafe_processors:
-            _validate_ray_safe_processors(config_builder)
+            validate_ray_safe_processors(config_builder)
 
         dataset = self._resolve_input_dataset(ray, input_dataset=input_dataset, num_records=num_records)
         input_blocks = _get_num_blocks(dataset)
@@ -277,22 +277,6 @@ class RayBackend:
         if self.drop_order_column:
             return ordered.drop_columns([self.order_column])
         return ordered
-
-
-def _validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
-    unsafe_processors = [
-        processor
-        for processor in config_builder.get_processor_configs()
-        if processor.processor_type != ProcessorType.DROP_COLUMNS
-    ]
-    if not unsafe_processors:
-        return
-    processor_names = ", ".join(f"{processor.name} ({processor.processor_type})" for processor in unsafe_processors)
-    raise RayBackendConfigurationError(
-        "RayBackend currently supports only distributed-safe processors. "
-        f"Unsupported processor(s): {processor_names}. "
-        "Pass allow_unsafe_processors=True to bypass this experimental guard."
-    )
 
 
 def _get_num_blocks(dataset: Any) -> int | None:

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -7,8 +7,10 @@ import copy
 import importlib
 import os
 import pickle
+import socket
 import tempfile
 import time
+import uuid
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
@@ -32,7 +34,21 @@ from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage, BatchStage
 from data_designer.engine.storage.media_storage import StorageMode
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
-from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.metrics import (
+    RayDatasetMetrics,
+    RayWorkerMetrics,
+    aggregate_ray_metrics,
+    normalize_ray_worker_metrics,
+)
+from data_designer.integrations.ray.observability import (
+    RayDatasetAnalysis,
+    RayThrottleSnapshot,
+    RayTraceEvent,
+    RayWorkerProfile,
+    normalize_ray_throttle_snapshot,
+    normalize_ray_trace_event,
+    normalize_ray_worker_profile,
+)
 from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, RayMapConcurrency
 from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 from data_designer.integrations.ray.throttling import create_ray_throttle_manager
@@ -77,6 +93,12 @@ class _RayExecutionPayload:
     hidden_order_column: str | None = None
 
 
+@dataclass(frozen=True)
+class _RayObservabilityOptions:
+    profile_workers: bool = False
+    trace_enabled: bool = False
+
+
 class RayDatasetCreationResults:
     """Results wrapper for Ray-resident Data Designer outputs."""
 
@@ -90,23 +112,27 @@ class RayDatasetCreationResults:
         metrics_collector: Any | None = None,
         throttle_manager: Any | None = None,
         output: Any | None = None,
+        observability_options: _RayObservabilityOptions | None = None,
     ) -> None:
         self.dataset = dataset
         self._config_builder = config_builder
         self._driver_metrics = metrics
         self._metrics_cache: RayDatasetMetrics | None = None
+        self._worker_metrics_cache: list[RayWorkerMetrics] | None = None
+        self._analysis_cache: RayDatasetAnalysis | None = None
         self._ray = ray
         self._metrics_collector = metrics_collector
         self._throttle_manager = throttle_manager
         self._output = output
+        self._observability_options = observability_options or _RayObservabilityOptions()
 
     def load_dataset(self) -> Any:
         """Return the Ray Dataset without materializing it on the driver."""
         return self.dataset
 
-    def load_analysis(self) -> None:
-        """Ray-resident jobs do not produce local profiler artifacts."""
-        return None
+    def load_analysis(self) -> RayDatasetAnalysis | None:
+        """Return Ray-native worker profiles and bounded traces when available."""
+        return self.load_observability()
 
     def load_metrics(self) -> RayDatasetMetrics:
         """Return driver-visible Ray execution metrics."""
@@ -115,21 +141,59 @@ class RayDatasetCreationResults:
         if self._ray is None or self._metrics_collector is None:
             return self._driver_metrics
         try:
-            payloads = self._ray.get(self._metrics_collector.snapshot.remote())
-            if not payloads:
-                self._materialize_dataset_for_metrics()
-                payloads = self._ray.get(self._metrics_collector.snapshot.remote())
+            worker_metrics_payloads = self._load_worker_metrics_payloads()
         except Exception as exc:
             raise RayDatasetGenerationError("RayBackend failed to load worker metrics.") from exc
-        if not payloads:
+        if not worker_metrics_payloads:
             return self._driver_metrics
-        worker_metrics = aggregate_ray_metrics(payloads)
+        worker_metrics = aggregate_ray_metrics(worker_metrics_payloads)
         self._metrics_cache = _merge_driver_and_worker_metrics(
             self._driver_metrics,
             worker_metrics,
             throttle_metrics=self._load_throttle_metrics(),
         )
         return self._metrics_cache
+
+    def load_worker_metrics(self) -> list[RayWorkerMetrics]:
+        """Return per-worker metrics payloads before dataset-level aggregation."""
+        if self._ray is None or self._metrics_collector is None:
+            return []
+        try:
+            return list(self._load_worker_metrics_payloads())
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed to load worker metrics.") from exc
+
+    def load_observability(self) -> RayDatasetAnalysis | None:
+        """Return bounded Ray-native profiles, traces, and worker-local throttle snapshots."""
+        if self._analysis_cache is not None:
+            return self._analysis_cache
+        if self._ray is None or self._metrics_collector is None:
+            return None
+        try:
+            payload = self._load_observability_payload()
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed to load Ray observability artifacts.") from exc
+        if not _has_observability_payload(payload):
+            return None
+
+        metrics = self.load_metrics()
+        worker_profiles = [
+            normalize_ray_worker_profile(profile) for profile in payload.get("worker_profiles", []) or []
+        ]
+        trace_events = [normalize_ray_trace_event(event) for event in payload.get("trace_events", []) or []]
+        throttle_snapshots = [
+            normalize_ray_throttle_snapshot(snapshot) for snapshot in payload.get("throttle_snapshots", []) or []
+        ]
+        self._analysis_cache = RayDatasetAnalysis(
+            total_rows=metrics.total_rows,
+            blocks=metrics.blocks,
+            failed_blocks=metrics.failed_blocks,
+            worker_profiles=worker_profiles,
+            trace_events=trace_events,
+            trace_events_dropped=int(payload.get("trace_events_dropped", 0) or 0),
+            throttle_snapshots=throttle_snapshots,
+        )
+        return self._analysis_cache
 
     @property
     def metrics(self) -> RayDatasetMetrics:
@@ -141,6 +205,26 @@ class RayDatasetCreationResults:
         if not callable(materialize):
             return
         self.dataset = materialize()
+
+    def _load_worker_metrics_payloads(self) -> list[RayWorkerMetrics]:
+        if self._worker_metrics_cache is not None:
+            return self._worker_metrics_cache
+        payloads = self._ray.get(self._metrics_collector.snapshot.remote())
+        if not payloads:
+            self._materialize_dataset_for_metrics()
+            payloads = self._ray.get(self._metrics_collector.snapshot.remote())
+        self._worker_metrics_cache = [normalize_ray_worker_metrics(payload) for payload in payloads]
+        return self._worker_metrics_cache
+
+    def _load_observability_payload(self) -> dict[str, Any]:
+        observability_snapshot = getattr(self._metrics_collector, "observability_snapshot", None)
+        if observability_snapshot is None:
+            return {}
+        payload = self._ray.get(observability_snapshot.remote())
+        if not _has_observability_payload(payload):
+            self._load_worker_metrics_payloads()
+            payload = self._ray.get(observability_snapshot.remote())
+        return dict(payload)
 
     def _load_throttle_metrics(self) -> dict[str, Any] | None:
         if self._throttle_manager is None:
@@ -210,6 +294,9 @@ class RayBackend:
         keep_internal_order_column: bool = False,
         allow_unsafe_processors: bool = False,
         global_provider_throttling: bool = True,
+        profile_workers: bool = True,
+        trace_enabled: bool = False,
+        max_trace_events: int = 1000,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
             raise ValueError("RayBackend output must be 'dataset' or 'arrow_refs'.")
@@ -217,6 +304,8 @@ class RayBackend:
             raise ValueError("RayBackend object_ref_format must be 'arrow' or 'pandas'.")
         if order_column is not None and order_column == "":
             raise ValueError("RayBackend order_column must be a non-empty string when provided.")
+        if max_trace_events < 0:
+            raise ValueError("RayBackend max_trace_events must be non-negative.")
         self.block_planning = _resolve_block_planning(
             block_planning,
             override_num_blocks=override_num_blocks,
@@ -255,6 +344,9 @@ class RayBackend:
         self.keep_internal_order_column = keep_internal_order_column
         self.allow_unsafe_processors = allow_unsafe_processors
         self.global_provider_throttling = global_provider_throttling
+        self.profile_workers = profile_workers
+        self.trace_enabled = trace_enabled
+        self.max_trace_events = max_trace_events
 
     def create(
         self,
@@ -311,8 +403,12 @@ class RayBackend:
         if hidden_order_column is not None and use_input_dataset:
             dataset = _attach_hidden_row_id_column(ray, dataset, hidden_order_column=hidden_order_column)
         input_blocks = _get_num_blocks(dataset)
-        metrics_collector = _create_metrics_collector(ray)
+        metrics_collector = _create_metrics_collector(ray, max_trace_events=self.max_trace_events)
         batch_size = self.batch_size or data_designer._run_config.buffer_size
+        observability_options = _RayObservabilityOptions(
+            profile_workers=self.profile_workers,
+            trace_enabled=self.trace_enabled,
+        )
         throttle_manager = (
             create_ray_throttle_manager(ray, data_designer._run_config)
             if self.global_provider_throttling
@@ -347,6 +443,7 @@ class RayBackend:
             "fn_constructor_kwargs": {
                 "execution_payload": execution_payload,
                 "metrics_collector": metrics_collector,
+                "observability_options": observability_options,
             },
             "batch_size": batch_size,
             "batch_format": "pandas",
@@ -394,6 +491,7 @@ class RayBackend:
             metrics_collector=metrics_collector,
             throttle_manager=throttle_manager,
             output=output,
+            observability_options=observability_options,
         )
 
     def _resolve_input_dataset(
@@ -741,21 +839,48 @@ def _validate_worker_payload_serializable(payload: _RayExecutionPayload) -> None
 
 
 class _RayMetricsCollector:
-    def __init__(self) -> None:
+    def __init__(self, max_trace_events: int = 1000) -> None:
         self._payloads: list[dict[str, Any]] = []
+        self._worker_profiles: list[dict[str, Any]] = []
+        self._trace_events: list[dict[str, Any]] = []
+        self._trace_events_dropped = 0
+        self._throttle_snapshots: list[dict[str, Any]] = []
+        self._max_trace_events = max_trace_events
 
     def record(self, payload: dict[str, Any]) -> None:
         self._payloads.append(payload)
 
+    def record_observability(self, payload: dict[str, Any]) -> None:
+        profile = payload.get("worker_profile")
+        if isinstance(profile, dict):
+            self._worker_profiles.append(profile)
+        for event in payload.get("trace_events", []) or []:
+            if len(self._trace_events) >= self._max_trace_events:
+                self._trace_events_dropped += 1
+                continue
+            if isinstance(event, dict):
+                self._trace_events.append(event)
+        for snapshot in payload.get("throttle_snapshots", []) or []:
+            if isinstance(snapshot, dict):
+                self._throttle_snapshots.append(snapshot)
+
     def snapshot(self) -> list[dict[str, Any]]:
         return list(self._payloads)
 
+    def observability_snapshot(self) -> dict[str, Any]:
+        return {
+            "worker_profiles": list(self._worker_profiles),
+            "trace_events": list(self._trace_events),
+            "trace_events_dropped": self._trace_events_dropped,
+            "throttle_snapshots": list(self._throttle_snapshots),
+        }
 
-def _create_metrics_collector(ray: Any) -> Any | None:
+
+def _create_metrics_collector(ray: Any, *, max_trace_events: int = 1000) -> Any | None:
     remote = getattr(ray, "remote", None)
     if not callable(remote):
         return None
-    return remote(_RayMetricsCollector).remote()
+    return remote(_RayMetricsCollector).remote(max_trace_events=max_trace_events)
 
 
 def _merge_driver_and_worker_metrics(
@@ -934,13 +1059,18 @@ class _RayBatchWorker:
         *,
         execution_payload: _RayExecutionPayload,
         metrics_collector: Any | None = None,
+        observability_options: _RayObservabilityOptions | None = None,
     ) -> None:
         os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1"
         self._execution_payload: _RayExecutionPayload = execution_payload
         self._metrics_collector: Any | None = metrics_collector
+        self._observability_options: _RayObservabilityOptions = observability_options or _RayObservabilityOptions()
         self._base_config: DataDesignerConfig = DataDesignerConfig.model_validate_json(execution_payload.config_json)
         self._artifact_storage: _InMemoryPreviewArtifactStorage = _InMemoryPreviewArtifactStorage()
         worker_options = execution_payload.worker_options
+        run_config = copy.deepcopy(worker_options.run_config)
+        if self._observability_options.trace_enabled:
+            run_config.async_trace = True
         self._seed_reader_registry: SeedReaderRegistry = SeedReaderRegistry(
             readers=copy.deepcopy(worker_options.seed_readers)
         )
@@ -955,7 +1085,7 @@ class _RayBatchWorker:
             seed_reader_registry=self._seed_reader_registry,
             person_reader=worker_options.person_reader or create_person_reader(worker_options.managed_assets_path),
             seed_dataset_source=None,
-            run_config=copy.deepcopy(worker_options.run_config),
+            run_config=run_config,
             mcp_providers=worker_options.mcp_providers,
             tool_configs=self._base_config.tool_configs or [],
             throttle_manager=worker_options.throttle_manager,
@@ -969,12 +1099,50 @@ class _RayBatchWorker:
 
     def generate_batch(self, batch: Any) -> Any:
         start_time = time.perf_counter()
+        block_id = uuid.uuid4().hex
+        observability_options = self._observability_options
+        worker_context = _get_ray_worker_context()
+        trace_events: list[RayTraceEvent] = []
         dataframe = _coerce_pandas_dataframe(batch)
         num_records = len(dataframe)
+        if observability_options.trace_enabled:
+            trace_events.append(
+                _create_trace_event(
+                    block_id,
+                    "block_started",
+                    start_time,
+                    row_count=num_records,
+                    worker_context=worker_context,
+                    details={"input_columns": [str(column) for column in dataframe.columns]},
+                )
+            )
         if num_records == 0:
+            elapsed_seconds = time.perf_counter() - start_time
+            profile = (
+                _profile_worker_output(dataframe, block_id=block_id, model_usage=None)
+                if observability_options.profile_workers
+                else None
+            )
+            if observability_options.trace_enabled:
+                trace_events.append(
+                    _create_trace_event(
+                        block_id,
+                        "block_completed",
+                        start_time,
+                        row_count=0,
+                        worker_context=worker_context,
+                        details={"empty_batch": True},
+                    )
+                )
             _record_worker_metrics(
                 self._metrics_collector,
-                RayWorkerMetrics(total_rows=0, blocks=1, elapsed_seconds=time.perf_counter() - start_time),
+                RayWorkerMetrics(total_rows=0, blocks=1, elapsed_seconds=elapsed_seconds, block_id=block_id),
+            )
+            _record_worker_observability(
+                self._metrics_collector,
+                worker_profile=profile,
+                trace_events=trace_events,
+                throttle_snapshots=[],
             )
             return dataframe
 
@@ -991,6 +1159,16 @@ class _RayBatchWorker:
                 resource_provider=self._resource_provider,
                 use_async=True,
             )
+            if observability_options.trace_enabled:
+                trace_events.append(
+                    _create_trace_event(
+                        block_id,
+                        "generation_started",
+                        start_time,
+                        row_count=num_records,
+                        worker_context=worker_context,
+                    )
+                )
             raw_dataset = builder.build_preview(num_records=num_records)
             output = builder.process_preview(raw_dataset)
             if self._execution_payload.hidden_order_column is not None:
@@ -1000,17 +1178,59 @@ class _RayBatchWorker:
                     hidden_order_column=self._execution_payload.hidden_order_column,
                 )
             elapsed_seconds = time.perf_counter() - start_time
+            model_usage = self._get_model_usage_delta(model_usage_snapshot, elapsed_seconds)
+            if observability_options.trace_enabled:
+                trace_events.extend(
+                    _task_traces_to_events(
+                        builder.task_traces,
+                        block_id=block_id,
+                        worker_context=worker_context,
+                    )
+                )
+                trace_events.append(
+                    _create_trace_event(
+                        block_id,
+                        "block_completed",
+                        start_time,
+                        row_count=len(output),
+                        worker_context=worker_context,
+                        details={"output_columns": [str(column) for column in output.columns]},
+                    )
+                )
+            throttle_snapshots = _snapshot_worker_throttle(self._resource_provider.model_registry.throttle_manager)
             _record_worker_metrics(
                 self._metrics_collector,
                 RayWorkerMetrics(
                     total_rows=len(output),
                     blocks=1,
                     elapsed_seconds=elapsed_seconds,
-                    model_usage=self._get_model_usage_delta(model_usage_snapshot, elapsed_seconds),
+                    model_usage=model_usage,
+                    block_id=block_id,
                 ),
+            )
+            _record_worker_observability(
+                self._metrics_collector,
+                worker_profile=(
+                    _profile_worker_output(output, block_id=block_id, model_usage=model_usage)
+                    if observability_options.profile_workers
+                    else None
+                ),
+                trace_events=trace_events,
+                throttle_snapshots=throttle_snapshots,
             )
             return output
         except Exception as exc:
+            if observability_options.trace_enabled:
+                trace_events.append(
+                    _create_trace_event(
+                        block_id,
+                        "block_failed",
+                        start_time,
+                        row_count=num_records,
+                        worker_context=worker_context,
+                        details={"error_type": type(exc).__name__, "error": str(exc)},
+                    )
+                )
             _record_worker_metrics(
                 self._metrics_collector,
                 RayWorkerMetrics(
@@ -1018,7 +1238,14 @@ class _RayBatchWorker:
                     blocks=1,
                     failed_blocks=1,
                     elapsed_seconds=time.perf_counter() - start_time,
+                    block_id=block_id,
                 ),
+            )
+            _record_worker_observability(
+                self._metrics_collector,
+                worker_profile=None,
+                trace_events=trace_events,
+                throttle_snapshots=[],
             )
             raise RayDatasetGenerationError(_format_worker_failure_message(dataframe=dataframe, exc=exc)) from exc
         finally:
@@ -1089,6 +1316,7 @@ def _generate_batch(
     seed_window: _RaySeedWindow | None = None,
     hidden_order_column: str | None = None,
     metrics_collector: Any | None = None,
+    observability_options: _RayObservabilityOptions | None = None,
 ) -> Any:
     if worker is not None:
         return worker.generate_batch(batch)
@@ -1101,7 +1329,11 @@ def _generate_batch(
         seed_window=seed_window,
         hidden_order_column=hidden_order_column,
     )
-    return _RayBatchWorker(execution_payload=execution_payload, metrics_collector=metrics_collector)(batch)
+    return _RayBatchWorker(
+        execution_payload=execution_payload,
+        metrics_collector=metrics_collector,
+        observability_options=observability_options,
+    )(batch)
 
 
 def _strip_internal_columns(dataframe: Any) -> Any:
@@ -1229,10 +1461,201 @@ def _get_ray_task_context() -> str | None:
     return ", ".join(context_values) if context_values else None
 
 
+def _record_worker_observability(
+    metrics_collector: Any | None,
+    *,
+    worker_profile: RayWorkerProfile | None,
+    trace_events: list[RayTraceEvent],
+    throttle_snapshots: list[RayThrottleSnapshot],
+) -> None:
+    if metrics_collector is None:
+        return
+    payload = {
+        "worker_profile": worker_profile.to_dict() if worker_profile is not None else None,
+        "trace_events": [event.to_dict() for event in trace_events],
+        "throttle_snapshots": [snapshot.to_dict() for snapshot in throttle_snapshots],
+    }
+    importlib.import_module("ray").get(metrics_collector.record_observability.remote(payload))
+
+
 def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:
     if metrics_collector is None:
         return
     importlib.import_module("ray").get(metrics_collector.record.remote(metrics.to_dict()))
+
+
+def _profile_worker_output(
+    output: Any, *, block_id: str, model_usage: dict[str, dict[str, Any]] | None
+) -> RayWorkerProfile:
+    warnings: list[str] = []
+    try:
+        columns = [str(column) for column in output.columns]
+        column_dtypes = {str(column): str(dtype) for column, dtype in output.dtypes.items()}
+        non_null_counts = {str(column): int(value) for column, value in output.notna().sum().to_dict().items()}
+        null_counts = {str(column): int(value) for column, value in output.isna().sum().to_dict().items()}
+        memory_usage_bytes = int(output.memory_usage(deep=True).sum())
+    except Exception as exc:
+        columns = []
+        column_dtypes = {}
+        non_null_counts = {}
+        null_counts = {}
+        memory_usage_bytes = None
+        warnings.append(f"Failed to profile Ray worker output: {type(exc).__name__}: {exc}")
+    return RayWorkerProfile(
+        block_id=block_id,
+        total_rows=len(output),
+        columns=columns,
+        column_dtypes=column_dtypes,
+        non_null_counts=non_null_counts,
+        null_counts=null_counts,
+        memory_usage_bytes=memory_usage_bytes,
+        model_usage=model_usage,
+        warnings=warnings,
+    )
+
+
+def _snapshot_worker_throttle(throttle_manager: Any | None) -> list[RayThrottleSnapshot]:
+    if throttle_manager is None:
+        return []
+    domains = getattr(throttle_manager, "_domains", None)
+    if not isinstance(domains, dict):
+        return []
+    get_effective_max = getattr(throttle_manager, "get_effective_max", None)
+    snapshots: list[RayThrottleSnapshot] = []
+    for key, state in domains.items():
+        if not isinstance(key, tuple) or len(key) != 3:
+            continue
+        provider_name, model_id, domain = key
+        if not all(isinstance(value, str) for value in (provider_name, model_id, domain)):
+            continue
+        effective_max = get_effective_max(provider_name, model_id) if callable(get_effective_max) else None
+        snapshots.append(
+            RayThrottleSnapshot(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                current_limit=_safe_int_attr(state, "current_limit"),
+                effective_max=effective_max,
+                in_flight=_safe_int_attr(state, "in_flight"),
+                waiters=_safe_int_attr(state, "waiters"),
+                rate_limit_ceiling=_safe_int_attr(state, "rate_limit_ceiling"),
+                consecutive_rate_limits=_safe_int_attr(state, "consecutive_429s"),
+            )
+        )
+    return snapshots
+
+
+def _task_traces_to_events(
+    task_traces: list[Any],
+    *,
+    block_id: str,
+    worker_context: dict[str, Any],
+) -> list[RayTraceEvent]:
+    events: list[RayTraceEvent] = []
+    for task_trace in task_traces:
+        dispatched_at = _safe_float_attr(task_trace, "dispatched_at")
+        slot_acquired_at = _safe_float_attr(task_trace, "slot_acquired_at")
+        completed_at = _safe_float_attr(task_trace, "completed_at")
+        elapsed_seconds = max(completed_at - dispatched_at, 0.0) if completed_at > 0 and dispatched_at > 0 else 0.0
+        wait_seconds = max(slot_acquired_at - dispatched_at, 0.0) if slot_acquired_at > 0 and dispatched_at > 0 else 0.0
+        run_seconds = max(completed_at - slot_acquired_at, 0.0) if completed_at > 0 and slot_acquired_at > 0 else 0.0
+        events.append(
+            RayTraceEvent(
+                block_id=block_id,
+                event_type="engine_task",
+                timestamp_seconds=time.time(),
+                elapsed_seconds=elapsed_seconds,
+                row_count=0,
+                worker_hostname=worker_context["worker_hostname"],
+                worker_pid=worker_context["worker_pid"],
+                ray_task_id=worker_context.get("ray_task_id"),
+                ray_node_id=worker_context.get("ray_node_id"),
+                details={
+                    "column": getattr(task_trace, "column", None),
+                    "row_group": getattr(task_trace, "row_group", None),
+                    "row_index": getattr(task_trace, "row_index", None),
+                    "task_type": getattr(task_trace, "task_type", None),
+                    "status": getattr(task_trace, "status", None),
+                    "error": getattr(task_trace, "error", None),
+                    "queue_wait_seconds": wait_seconds,
+                    "run_seconds": run_seconds,
+                },
+            )
+        )
+    return events
+
+
+def _create_trace_event(
+    block_id: str,
+    event_type: str,
+    start_time: float,
+    *,
+    row_count: int,
+    worker_context: dict[str, Any],
+    details: dict[str, Any] | None = None,
+) -> RayTraceEvent:
+    return RayTraceEvent(
+        block_id=block_id,
+        event_type=event_type,
+        timestamp_seconds=time.time(),
+        elapsed_seconds=time.perf_counter() - start_time,
+        row_count=row_count,
+        worker_hostname=worker_context["worker_hostname"],
+        worker_pid=worker_context["worker_pid"],
+        ray_task_id=worker_context.get("ray_task_id"),
+        ray_node_id=worker_context.get("ray_node_id"),
+        details=details,
+    )
+
+
+def _get_ray_worker_context() -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "worker_hostname": socket.gethostname(),
+        "worker_pid": os.getpid(),
+        "ray_task_id": None,
+        "ray_node_id": None,
+    }
+    try:
+        ray = importlib.import_module("ray")
+        get_runtime_context = getattr(ray, "get_runtime_context", None)
+        runtime_context = get_runtime_context() if callable(get_runtime_context) else None
+    except Exception:
+        runtime_context = None
+    if runtime_context is None:
+        return context
+    context["ray_task_id"] = _runtime_context_value(runtime_context, "get_task_id")
+    context["ray_node_id"] = _runtime_context_value(runtime_context, "get_node_id")
+    return context
+
+
+def _runtime_context_value(runtime_context: Any, method_name: str) -> str | None:
+    method = getattr(runtime_context, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        value = method()
+    except Exception:
+        return None
+    return str(value) if value is not None else None
+
+
+def _safe_int_attr(value: Any, attr_name: str) -> int:
+    attr = getattr(value, attr_name, 0)
+    return attr if isinstance(attr, int) and not isinstance(attr, bool) and attr >= 0 else 0
+
+
+def _safe_float_attr(value: Any, attr_name: str) -> float:
+    attr = getattr(value, attr_name, 0.0)
+    return float(attr) if isinstance(attr, (int, float)) and not isinstance(attr, bool) and attr >= 0 else 0.0
+
+
+def _has_observability_payload(payload: dict[str, Any]) -> bool:
+    return bool(
+        payload.get("worker_profiles")
+        or payload.get("trace_events")
+        or payload.get("trace_events_dropped")
+        or payload.get("throttle_snapshots")
+    )
 
 
 def _coerce_pandas_dataframe(batch: Any) -> Any:

--- a/packages/data-designer/src/data_designer/integrations/ray/metrics.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/metrics.py
@@ -47,6 +47,7 @@ class RayDatasetMetrics:
     failed_blocks: int = 0
     elapsed_seconds: float = 0.0
     model_usage: ModelUsageSummary | None = None
+    throttle: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         _validate_non_negative_int("total_rows", self.total_rows)

--- a/packages/data-designer/src/data_designer/integrations/ray/metrics.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/metrics.py
@@ -22,12 +22,15 @@ class RayWorkerMetrics:
     failed_blocks: int = 0
     elapsed_seconds: float = 0.0
     model_usage: ModelUsageSummary | None = None
+    block_id: str | None = None
 
     def __post_init__(self) -> None:
         _validate_non_negative_int("total_rows", self.total_rows)
         _validate_non_negative_int("blocks", self.blocks)
         _validate_non_negative_int("failed_blocks", self.failed_blocks)
         _validate_non_negative_float("elapsed_seconds", self.elapsed_seconds)
+        if self.block_id is not None and not isinstance(self.block_id, str):
+            raise RayMetricsError("Ray metrics field 'block_id' must be a string when provided.")
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation."""
@@ -114,6 +117,7 @@ def normalize_ray_worker_metrics(payload: RayMetricsPayload) -> RayWorkerMetrics
             failed_blocks=payload.failed_blocks,
             elapsed_seconds=payload.elapsed_seconds,
             model_usage=payload.model_usage,
+            block_id=None,
         )
     if isinstance(payload, RayWorkerMetrics):
         return payload
@@ -126,6 +130,7 @@ def normalize_ray_worker_metrics(payload: RayMetricsPayload) -> RayWorkerMetrics
         failed_blocks=_coerce_int(payload, "failed_blocks", default=0),
         elapsed_seconds=_coerce_float(payload, "elapsed_seconds", default=0.0),
         model_usage=_coerce_model_usage(payload.get("model_usage")),
+        block_id=_coerce_optional_str(payload.get("block_id")),
     )
 
 
@@ -157,6 +162,14 @@ def _coerce_model_usage(value: Any) -> ModelUsageSummary | None:
             raise RayMetricsError(f"Ray metrics model usage for {model_name!r} must be a mapping.")
         model_usage[model_name] = dict(stats)
     return model_usage
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RayMetricsError("Ray metrics field 'block_id' must be a string when provided.")
+    return value
 
 
 def _validate_non_negative_int(field_name: str, value: int) -> None:

--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import html
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from data_designer.integrations.ray.errors import RayMetricsError
+
+ModelUsageSummary = dict[str, dict[str, Any]]
+RayTraceEventPayload: TypeAlias = "RayTraceEvent | Mapping[str, Any]"
+RayWorkerProfilePayload: TypeAlias = "RayWorkerProfile | Mapping[str, Any]"
+RayThrottleSnapshotPayload: TypeAlias = "RayThrottleSnapshot | Mapping[str, Any]"
+
+
+@dataclass(frozen=True, slots=True)
+class RayTraceEvent:
+    """Bounded execution trace event emitted by a Ray worker."""
+
+    block_id: str
+    event_type: str
+    timestamp_seconds: float
+    elapsed_seconds: float = 0.0
+    row_count: int = 0
+    worker_hostname: str | None = None
+    worker_pid: int | None = None
+    ray_task_id: str | None = None
+    ray_node_id: str | None = None
+    details: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str("block_id", self.block_id)
+        _validate_non_empty_str("event_type", self.event_type)
+        _validate_non_negative_float("timestamp_seconds", self.timestamp_seconds)
+        _validate_non_negative_float("elapsed_seconds", self.elapsed_seconds)
+        _validate_non_negative_int("row_count", self.row_count)
+        if self.worker_pid is not None:
+            _validate_non_negative_int("worker_pid", self.worker_pid)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RayWorkerProfile:
+    """Small per-block profiler summary that does not materialize the full dataset on the driver."""
+
+    block_id: str
+    total_rows: int = 0
+    columns: list[str] = field(default_factory=list)
+    column_dtypes: dict[str, str] = field(default_factory=dict)
+    non_null_counts: dict[str, int] = field(default_factory=dict)
+    null_counts: dict[str, int] = field(default_factory=dict)
+    memory_usage_bytes: int | None = None
+    model_usage: ModelUsageSummary | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str("block_id", self.block_id)
+        _validate_non_negative_int("total_rows", self.total_rows)
+        if self.memory_usage_bytes is not None:
+            _validate_non_negative_int("memory_usage_bytes", self.memory_usage_bytes)
+        for column in self.columns:
+            _validate_non_empty_str("columns item", column)
+        for field_name, counts in (("non_null_counts", self.non_null_counts), ("null_counts", self.null_counts)):
+            for column_name, value in counts.items():
+                _validate_non_empty_str(f"{field_name} key", column_name)
+                _validate_non_negative_int(f"{field_name}[{column_name!r}]", value)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RayThrottleSnapshot:
+    """Worker-local throttle state snapshot for provider throttling diagnosis."""
+
+    provider_name: str
+    model_id: str
+    domain: str
+    current_limit: int
+    effective_max: int | None = None
+    in_flight: int = 0
+    waiters: int = 0
+    rate_limit_ceiling: int = 0
+    consecutive_rate_limits: int = 0
+
+    def __post_init__(self) -> None:
+        _validate_non_empty_str("provider_name", self.provider_name)
+        _validate_non_empty_str("model_id", self.model_id)
+        _validate_non_empty_str("domain", self.domain)
+        _validate_non_negative_int("current_limit", self.current_limit)
+        if self.effective_max is not None:
+            _validate_non_negative_int("effective_max", self.effective_max)
+        _validate_non_negative_int("in_flight", self.in_flight)
+        _validate_non_negative_int("waiters", self.waiters)
+        _validate_non_negative_int("rate_limit_ceiling", self.rate_limit_ceiling)
+        _validate_non_negative_int("consecutive_rate_limits", self.consecutive_rate_limits)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RayDatasetAnalysis:
+    """Ray-native analysis artifact composed from bounded worker summaries."""
+
+    total_rows: int = 0
+    blocks: int = 0
+    failed_blocks: int = 0
+    worker_profiles: list[RayWorkerProfile] = field(default_factory=list)
+    trace_events: list[RayTraceEvent] = field(default_factory=list)
+    trace_events_dropped: int = 0
+    throttle_snapshots: list[RayThrottleSnapshot] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        _validate_non_negative_int("total_rows", self.total_rows)
+        _validate_non_negative_int("blocks", self.blocks)
+        _validate_non_negative_int("failed_blocks", self.failed_blocks)
+        _validate_non_negative_int("trace_events_dropped", self.trace_events_dropped)
+
+    @property
+    def successful_blocks(self) -> int:
+        """Return completed block count after failed blocks are subtracted."""
+        return max(self.blocks - self.failed_blocks, 0)
+
+    @property
+    def column_names(self) -> list[str]:
+        """Return sorted unique column names observed across worker profiles."""
+        return sorted({column for profile in self.worker_profiles for column in profile.columns})
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+    def to_report(self, save_path: str | Path | None = None, include_sections: list[Any] | None = None) -> None:
+        """Write a compact JSON or HTML report for Ray-native analysis."""
+        del include_sections
+        if save_path is None:
+            return
+        path = Path(save_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(self.to_dict(), indent=2, sort_keys=True)
+        if path.suffix.lower() in {".html", ".htm"}:
+            path.write_text(_analysis_payload_to_html(payload), encoding="utf-8")
+            return
+        path.write_text(f"{payload}\n", encoding="utf-8")
+
+
+def normalize_ray_trace_event(payload: RayTraceEventPayload) -> RayTraceEvent:
+    """Normalize a trace dataclass or mapping payload."""
+    if isinstance(payload, RayTraceEvent):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise RayMetricsError(f"Ray trace event payload must be a mapping, got {type(payload)!r}.")
+    return RayTraceEvent(
+        block_id=_coerce_str(payload, "block_id"),
+        event_type=_coerce_str(payload, "event_type"),
+        timestamp_seconds=_coerce_float(payload, "timestamp_seconds", default=0.0),
+        elapsed_seconds=_coerce_float(payload, "elapsed_seconds", default=0.0),
+        row_count=_coerce_int(payload, "row_count", default=0),
+        worker_hostname=_coerce_optional_str(payload.get("worker_hostname")),
+        worker_pid=_coerce_optional_int(payload.get("worker_pid"), "worker_pid"),
+        ray_task_id=_coerce_optional_str(payload.get("ray_task_id")),
+        ray_node_id=_coerce_optional_str(payload.get("ray_node_id")),
+        details=_coerce_optional_mapping(payload.get("details")),
+    )
+
+
+def normalize_ray_worker_profile(payload: RayWorkerProfilePayload) -> RayWorkerProfile:
+    """Normalize a worker profile dataclass or mapping payload."""
+    if isinstance(payload, RayWorkerProfile):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise RayMetricsError(f"Ray worker profile payload must be a mapping, got {type(payload)!r}.")
+    return RayWorkerProfile(
+        block_id=_coerce_str(payload, "block_id"),
+        total_rows=_coerce_int(payload, "total_rows", default=0),
+        columns=_coerce_str_list(payload.get("columns")),
+        column_dtypes=_coerce_str_mapping(payload.get("column_dtypes")),
+        non_null_counts=_coerce_int_mapping(payload.get("non_null_counts")),
+        null_counts=_coerce_int_mapping(payload.get("null_counts")),
+        memory_usage_bytes=_coerce_optional_int(payload.get("memory_usage_bytes"), "memory_usage_bytes"),
+        model_usage=_coerce_model_usage(payload.get("model_usage")),
+        warnings=_coerce_str_list(payload.get("warnings")),
+    )
+
+
+def normalize_ray_throttle_snapshot(payload: RayThrottleSnapshotPayload) -> RayThrottleSnapshot:
+    """Normalize a throttle snapshot dataclass or mapping payload."""
+    if isinstance(payload, RayThrottleSnapshot):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise RayMetricsError(f"Ray throttle snapshot payload must be a mapping, got {type(payload)!r}.")
+    return RayThrottleSnapshot(
+        provider_name=_coerce_str(payload, "provider_name"),
+        model_id=_coerce_str(payload, "model_id"),
+        domain=_coerce_str(payload, "domain"),
+        current_limit=_coerce_int(payload, "current_limit", default=0),
+        effective_max=_coerce_optional_int(payload.get("effective_max"), "effective_max"),
+        in_flight=_coerce_int(payload, "in_flight", default=0),
+        waiters=_coerce_int(payload, "waiters", default=0),
+        rate_limit_ceiling=_coerce_int(payload, "rate_limit_ceiling", default=0),
+        consecutive_rate_limits=_coerce_int(payload, "consecutive_rate_limits", default=0),
+    )
+
+
+def _analysis_payload_to_html(payload: str) -> str:
+    escaped = html.escape(payload)
+    return (
+        "<!doctype html>\n"
+        '<html><head><meta charset="utf-8"><title>Data Designer Ray Analysis</title></head>'
+        "<body><h1>Data Designer Ray Analysis</h1><pre>"
+        f"{escaped}"
+        "</pre></body></html>\n"
+    )
+
+
+def _coerce_str(payload: Mapping[str, Any], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be a string.")
+    return value
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RayMetricsError("Ray observability optional string fields must be strings when provided.")
+    return value
+
+
+def _coerce_int(payload: Mapping[str, Any], field_name: str, *, default: int) -> int:
+    value = payload.get(field_name, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be an integer.")
+    return value
+
+
+def _coerce_optional_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be an integer when provided.")
+    return value
+
+
+def _coerce_float(payload: Mapping[str, Any], field_name: str, *, default: float) -> float:
+    value = payload.get(field_name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be numeric.")
+    return float(value)
+
+
+def _coerce_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RayMetricsError("Ray observability list fields must be lists when provided.")
+    if not all(isinstance(item, str) for item in value):
+        raise RayMetricsError("Ray observability list field values must be strings.")
+    return list(value)
+
+
+def _coerce_str_mapping(value: Any) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise RayMetricsError("Ray observability string mapping fields must be mappings when provided.")
+    output: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise RayMetricsError("Ray observability string mapping keys and values must be strings.")
+        output[key] = item
+    return output
+
+
+def _coerce_int_mapping(value: Any) -> dict[str, int]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise RayMetricsError("Ray observability count mapping fields must be mappings when provided.")
+    output: dict[str, int] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or isinstance(item, bool) or not isinstance(item, int):
+            raise RayMetricsError("Ray observability count mapping keys must be strings and values must be integers.")
+        output[key] = item
+    return output
+
+
+def _coerce_optional_mapping(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise RayMetricsError("Ray observability details must be a mapping when provided.")
+    return dict(value)
+
+
+def _coerce_model_usage(value: Any) -> ModelUsageSummary | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise RayMetricsError("Ray observability model_usage must be a mapping when provided.")
+    model_usage: ModelUsageSummary = {}
+    for model_name, stats in value.items():
+        if not isinstance(model_name, str):
+            raise RayMetricsError("Ray observability model usage keys must be strings.")
+        if not isinstance(stats, Mapping):
+            raise RayMetricsError(f"Ray observability model usage for {model_name!r} must be a mapping.")
+        model_usage[model_name] = dict(stats)
+    return model_usage
+
+
+def _validate_non_empty_str(field_name: str, value: str) -> None:
+    if not isinstance(value, str) or value == "":
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be a non-empty string.")
+
+
+def _validate_non_negative_int(field_name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be an integer.")
+    if value < 0:
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be non-negative.")
+
+
+def _validate_non_negative_float(field_name: str, value: float) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be numeric.")
+    if value < 0:
+        raise RayMetricsError(f"Ray observability field {field_name!r} must be non-negative.")

--- a/packages/data-designer/src/data_designer/integrations/ray/options.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/options.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+RayMapConcurrency = int | tuple[int, int] | tuple[int, int, int]
+
+
+@dataclass(frozen=True, slots=True)
+class RayResolvedBlockPlan:
+    """Resolved Ray Data read planning options for from-scratch generation."""
+
+    override_num_blocks: int | None = None
+    read_concurrency: int | None = None
+    planned_blocks: int | None = None
+
+    def to_range_kwargs(self) -> dict[str, int]:
+        """Return keyword arguments accepted by ``ray.data.range``."""
+        kwargs: dict[str, int] = {}
+        if self.override_num_blocks is not None:
+            kwargs["override_num_blocks"] = self.override_num_blocks
+        if self.read_concurrency is not None:
+            kwargs["concurrency"] = self.read_concurrency
+        return kwargs
+
+
+@dataclass(frozen=True, slots=True)
+class RayBlockPlanning:
+    """Controls for Ray Data block creation when RayBackend creates a range dataset."""
+
+    override_num_blocks: int | None = None
+    target_block_size: int | None = None
+    min_blocks: int | None = None
+    max_blocks: int | None = None
+    read_concurrency: int | None = None
+
+    def __post_init__(self) -> None:
+        _validate_optional_positive_int("override_num_blocks", self.override_num_blocks)
+        _validate_optional_positive_int("target_block_size", self.target_block_size)
+        _validate_optional_positive_int("min_blocks", self.min_blocks)
+        _validate_optional_positive_int("max_blocks", self.max_blocks)
+        _validate_optional_positive_int("read_concurrency", self.read_concurrency)
+        if self.override_num_blocks is not None and any(
+            value is not None for value in (self.target_block_size, self.min_blocks, self.max_blocks)
+        ):
+            raise ValueError(
+                "RayBlockPlanning override_num_blocks cannot be combined with target_block_size, "
+                "min_blocks, or max_blocks."
+            )
+        if self.min_blocks is not None and self.max_blocks is not None and self.min_blocks > self.max_blocks:
+            raise ValueError("RayBlockPlanning min_blocks must be less than or equal to max_blocks.")
+        if self.target_block_size is None and (self.min_blocks is not None or self.max_blocks is not None):
+            raise ValueError("RayBlockPlanning min_blocks and max_blocks require target_block_size.")
+
+    @property
+    def has_explicit_controls(self) -> bool:
+        """Return whether any from-scratch read planning control was configured."""
+        return any(
+            value is not None
+            for value in (
+                self.override_num_blocks,
+                self.target_block_size,
+                self.min_blocks,
+                self.max_blocks,
+                self.read_concurrency,
+            )
+        )
+
+    def resolve(self, *, num_records: int) -> RayResolvedBlockPlan:
+        """Resolve configured planning controls for a concrete record count."""
+        if num_records < 0:
+            raise ValueError("RayBlockPlanning num_records must be non-negative.")
+        if self.override_num_blocks is not None:
+            return RayResolvedBlockPlan(
+                override_num_blocks=self.override_num_blocks,
+                read_concurrency=self.read_concurrency,
+                planned_blocks=self.override_num_blocks,
+            )
+        if self.target_block_size is None:
+            return RayResolvedBlockPlan(read_concurrency=self.read_concurrency)
+
+        planned_blocks = max(math.ceil(max(num_records, 1) / self.target_block_size), 1)
+        if self.min_blocks is not None:
+            planned_blocks = max(planned_blocks, self.min_blocks)
+        if self.max_blocks is not None:
+            planned_blocks = min(planned_blocks, self.max_blocks)
+        if num_records > 0:
+            planned_blocks = min(planned_blocks, num_records)
+        return RayResolvedBlockPlan(
+            override_num_blocks=planned_blocks,
+            read_concurrency=self.read_concurrency,
+            planned_blocks=planned_blocks,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RayExecutionOptions:
+    """Validated Ray Data ``map_batches`` execution options."""
+
+    num_cpus: float | None = None
+    num_gpus: float | None = None
+    memory: float | None = None
+    resources: Mapping[str, float] | None = None
+    scheduling_strategy: Any | None = None
+    compute: Any | None = None
+    concurrency: RayMapConcurrency | None = None
+    ray_remote_args_fn: Any | None = None
+    ray_remote_args: Mapping[str, Any] | None = None
+    use_actor_pool: bool = False
+    actor_pool_min_size: int | None = None
+    actor_pool_max_size: int | None = None
+    actor_pool_initial_size: int | None = None
+
+    def __post_init__(self) -> None:
+        _validate_optional_non_negative_number("num_cpus", self.num_cpus)
+        _validate_optional_non_negative_number("num_gpus", self.num_gpus)
+        _validate_optional_positive_number("memory", self.memory)
+        _validate_resources(self.resources)
+        if isinstance(self.scheduling_strategy, str) and not self.scheduling_strategy:
+            raise ValueError("RayExecutionOptions scheduling_strategy must be non-empty when provided.")
+        if self.compute is not None and self.use_actor_pool:
+            raise ValueError("RayExecutionOptions compute cannot be combined with use_actor_pool=True.")
+        if self.compute is not None and self.concurrency is not None:
+            raise ValueError("RayExecutionOptions compute cannot be combined with concurrency.")
+        _validate_map_concurrency(self.concurrency)
+        _validate_optional_positive_int("actor_pool_min_size", self.actor_pool_min_size)
+        _validate_optional_positive_int("actor_pool_max_size", self.actor_pool_max_size)
+        _validate_optional_positive_int("actor_pool_initial_size", self.actor_pool_initial_size)
+        if self.actor_pool_min_size is not None and not self.use_actor_pool:
+            raise ValueError("RayExecutionOptions actor_pool_min_size requires use_actor_pool=True.")
+        if self.actor_pool_max_size is not None and not self.use_actor_pool:
+            raise ValueError("RayExecutionOptions actor_pool_max_size requires use_actor_pool=True.")
+        if self.actor_pool_initial_size is not None and not self.use_actor_pool:
+            raise ValueError("RayExecutionOptions actor_pool_initial_size requires use_actor_pool=True.")
+        if (
+            self.actor_pool_min_size is not None
+            and self.actor_pool_max_size is not None
+            and self.actor_pool_min_size > self.actor_pool_max_size
+        ):
+            raise ValueError("RayExecutionOptions actor_pool_min_size must be less than or equal to max_size.")
+        if self.actor_pool_initial_size is not None:
+            if self.actor_pool_min_size is not None and self.actor_pool_initial_size < self.actor_pool_min_size:
+                raise ValueError("RayExecutionOptions actor_pool_initial_size must be at least actor_pool_min_size.")
+            if self.actor_pool_max_size is not None and self.actor_pool_initial_size > self.actor_pool_max_size:
+                raise ValueError("RayExecutionOptions actor_pool_initial_size must be at most actor_pool_max_size.")
+        _validate_remote_arg_conflicts(self)
+
+    def to_map_batches_kwargs(self, ray: Any | None = None) -> dict[str, Any]:
+        """Return keyword arguments accepted by ``Dataset.map_batches``."""
+        kwargs: dict[str, Any] = {}
+        _set_if_not_none(kwargs, "num_cpus", self.num_cpus)
+        _set_if_not_none(kwargs, "num_gpus", self.num_gpus)
+        _set_if_not_none(kwargs, "memory", self.memory)
+        if self.resources is not None:
+            kwargs["resources"] = dict(self.resources)
+        _set_if_not_none(kwargs, "scheduling_strategy", self.scheduling_strategy)
+        _set_if_not_none(kwargs, "compute", self.compute)
+        _set_if_not_none(kwargs, "concurrency", self.concurrency)
+        _set_if_not_none(kwargs, "ray_remote_args_fn", self.ray_remote_args_fn)
+        if self.ray_remote_args is not None:
+            kwargs.update(dict(self.ray_remote_args))
+        if self.use_actor_pool:
+            if ray is None:
+                raise ValueError("RayExecutionOptions use_actor_pool=True requires an imported ray module.")
+            kwargs["compute"] = _create_actor_pool_strategy(ray, self)
+        return kwargs
+
+
+def _validate_optional_positive_int(field_name: str, value: int | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"Ray option {field_name} must be a positive integer.")
+
+
+def _validate_optional_non_negative_number(field_name: str, value: float | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise ValueError(f"Ray option {field_name} must be a non-negative number.")
+
+
+def _validate_optional_positive_number(field_name: str, value: float | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ValueError(f"Ray option {field_name} must be a positive number.")
+
+
+def _validate_resources(resources: Mapping[str, float] | None) -> None:
+    if resources is None:
+        return
+    for name, value in resources.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError("RayExecutionOptions resource names must be non-empty strings.")
+        _validate_optional_positive_number(f"resources[{name!r}]", value)
+
+
+def _validate_map_concurrency(value: RayMapConcurrency | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, int):
+        _validate_optional_positive_int("concurrency", value)
+        return
+    if not isinstance(value, tuple) or len(value) not in (2, 3):
+        raise ValueError("RayExecutionOptions concurrency must be a positive integer or a 2/3-item tuple.")
+    for index, item in enumerate(value):
+        _validate_optional_positive_int(f"concurrency[{index}]", item)
+    if value[0] > value[1]:
+        raise ValueError("RayExecutionOptions concurrency minimum must be less than or equal to maximum.")
+    if len(value) == 3 and not value[0] <= value[2] <= value[1]:
+        raise ValueError("RayExecutionOptions concurrency initial size must be within the min/max range.")
+
+
+def _validate_remote_arg_conflicts(options: RayExecutionOptions) -> None:
+    if options.ray_remote_args is None:
+        return
+    explicit_fields = {
+        "num_cpus": options.num_cpus,
+        "num_gpus": options.num_gpus,
+        "memory": options.memory,
+        "resources": options.resources,
+        "scheduling_strategy": options.scheduling_strategy,
+        "compute": options.compute if not options.use_actor_pool else True,
+        "concurrency": options.concurrency,
+        "ray_remote_args_fn": options.ray_remote_args_fn,
+    }
+    conflicts = sorted(
+        name for name, value in explicit_fields.items() if value is not None and name in options.ray_remote_args
+    )
+    if conflicts:
+        conflict_list = ", ".join(conflicts)
+        raise ValueError(
+            f"RayExecutionOptions received duplicate explicit and ray_remote_args values: {conflict_list}."
+        )
+
+
+def _create_actor_pool_strategy(ray: Any, options: RayExecutionOptions) -> Any:
+    actor_pool_strategy = getattr(ray.data, "ActorPoolStrategy", None)
+    if not callable(actor_pool_strategy):
+        raise ValueError("RayExecutionOptions use_actor_pool=True requires ray.data.ActorPoolStrategy.")
+    kwargs: dict[str, int] = {}
+    _set_if_not_none(kwargs, "min_size", options.actor_pool_min_size or 1)
+    _set_if_not_none(kwargs, "max_size", options.actor_pool_max_size)
+    _set_if_not_none(kwargs, "initial_size", options.actor_pool_initial_size)
+    return actor_pool_strategy(**kwargs)
+
+
+def _set_if_not_none(target: dict[str, Any], key: str, value: Any | None) -> None:
+    if value is not None:
+        target[key] = value

--- a/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from data_designer.config.base import ProcessorConfig
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.processors import ProcessorDistributedSafety
+from data_designer.integrations.ray.errors import RayBackendConfigurationError
+
+
+def validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
+    """Validate that configured processors are explicitly safe for Ray execution."""
+    unsupported: list[str] = []
+    for processor in config_builder.get_processor_configs():
+        safety = _get_distributed_safety(processor)
+        if safety is None or not safety.ray_safe or safety.requires_global_order:
+            unsupported.append(_format_processor_violation(processor, safety))
+
+    if not unsupported:
+        return
+
+    raise RayBackendConfigurationError(
+        "RayBackend supports only processors explicitly declared distributed-safe. "
+        f"Unsupported processor(s): {'; '.join(unsupported)}. "
+        "Review the processor's distributed_safety metadata, or pass "
+        "allow_unsafe_processors=True to bypass this experimental guard."
+    )
+
+
+def _get_distributed_safety(processor: ProcessorConfig) -> ProcessorDistributedSafety | None:
+    safety = getattr(processor, "distributed_safety", None)
+    if isinstance(safety, ProcessorDistributedSafety):
+        return safety
+    return None
+
+
+def _format_processor_violation(processor: ProcessorConfig, safety: ProcessorDistributedSafety | None) -> str:
+    processor_type = getattr(processor.processor_type, "value", processor.processor_type)
+    label = f"{processor.name} ({processor_type})"
+    if safety is None:
+        return f"{label}: missing distributed_safety metadata"
+
+    reasons: list[str] = []
+    if not safety.ray_safe:
+        reasons.append("ray_safe=False")
+    if safety.requires_global_order:
+        reasons.append("requires_global_order=True")
+    reasons.append(f"side_effects={safety.side_effects}")
+    if safety.reason is not None:
+        reasons.append(f"reason={safety.reason}")
+    return f"{label}: {', '.join(reasons)}"

--- a/packages/data-designer/src/data_designer/integrations/ray/throttling.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/throttling.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import time
+from typing import Any
+
+from data_designer.config.run_config import RunConfig, ThrottleConfig
+from data_designer.engine.models.clients.throttle_manager import (
+    CAPACITY_POLL_INTERVAL,
+    DEFAULT_ACQUIRE_TIMEOUT,
+    ThrottleDomain,
+    ThrottleManager,
+)
+from data_designer.integrations.ray.errors import RayDatasetGenerationError
+
+
+class RayThrottleCoordinator:
+    """Ray actor payload that owns job-wide provider throttle state."""
+
+    def __init__(self, throttle_config: ThrottleConfig | None = None) -> None:
+        self._manager = ThrottleManager(throttle_config)
+
+    def register(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        alias: str,
+        max_parallel_requests: int,
+    ) -> None:
+        self._manager.register(
+            provider_name=provider_name,
+            model_id=model_id,
+            alias=alias,
+            max_parallel_requests=max_parallel_requests,
+        )
+
+    def try_acquire(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> float:
+        return self._manager.try_acquire(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            now=now,
+        )
+
+    def release_success(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        self._manager.release_success(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            now=now,
+        )
+
+    def release_rate_limited(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None:
+        self._manager.release_rate_limited(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            retry_after=retry_after,
+            now=now,
+        )
+
+    def release_failure(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        self._manager.release_failure(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            now=now,
+        )
+
+    def snapshot(self) -> dict[str, object]:
+        return self._manager.snapshot()
+
+
+class RayThrottleManagerProxy:
+    """Throttle manager interface backed by a Ray actor.
+
+    Acquire loops run in the caller process so the coordinator actor remains
+    available to process release calls from other workers.
+    """
+
+    def __init__(self, coordinator: Any) -> None:
+        self._coordinator = coordinator
+
+    def register(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        alias: str,
+        max_parallel_requests: int,
+    ) -> None:
+        _ray_get(
+            self._coordinator.register.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                alias=alias,
+                max_parallel_requests=max_parallel_requests,
+            )
+        )
+
+    def try_acquire(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> float:
+        return float(
+            _ray_get(
+                self._coordinator.try_acquire.remote(
+                    provider_name=provider_name,
+                    model_id=model_id,
+                    domain=domain,
+                    now=now,
+                )
+            )
+        )
+
+    def acquire_sync(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+        while wait != 0.0:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or wait > remaining:
+                raise TimeoutError(
+                    f"Ray throttle acquire timed out after {timeout:.0f}s "
+                    f"for {provider_name}/{model_id} [{domain.value}]"
+                )
+            time.sleep(min(wait, remaining, CAPACITY_POLL_INTERVAL))
+            wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+
+    async def acquire_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+        while wait != 0.0:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or wait > remaining:
+                raise TimeoutError(
+                    f"Ray throttle acquire timed out after {timeout:.0f}s "
+                    f"for {provider_name}/{model_id} [{domain.value}]"
+                )
+            await asyncio.sleep(min(wait, remaining, CAPACITY_POLL_INTERVAL))
+            wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+
+    def release_success(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        _ray_get(
+            self._coordinator.release_success.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                now=now,
+            )
+        )
+
+    def release_rate_limited(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None:
+        _ray_get(
+            self._coordinator.release_rate_limited.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                retry_after=retry_after,
+                now=now,
+            )
+        )
+
+    def release_failure(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        _ray_get(
+            self._coordinator.release_failure.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                now=now,
+            )
+        )
+
+    def snapshot(self) -> dict[str, object]:
+        return dict(_ray_get(self._coordinator.snapshot.remote()))
+
+
+def create_ray_throttle_manager(ray: Any, run_config: RunConfig) -> RayThrottleManagerProxy:
+    """Create a Ray actor-backed throttle manager for one RayBackend job."""
+    remote = getattr(ray, "remote", None)
+    if not callable(remote):
+        raise RayDatasetGenerationError("RayBackend global provider throttling requires ray.remote.")
+    coordinator = remote(RayThrottleCoordinator).remote(run_config.throttle)
+    return RayThrottleManagerProxy(coordinator)
+
+
+def _ray_get(ref: Any) -> Any:
+    try:
+        return importlib.import_module("ray").get(ref)
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend global provider throttle coordination failed.") from exc

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -18,20 +18,41 @@ from data_designer.config.run_config import RunConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
-from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetMetrics
+from data_designer.integrations.ray import (
+    RayBackend,
+    RayBackendConfigurationError,
+    RayDatasetCreationResults,
+    RayDatasetGenerationError,
+    RayDatasetMetrics,
+)
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
 
 
 class FakeRayDataset:
-    def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
+    def __init__(self, blocks: list[lazy.pd.DataFrame], *, reverse_mapped_blocks: bool = False) -> None:
         self.blocks = blocks
+        self.reverse_mapped_blocks = reverse_mapped_blocks
         self.map_batches_kwargs: dict[str, Any] | None = None
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         self.map_batches_kwargs = kwargs
         fn_kwargs = kwargs.get("fn_kwargs") or {}
-        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+        blocks = [fn(block, **fn_kwargs) for block in self.blocks]
+        if self.reverse_mapped_blocks:
+            blocks.reverse()
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
+
+    def zip(self, other: FakeRayDataset) -> FakeRayDataset:
+        other_df = other.to_pandas()
+        offset = 0
+        blocks: list[lazy.pd.DataFrame] = []
+        for block in self.blocks:
+            block_len = len(block)
+            other_block = other_df.iloc[offset : offset + block_len].reset_index(drop=True)
+            blocks.append(lazy.pd.concat([block.reset_index(drop=True), other_block], axis=1))
+            offset += block_len
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
 
     def to_arrow_refs(self) -> list[str]:
         return [f"arrow-ref-{i}" for i, _ in enumerate(self.blocks)]
@@ -49,6 +70,9 @@ class FakeRayDataset:
     def num_blocks(self) -> int:
         return len(self.blocks)
 
+    def count(self) -> int:
+        return sum(len(block) for block in self.blocks)
+
 
 class FakeRayDataModule:
     Dataset = FakeRayDataset
@@ -56,17 +80,21 @@ class FakeRayDataModule:
     def __init__(self) -> None:
         self.from_arrow_refs_input: list[Any] | None = None
         self.from_pandas_refs_input: list[Any] | None = None
+        self.reverse_mapped_blocks = False
 
     def range(self, num_records: int) -> FakeRayDataset:
         return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
 
     def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_arrow_refs_input = refs
-        return FakeRayDataset([_arrow_ref_to_pandas(ref) for ref in refs])
+        return FakeRayDataset(
+            [_arrow_ref_to_pandas(ref) for ref in refs],
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
 
     def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_pandas_refs_input = refs
-        return FakeRayDataset(list(refs))
+        return FakeRayDataset(list(refs), reverse_mapped_blocks=self.reverse_mapped_blocks)
 
 
 class CountingRayDataset:
@@ -267,22 +295,35 @@ def test_ray_backend_can_sort_by_explicit_order_column(
     ]
 
 
-def test_ray_backend_requires_order_column_for_preserve_order(
+def test_ray_backend_preserve_order_does_not_require_explicit_order_column(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    stub_sampler_only_config_builder: Any,
+    stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
     _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset(
+        [
+            lazy.pd.DataFrame({"x": [1], "label": ["a"]}),
+            lazy.pd.DataFrame({"x": [2], "label": ["b"]}),
+        ],
+        reverse_mapped_blocks=True,
+    )
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
         managed_assets_path=_managed_assets_path(tmp_path),
         backend=RayBackend(preserve_order=True),
     )
+    config_builder = _input_expression_config_builder(stub_model_configs)
 
-    with pytest.raises(RayBackendConfigurationError, match="requires order_column"):
-        designer.create(stub_sampler_only_config_builder, num_records=1)
+    output_df = designer.create(config_builder, input_dataset=input_dataset).load_dataset().to_pandas()
+
+    assert output_df.to_dict(orient="records") == [
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+    ]
 
 
 def test_ray_backend_uses_pandas_object_refs_as_in_memory_seed(
@@ -427,6 +468,25 @@ def test_ray_backend_arrow_refs_load_dataset_uses_materialized_refs_without_reru
         {"id": 1, "generated": 1},
     ]
     assert generate_calls == 1
+
+
+def test_ray_results_to_arrow_refs_wraps_materialization_failures(
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    class FailingArrowDataset:
+        def to_arrow_refs(self) -> list[Any]:
+            raise RuntimeError("object store unavailable")
+
+    results = RayDatasetCreationResults(
+        dataset=FailingArrowDataset(),
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(),
+    )
+
+    with pytest.raises(RayDatasetGenerationError, match="materialize Arrow ObjectRefs") as exc_info:
+        results.to_arrow_refs()
+
+    assert "object store unavailable" in str(exc_info.value.__cause__)
 
 
 def test_ray_backend_dataset_output_wraps_dataset_and_delegates_arrow_refs(

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -30,8 +30,7 @@ class FakeRayDataset:
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         self.map_batches_kwargs = kwargs
-        fn_kwargs = kwargs.get("fn_kwargs") or {}
-        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+        return FakeRayDataset(_map_batches_blocks(fn, self.blocks, kwargs))
 
     def to_arrow_refs(self) -> list[str]:
         return [f"arrow-ref-{i}" for i, _ in enumerate(self.blocks)]
@@ -109,8 +108,7 @@ class CountingRayDataset:
             return self.blocks
         if self.map_fn is None:
             return self.parent._evaluate()
-        fn_kwargs = (self.map_kwargs or {}).get("fn_kwargs") or {}
-        return [self.map_fn(block, **fn_kwargs) for block in self.parent._evaluate()]
+        return _map_batches_blocks(self.map_fn, self.parent._evaluate(), self.map_kwargs or {})
 
 
 class CountingRayDataModule:
@@ -126,6 +124,13 @@ class CountingRayDataModule:
     def from_arrow_refs(self, refs: list[Any]) -> CountingRayDataset:
         self.from_arrow_refs_input = refs
         return CountingRayDataset([self.ref_blocks[ref] for ref in refs], self)
+
+
+def _map_batches_blocks(fn: Any, blocks: list[lazy.pd.DataFrame], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
+    fn_kwargs = kwargs.get("fn_kwargs") or {}
+    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
+    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
+    return [map_fn(block, **fn_kwargs) for block in blocks]
 
 
 def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
@@ -193,6 +198,8 @@ def test_ray_backend_uses_input_dataset_as_in_memory_seed(
 
     assert input_dataset.map_batches_kwargs is not None
     assert input_dataset.map_batches_kwargs["num_cpus"] == 0.5
+    assert "fn_kwargs" not in input_dataset.map_batches_kwargs
+    assert input_dataset.map_batches_kwargs["fn_constructor_kwargs"]["execution_payload"].use_input_dataset is True
     assert "ray_remote_args" not in input_dataset.map_batches_kwargs
     assert output_df.to_dict(orient="records") == [
         {"x": 1, "label": "a", "x_label": "1-a"},

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 
 import data_designer.lazy_heavy_imports as lazy
-from data_designer.config.column_configs import ExpressionColumnConfig
+from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.processors import SchemaTransformProcessorConfig
 from data_designer.config.run_config import RunConfig
@@ -34,9 +34,11 @@ class FakeRayDataset:
         self.blocks = blocks
         self.reverse_mapped_blocks = reverse_mapped_blocks
         self.map_batches_kwargs: dict[str, Any] | None = None
+        self.map_batches_fn: Any | None = None
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         self.map_batches_kwargs = kwargs
+        self.map_batches_fn = fn
         blocks = _map_batches_blocks(fn, self.blocks, kwargs)
         if self.reverse_mapped_blocks:
             blocks.reverse()
@@ -73,6 +75,11 @@ class FakeRayDataset:
         return sum(len(block) for block in self.blocks)
 
 
+class FakeActorPoolStrategy:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
 class FakeRayDataModule:
     Dataset = FakeRayDataset
 
@@ -80,9 +87,22 @@ class FakeRayDataModule:
         self.from_arrow_refs_input: list[Any] | None = None
         self.from_pandas_refs_input: list[Any] | None = None
         self.reverse_mapped_blocks = False
+        self.range_kwargs: dict[str, Any] | None = None
 
-    def range(self, num_records: int) -> FakeRayDataset:
-        return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+    def ActorPoolStrategy(self, **kwargs: Any) -> FakeActorPoolStrategy:
+        return FakeActorPoolStrategy(**kwargs)
+
+    def range(self, num_records: int, **kwargs: Any) -> FakeRayDataset:
+        self.range_kwargs = kwargs
+        block_count = kwargs.get("override_num_blocks") or 1
+        if num_records > 0:
+            block_count = min(block_count, num_records)
+        blocks = []
+        for index in range(block_count):
+            start = index * num_records // block_count
+            end = (index + 1) * num_records // block_count
+            blocks.append(lazy.pd.DataFrame({"id": list(range(start, end))}))
+        return FakeRayDataset(blocks)
 
     def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_arrow_refs_input = refs
@@ -202,6 +222,18 @@ def _input_expression_config_builder(stub_model_configs: Any) -> DataDesignerCon
     return config_builder
 
 
+def _llm_config_builder(stub_model_configs: Any) -> DataDesignerConfigBuilder:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(
+        LLMTextColumnConfig(
+            name="text",
+            prompt="Say hello.",
+            model_alias="stub-model",
+        )
+    )
+    return config_builder
+
+
 def test_ray_backend_uses_input_dataset_as_in_memory_seed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -233,6 +265,261 @@ def test_ray_backend_uses_input_dataset_as_in_memory_seed(
         {"x": 1, "label": "a", "x_label": "1-a"},
         {"x": 2, "label": "b", "x_label": "2-b"},
     ]
+
+
+def test_ray_backend_uses_override_num_blocks_for_from_scratch_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2, override_num_blocks=3, read_concurrency=2),
+    )
+
+    results = designer.create(stub_sampler_only_config_builder, num_records=5)
+
+    assert fake_ray.data.range_kwargs == {"override_num_blocks": 3, "concurrency": 2}
+    assert results.load_metrics().blocks == 3
+
+
+@pytest.mark.parametrize(
+    ("num_records", "target_block_size", "min_blocks", "max_blocks", "expected_blocks"),
+    [
+        (3, 100, None, None, 1),
+        (20, 4, 2, 3, 3),
+    ],
+)
+def test_ray_backend_resolves_target_block_size_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: Any,
+    stub_model_providers: Any,
+    num_records: int,
+    target_block_size: int,
+    min_blocks: int | None,
+    max_blocks: int | None,
+    expected_blocks: int,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=2,
+            target_block_size=target_block_size,
+            min_blocks=min_blocks,
+            max_blocks=max_blocks,
+        ),
+    )
+
+    results = designer.create(stub_sampler_only_config_builder, num_records=num_records)
+
+    assert fake_ray.data.range_kwargs == {"override_num_blocks": expected_blocks}
+    assert results.load_metrics().blocks == expected_blocks
+
+
+def test_ray_backend_rejects_block_planning_with_input_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(override_num_blocks=2),
+    )
+
+    with pytest.raises(RayBackendConfigurationError, match="block planning controls"):
+        designer.create(stub_sampler_only_config_builder, input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is None
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"override_num_blocks": 0}, "positive integer"),
+        ({"target_block_size": 10, "min_blocks": 4, "max_blocks": 2}, "min_blocks"),
+        ({"min_blocks": 2}, "require target_block_size"),
+    ],
+)
+def test_ray_backend_validates_invalid_block_planning_options(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        RayBackend(**kwargs)
+
+
+def test_ray_backend_propagates_execution_resource_options(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            num_cpus=0.5,
+            num_gpus=1,
+            memory=1024,
+            resources={"model_client": 1},
+            scheduling_strategy="SPREAD",
+            map_concurrency=2,
+        ),
+    )
+
+    designer.create(_input_expression_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_kwargs["num_cpus"] == 0.5
+    assert input_dataset.map_batches_kwargs["num_gpus"] == 1
+    assert input_dataset.map_batches_kwargs["memory"] == 1024
+    assert input_dataset.map_batches_kwargs["resources"] == {"model_client": 1}
+    assert input_dataset.map_batches_kwargs["scheduling_strategy"] == "SPREAD"
+    assert input_dataset.map_batches_kwargs["concurrency"] == 2
+
+
+def test_ray_backend_actor_pool_uses_autoscaling_strategy_and_constructor_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            use_actor_pool=True,
+            actor_pool_min_size=1,
+            actor_pool_max_size=4,
+            actor_pool_initial_size=2,
+            scheduling_strategy="DEFAULT",
+        ),
+    )
+
+    designer.create(_input_expression_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_fn is ray_backend_module._RayBatchWorker
+    assert "fn_kwargs" not in input_dataset.map_batches_kwargs
+    assert "fn_constructor_kwargs" in input_dataset.map_batches_kwargs
+    assert input_dataset.map_batches_kwargs["scheduling_strategy"] == "DEFAULT"
+    assert input_dataset.map_batches_kwargs["compute"].kwargs == {
+        "min_size": 1,
+        "max_size": 4,
+        "initial_size": 2,
+    }
+
+
+def test_ray_backend_driver_model_health_check_runs_once_and_workers_skip_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+    preflight_aliases: list[list[str]] = []
+    worker_skip_flags: list[list[bool]] = []
+
+    def run_driver_model_health_check(_: Any, __: DataDesignerConfigBuilder, model_aliases: list[str]) -> None:
+        preflight_aliases.append(model_aliases)
+
+    def generate_batch(batch: lazy.pd.DataFrame, *, worker: Any, **_: Any) -> Any:
+        worker_skip_flags.append([model_config.skip_health_check for model_config in worker._base_config.model_configs])
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_run_driver_model_health_check", run_driver_model_health_check)
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    config_builder = _llm_config_builder(stub_model_configs)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1),
+    )
+
+    designer.create(config_builder, input_dataset=input_dataset)
+
+    assert preflight_aliases == [["stub-model"]]
+    assert worker_skip_flags == [[True]]
+    assert [model_config.skip_health_check for model_config in config_builder.model_configs] == [False]
+
+
+def test_ray_backend_worker_model_health_checks_can_be_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+    worker_skip_flags: list[list[bool]] = []
+
+    def generate_batch(batch: lazy.pd.DataFrame, *, worker: Any, **_: Any) -> Any:
+        worker_skip_flags.append([model_config.skip_health_check for model_config in worker._base_config.model_configs])
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_run_driver_model_health_check", lambda *_: None)
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1, worker_model_health_checks=True),
+    )
+
+    designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert worker_skip_flags == [[False]]
+
+
+def test_ray_backend_driver_model_health_check_failure_stops_before_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+
+    def fail_preflight(_: Any, __: DataDesignerConfigBuilder, ___: list[str]) -> None:
+        raise RayDatasetGenerationError("preflight failed")
+
+    monkeypatch.setattr(ray_backend_module, "_run_driver_model_health_check", fail_preflight)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1),
+    )
+
+    with pytest.raises(RayDatasetGenerationError, match="preflight failed"):
+        designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is None
 
 
 def test_ray_backend_preserves_input_dataset_order_across_blocks(

--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+
+
+def _load_benchmark_module() -> Any:
+    repo_root = Path(__file__).resolve().parents[5]
+    script_path = repo_root / "scripts" / "benchmarks" / "benchmark_ray_openai.py"
+    spec = importlib.util.spec_from_file_location("benchmark_ray_openai", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load benchmark script from {script_path}.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_backends_supports_full_apples_to_apples_suite() -> None:
+    benchmark = _load_benchmark_module()
+
+    assert benchmark._parse_backends("all") == list(benchmark.ALL_BACKENDS)
+    assert benchmark._parse_backends("local-sync,local-async,ray-dataset,ray-arrow-refs") == [
+        "local-sync",
+        "local-async",
+        "ray-dataset",
+        "ray-arrow-refs",
+    ]
+    assert benchmark._parse_backends("local-sync,local-sync,ray-dataset") == ["local-sync", "ray-dataset"]
+
+
+def test_parse_backends_rejects_unknown_backend() -> None:
+    benchmark = _load_benchmark_module()
+
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        benchmark._parse_backends("local,ray")
+
+
+def test_result_payload_reports_validity_and_provider_counters(tmp_path: Path) -> None:
+    benchmark = _load_benchmark_module()
+    output = lazy.pd.DataFrame(
+        {
+            "instruction": ["write code", "debug code"],
+            "code_implementation": ["print('ok')", "print('debug')"],
+        }
+    )
+    metrics = {
+        "total_rows": 2,
+        "blocks": 1,
+        "elapsed_seconds": 2.0,
+        "model_usage": {
+            "gpt-4.1": {
+                "token_usage": {"input_tokens": 10, "output_tokens": 30, "total_tokens": 40},
+                "request_usage": {"successful_requests": 2, "failed_requests": 1, "total_requests": 3},
+                "retry_count": 4,
+                "rate_limited_requests": 1,
+            }
+        },
+    }
+
+    payload = benchmark._result_payload(
+        backend="local-sync",
+        iteration=1,
+        seed=11,
+        output=output,
+        elapsed_seconds=2.0,
+        metrics=metrics,
+        artifact_path=tmp_path,
+        output_mode="pandas",
+        batch_size=2,
+        max_parallel_requests=2,
+        expected_columns=["instruction", "code_implementation"],
+        expected_rows=2,
+    )
+
+    assert payload["validity"] == {
+        "row_count_matches": True,
+        "expected_columns_present": True,
+        "expected_columns_non_null": True,
+        "all_output_valid": True,
+    }
+    assert payload["throughput"]["requests_per_minute"] == 90
+    assert payload["throughput"]["tokens_per_second"] == 20
+    assert payload["throughput"]["retry_count"] == 4
+    assert payload["throughput"]["throttle_count"] == 1
+
+
+def test_summary_groups_iterations_and_speedups() -> None:
+    benchmark = _load_benchmark_module()
+    results = [
+        _benchmark_result(backend="local-sync", iteration=1, elapsed_seconds=10.0, rows_per_second=10.0),
+        _benchmark_result(backend="local-async", iteration=1, elapsed_seconds=5.0, rows_per_second=20.0),
+        _benchmark_result(backend="ray-dataset", iteration=1, elapsed_seconds=4.0, rows_per_second=25.0),
+        _benchmark_result(backend="local-sync", iteration=2, elapsed_seconds=8.0, rows_per_second=12.5),
+        _benchmark_result(backend="local-async", iteration=2, elapsed_seconds=4.0, rows_per_second=25.0),
+        _benchmark_result(backend="ray-dataset", iteration=2, elapsed_seconds=2.0, rows_per_second=50.0),
+    ]
+
+    summary = benchmark._build_summary(results)
+
+    assert summary["all_output_valid"] is True
+    assert summary["per_backend"]["local-sync"]["iterations"] == 2
+    assert summary["per_backend"]["local-async"]["rows_per_second"]["mean"] == 22.5
+    assert summary["comparisons_vs_local_sync"]["local-async"]["mean"] == 2.0
+    assert summary["comparisons_vs_local_sync"]["ray-dataset"]["mean"] == 3.25
+
+
+def _benchmark_result(
+    *,
+    backend: str,
+    iteration: int,
+    elapsed_seconds: float,
+    rows_per_second: float,
+) -> dict[str, Any]:
+    return {
+        "backend": backend,
+        "iteration": iteration,
+        "elapsed_seconds": elapsed_seconds,
+        "rows_per_second": rows_per_second,
+        "validity": {"all_output_valid": True},
+        "throughput": {
+            "requests_per_minute": 60.0,
+            "tokens_per_second": 120.0,
+            "failed_requests": 0,
+            "retry_count": 0,
+            "throttle_count": 0,
+        },
+    }

--- a/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
@@ -32,9 +32,8 @@ class FakeMetricDataset:
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeMetricDataset:
         self.map_batches_kwargs = kwargs
-        fn_kwargs = kwargs.get("fn_kwargs") or {}
         return FakeMetricDataset(
-            [fn(block, **fn_kwargs) for block in self.blocks],
+            _map_batches_blocks(fn, self.blocks, kwargs),
             worker_metrics=self.worker_metrics,
         )
 
@@ -50,6 +49,13 @@ class FakeRayDataModule:
 
     def range(self, num_records: int) -> FakeMetricDataset:
         return FakeMetricDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+
+
+def _map_batches_blocks(fn: Any, blocks: list[lazy.pd.DataFrame], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
+    fn_kwargs = kwargs.get("fn_kwargs") or {}
+    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
+    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
+    return [map_fn(block, **fn_kwargs) for block in blocks]
 
 
 class FakeObjectRef:

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+from typing import Any
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.integrations.ray import (
+    RayDatasetCreationResults,
+    RayDatasetMetrics,
+    RayThrottleSnapshot,
+    RayTraceEvent,
+    RayWorkerProfile,
+)
+from data_designer.integrations.ray import backend as ray_backend_module
+
+
+class FakeObjectRef:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+class FakeRemoteMethod:
+    def __init__(self, method: Any) -> None:
+        self._method = method
+
+    def remote(self, *args: Any, **kwargs: Any) -> FakeObjectRef:
+        return FakeObjectRef(self._method(*args, **kwargs))
+
+
+class FakeActorHandle:
+    def __init__(self, actor: Any) -> None:
+        self._actor = actor
+
+    def __getattr__(self, name: str) -> FakeRemoteMethod:
+        return FakeRemoteMethod(getattr(self._actor, name))
+
+
+def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
+    tmp_path: Path,
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    collector = ray_backend_module._RayMetricsCollector(max_trace_events=1)
+    collector.record({"total_rows": 2, "blocks": 1, "elapsed_seconds": 0.5, "block_id": "block-a"})
+    collector.record_observability(
+        {
+            "worker_profile": RayWorkerProfile(
+                block_id="block-a",
+                total_rows=2,
+                columns=["id", "label"],
+                column_dtypes={"id": "int64", "label": "object"},
+                non_null_counts={"id": 2, "label": 1},
+                null_counts={"id": 0, "label": 1},
+                memory_usage_bytes=128,
+            ).to_dict(),
+            "trace_events": [
+                RayTraceEvent(
+                    block_id="block-a",
+                    event_type="block_started",
+                    timestamp_seconds=1.0,
+                    row_count=2,
+                ).to_dict(),
+                RayTraceEvent(
+                    block_id="block-a",
+                    event_type="block_completed",
+                    timestamp_seconds=2.0,
+                    elapsed_seconds=0.5,
+                    row_count=2,
+                ).to_dict(),
+            ],
+            "throttle_snapshots": [
+                RayThrottleSnapshot(
+                    provider_name="stub-provider",
+                    model_id="stub-model",
+                    domain="chat",
+                    current_limit=2,
+                    effective_max=4,
+                    rate_limit_ceiling=3,
+                    consecutive_rate_limits=1,
+                ).to_dict()
+            ],
+        }
+    )
+    results = RayDatasetCreationResults(
+        dataset=lazy.pd.DataFrame({"id": [1, 2]}),
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(total_rows=0, blocks=1),
+        ray=types.SimpleNamespace(get=lambda ref: ref.value),
+        metrics_collector=FakeActorHandle(collector),
+    )
+
+    analysis = results.load_analysis()
+
+    assert analysis is not None
+    assert analysis.total_rows == 2
+    assert analysis.blocks == 1
+    assert analysis.worker_profiles[0].block_id == "block-a"
+    assert analysis.worker_profiles[0].null_counts == {"id": 0, "label": 1}
+    assert analysis.trace_events[0].event_type == "block_started"
+    assert analysis.trace_events_dropped == 1
+    assert analysis.throttle_snapshots[0].rate_limit_ceiling == 3
+    assert results.load_worker_metrics()[0].block_id == analysis.worker_profiles[0].block_id
+
+    report_path = tmp_path / "ray-analysis.json"
+    analysis.to_report(report_path)
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["worker_profiles"][0]["block_id"] == "block-a"
+
+
+def test_ray_results_load_analysis_returns_none_without_observability_payload(
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    collector = ray_backend_module._RayMetricsCollector(max_trace_events=0)
+    collector.record({"total_rows": 0, "blocks": 1, "elapsed_seconds": 0.25})
+    results = RayDatasetCreationResults(
+        dataset=lazy.pd.DataFrame({"id": []}),
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(total_rows=0, blocks=1),
+        ray=types.SimpleNamespace(get=lambda ref: ref.value),
+        metrics_collector=FakeActorHandle(collector),
+    )
+
+    assert results.load_analysis() is None

--- a/packages/data-designer/tests/integrations/ray/test_processor_policy.py
+++ b/packages/data-designer/tests/integrations/ray/test_processor_policy.py
@@ -6,14 +6,20 @@ from __future__ import annotations
 import sys
 import types
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 import pytest
 
 import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.base import ProcessorConfig
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.processors import DropColumnsProcessorConfig, SchemaTransformProcessorConfig
+from data_designer.config.processors import (
+    DropColumnsProcessorConfig,
+    ProcessorDistributedSafety,
+    ProcessorSideEffect,
+    SchemaTransformProcessorConfig,
+)
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError
 from data_designer.integrations.ray import backend as ray_backend_module
@@ -45,6 +51,20 @@ class FakeRayDataModule:
 
     def range(self, num_records: int) -> FakeRayDataset:
         return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+
+
+class MissingSafetyProcessorConfig(ProcessorConfig):
+    processor_type: Literal["missing_safety"] = "missing_safety"
+
+
+class GlobalOrderProcessorConfig(ProcessorConfig):
+    processor_type: Literal["global_order"] = "global_order"
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        ray_safe=True,
+        requires_global_order=True,
+        side_effects=ProcessorSideEffect.NONE,
+        reason="Requires a globally ordered dataset.",
+    )
 
 
 def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -131,9 +151,53 @@ def test_ray_backend_rejects_schema_transform_processor_by_default(
     )
     designer = _designer(tmp_path, stub_model_providers, backend=RayBackend())
 
-    with pytest.raises(RayBackendConfigurationError, match="Unsupported processor"):
+    with pytest.raises(RayBackendConfigurationError, match="Unsupported processor") as exc_info:
         designer.create(config_builder, input_dataset=input_dataset)
 
+    message = str(exc_info.value)
+    assert "schema-transform (schema_transform)" in message
+    assert "ray_safe=False" in message
+    assert "side_effects=dataset_artifact" in message
+    assert "worker-local storage" in message
+    assert "allow_unsafe_processors=True" in message
+    assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_backend_rejects_processor_without_distributed_safety_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    config_builder.add_processor(MissingSafetyProcessorConfig(name="custom-processor"))
+    designer = _designer(tmp_path, stub_model_providers, backend=RayBackend())
+
+    with pytest.raises(RayBackendConfigurationError, match="missing distributed_safety metadata") as exc_info:
+        designer.create(config_builder, input_dataset=input_dataset)
+
+    assert "custom-processor (missing_safety)" in str(exc_info.value)
+    assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_backend_rejects_global_order_processor_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    config_builder.add_processor(GlobalOrderProcessorConfig(name="global-order-processor"))
+    designer = _designer(tmp_path, stub_model_providers, backend=RayBackend())
+
+    with pytest.raises(RayBackendConfigurationError, match="requires_global_order=True") as exc_info:
+        designer.create(config_builder, input_dataset=input_dataset)
+
+    assert "global-order-processor (global_order)" in str(exc_info.value)
     assert input_dataset.map_batches_kwargs is None
 
 

--- a/packages/data-designer/tests/integrations/ray/test_processor_policy.py
+++ b/packages/data-designer/tests/integrations/ray/test_processor_policy.py
@@ -27,8 +27,7 @@ class FakeRayDataset:
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         self.map_batches_kwargs = kwargs
-        fn_kwargs = kwargs.get("fn_kwargs") or {}
-        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+        return FakeRayDataset(_map_batches_blocks(fn, self.blocks, kwargs))
 
     def to_pandas(self) -> lazy.pd.DataFrame:
         return lazy.pd.concat(self.blocks, ignore_index=True)
@@ -45,6 +44,13 @@ class FakeRayDataModule:
 
     def range(self, num_records: int) -> FakeRayDataset:
         return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+
+
+def _map_batches_blocks(fn: Any, blocks: list[lazy.pd.DataFrame], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
+    fn_kwargs = kwargs.get("fn_kwargs") or {}
+    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
+    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
+    return [map_fn(block, **fn_kwargs) for block in blocks]
 
 
 def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
+++ b/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.run_config import RunConfig
+from data_designer.engine.models.clients.throttle_manager import CAPACITY_POLL_INTERVAL, ThrottleDomain
+from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.integrations.ray import RayBackend
+from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray.metrics import RayWorkerMetrics
+from data_designer.integrations.ray.throttling import RayThrottleManagerProxy, create_ray_throttle_manager
+from data_designer.interface.data_designer import DataDesigner
+
+
+class FakeRayDataset:
+    def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
+        self.blocks = blocks
+
+    def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
+        fn_kwargs = kwargs.get("fn_kwargs") or {}
+        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+
+    def to_pandas(self) -> lazy.pd.DataFrame:
+        return lazy.pd.concat(self.blocks, ignore_index=True)
+
+    def num_blocks(self) -> int:
+        return len(self.blocks)
+
+
+class FakeRayDataModule:
+    Dataset = FakeRayDataset
+
+    def range(self, num_records: int) -> FakeRayDataset:
+        return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+
+
+class FakeObjectRef:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+class FakeRemoteMethod:
+    def __init__(self, method: Any) -> None:
+        self._method = method
+
+    def remote(self, *args: Any, **kwargs: Any) -> FakeObjectRef:
+        return FakeObjectRef(self._method(*args, **kwargs))
+
+
+class FakeActorHandle:
+    def __init__(self, actor: Any) -> None:
+        self._actor = actor
+
+    def __getattr__(self, name: str) -> FakeRemoteMethod:
+        return FakeRemoteMethod(getattr(self._actor, name))
+
+
+class FakeRemoteClass:
+    def __init__(self, cls: type) -> None:
+        self._cls = cls
+
+    def remote(self, *args: Any, **kwargs: Any) -> FakeActorHandle:
+        return FakeActorHandle(self._cls(*args, **kwargs))
+
+
+def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    fake_ray = types.ModuleType("ray")
+    fake_ray.data = FakeRayDataModule()
+    fake_ray.is_initialized = lambda: True
+    fake_ray.init = lambda: None
+    fake_ray.remote = lambda cls: FakeRemoteClass(cls)
+    fake_ray.get = lambda ref: ref.value
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    return fake_ray
+
+
+def _managed_assets_path(tmp_path: Path) -> Path:
+    path = tmp_path / "managed-assets"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def test_ray_throttle_proxy_coordinates_shared_provider_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    first_worker = create_ray_throttle_manager(fake_ray, RunConfig())
+    second_worker = RayThrottleManagerProxy(first_worker._coordinator)
+
+    first_worker.register(
+        provider_name="openai",
+        model_id="gpt-4.1",
+        alias="writer",
+        max_parallel_requests=1,
+    )
+
+    assert first_worker.try_acquire(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT) == 0.0
+    assert (
+        second_worker.try_acquire(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+        == CAPACITY_POLL_INTERVAL
+    )
+
+    first_worker.release_success(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+
+    assert second_worker.try_acquire(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT) == 0.0
+    snapshot = second_worker.snapshot()
+    assert snapshot["global_caps"] == [
+        {
+            "provider_name": "openai",
+            "model_id": "gpt-4.1",
+            "effective_max": 1,
+            "limits_by_alias": {"writer": 1},
+        }
+    ]
+
+
+def test_ray_backend_exposes_global_throttle_snapshot_in_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+
+    def generate_batch(
+        batch: lazy.pd.DataFrame,
+        *,
+        worker_options: Any,
+        metrics_collector: Any | None = None,
+        **_: Any,
+    ) -> lazy.pd.DataFrame:
+        throttle_manager = worker_options.throttle_manager
+        assert throttle_manager is not None
+        throttle_manager.register(
+            provider_name="openai",
+            model_id="gpt-4.1",
+            alias="writer",
+            max_parallel_requests=1,
+        )
+        throttle_manager.acquire_sync(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+        throttle_manager.release_success(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+        ray_backend_module._record_worker_metrics(
+            metrics_collector,
+            RayWorkerMetrics(total_rows=len(batch), blocks=1, elapsed_seconds=0.25),
+        )
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2),
+    )
+
+    results = designer.create(stub_sampler_only_config_builder, num_records=2)
+    metrics = results.load_metrics()
+
+    assert results.load_dataset().to_pandas().to_dict(orient="records") == [{"id": 0}, {"id": 1}]
+    assert metrics.total_rows == 2
+    assert metrics.throttle is not None
+    assert metrics.throttle["global_caps"][0]["effective_max"] == 1
+    assert metrics.throttle["domains"][0]["domain"] == ThrottleDomain.CHAT.value

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in real-Ray smoke tests for docs/assets recipe paths."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.column_configs import ExpressionColumnConfig
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.default_model_settings import (
+    get_builtin_model_configs,
+    get_builtin_model_providers,
+    resolve_seed_default_model_settings,
+)
+from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.integrations.ray import RayBackend
+from data_designer.interface.data_designer import DataDesigner
+
+REAL_RAY_SMOKE_ENV = "DATA_DESIGNER_RUN_REAL_RAY_SMOKE"
+OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
+
+
+def test_real_ray_markdown_seed_recipe_arrow_refs_smoke(
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    ray = _require_real_ray()
+    recipe = _load_recipe("docs/assets/recipes/plugin_development/markdown_seed_reader.py")
+    seed_dir = tmp_path / "markdown"
+    seed_dir.mkdir()
+    recipe.create_sample_markdown_files(seed_dir)
+    input_df = _markdown_sections_dataframe(recipe, seed_dir)
+    input_blocks = [input_df.iloc[:2].reset_index(drop=True), input_df.iloc[2:].reset_index(drop=True)]
+
+    ray.init(num_cpus=2, include_dashboard=False, ignore_reinit_error=True)
+    try:
+        input_dataset = ray.data.from_pandas(input_blocks)
+        config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+        config_builder.add_column(
+            ExpressionColumnConfig(
+                name="section_summary",
+                expr="{{ file_name }} :: {{ section_header }}",
+            )
+        )
+        designer = DataDesigner(
+            artifact_path=tmp_path / "artifacts",
+            model_providers=stub_model_providers,
+            secret_resolver=PlaintextResolver(),
+            managed_assets_path=tmp_path / "managed-assets",
+            backend=RayBackend(batch_size=2, output="arrow_refs"),
+        )
+
+        results = designer.create(config_builder, input_dataset=input_dataset)
+        refs = results.output
+        output_df = results.load_dataset().to_pandas()
+        metrics = results.load_metrics()
+
+        assert results.to_arrow_refs() == refs
+        assert len(refs) == metrics.blocks
+        assert metrics.total_rows == len(input_df)
+        assert metrics.failed_blocks == 0
+        assert output_df["section_summary"].notna().all()
+        assert output_df["section_summary"].str.contains("::").all()
+    finally:
+        ray.shutdown()
+
+
+def test_real_ray_text_to_python_openai_recipe_smoke(tmp_path: Path) -> None:
+    ray = _require_real_ray()
+    if not os.environ.get(OPENAI_API_KEY_ENV):
+        pytest.skip(f"{OPENAI_API_KEY_ENV} is required for the OpenAI-backed Ray smoke test.")
+
+    resolve_seed_default_model_settings()
+    recipe = _load_recipe("docs/assets/recipes/code_generation/text_to_python.py")
+    config_builder = _single_llm_text_to_python_config(recipe)
+    provider = _builtin_provider("openai")
+
+    ray.init(num_cpus=2, include_dashboard=False, ignore_reinit_error=True)
+    try:
+        designer = DataDesigner(
+            artifact_path=tmp_path / "artifacts",
+            model_providers=[provider],
+            managed_assets_path=tmp_path / "managed-assets",
+            backend=RayBackend(batch_size=1, output="arrow_refs"),
+        )
+
+        results = designer.create(config_builder, num_records=1)
+        refs = results.output
+        output_df = results.load_dataset().to_pandas()
+        metrics = results.load_metrics()
+        metrics_payload = metrics.to_dict()
+
+        assert results.to_arrow_refs() == refs
+        assert len(refs) == metrics.blocks
+        assert metrics.total_rows == 1
+        assert metrics.failed_blocks == 0
+        assert output_df["instruction"].notna().all()
+        assert output_df["instruction"].astype(str).str.len().min() > 0
+        assert metrics_payload["model_usage"]
+    finally:
+        ray.shutdown()
+
+
+def _require_real_ray() -> Any:
+    if os.environ.get(REAL_RAY_SMOKE_ENV) != "1":
+        pytest.skip(f"Set {REAL_RAY_SMOKE_ENV}=1 to run real-Ray smoke tests.")
+    return pytest.importorskip("ray")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[5]
+
+
+def _load_recipe(relative_path: str) -> Any:
+    recipe_path = _repo_root() / relative_path
+    spec = importlib.util.spec_from_file_location(f"ray_smoke_{recipe_path.stem}", recipe_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load recipe from {recipe_path}.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _markdown_sections_dataframe(recipe: Any, seed_dir: Path) -> Any:
+    records: list[dict[str, Any]] = []
+    for markdown_path in sorted(seed_dir.glob("*.md")):
+        sections = recipe.extract_markdown_sections(
+            markdown_text=markdown_path.read_text(encoding="utf-8"),
+            fallback_header=markdown_path.name,
+        )
+        for section_index, (section_header, section_content) in enumerate(sections):
+            records.append(
+                {
+                    "relative_path": markdown_path.name,
+                    "file_name": markdown_path.name,
+                    "section_index": section_index,
+                    "section_header": section_header,
+                    "section_content": section_content,
+                }
+            )
+    return lazy.pd.DataFrame(records)
+
+
+def _single_llm_text_to_python_config(recipe: Any) -> DataDesignerConfigBuilder:
+    source_builder = recipe.build_config(model_alias="openai-text")
+    config_builder = DataDesignerConfigBuilder(model_configs=[_builtin_model_config("openai-text")])
+    for column_config in source_builder.get_column_configs():
+        config_builder.add_column(copy.deepcopy(column_config))
+        if column_config.name == "instruction":
+            break
+    return config_builder
+
+
+def _builtin_model_config(alias: str) -> Any:
+    for model_config in get_builtin_model_configs():
+        if model_config.alias != alias:
+            continue
+        inference_parameters = model_config.inference_parameters.model_copy(
+            update={"max_parallel_requests": 1, "max_tokens": 256}
+        )
+        return model_config.model_copy(
+            deep=True,
+            update={"inference_parameters": inference_parameters, "skip_health_check": True},
+        )
+    raise RuntimeError(f"No built-in model config found for {alias!r}.")
+
+
+def _builtin_provider(name: str) -> Any:
+    for provider in get_builtin_model_providers():
+        if provider.name == name:
+            return provider
+    raise RuntimeError(f"No built-in provider found for {name!r}.")

--- a/packages/data-designer/tests/integrations/ray/test_semantics.py
+++ b/packages/data-designer/tests/integrations/ray/test_semantics.py
@@ -13,21 +13,37 @@ import pytest
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend
 from data_designer.interface.data_designer import DataDesigner
 
 
 class FakeRayDataset:
-    def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
+    def __init__(self, blocks: list[lazy.pd.DataFrame], *, reverse_mapped_blocks: bool = False) -> None:
         self.blocks = blocks
+        self.reverse_mapped_blocks = reverse_mapped_blocks
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         fn_kwargs = kwargs.get("fn_kwargs") or {}
-        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+        blocks = [fn(block, **fn_kwargs) for block in self.blocks]
+        if self.reverse_mapped_blocks:
+            blocks.reverse()
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
 
-    def to_arrow_refs(self) -> list[str]:
-        return [f"arrow-ref-{i}" for i, _ in enumerate(self.blocks)]
+    def zip(self, other: FakeRayDataset) -> FakeRayDataset:
+        other_df = other.to_pandas()
+        offset = 0
+        blocks: list[lazy.pd.DataFrame] = []
+        for block in self.blocks:
+            block_len = len(block)
+            other_block = other_df.iloc[offset : offset + block_len].reset_index(drop=True)
+            blocks.append(lazy.pd.concat([block.reset_index(drop=True), other_block], axis=1))
+            offset += block_len
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
+
+    def to_arrow_refs(self) -> list[lazy.pd.DataFrame]:
+        return self.blocks
 
     def to_pandas(self) -> lazy.pd.DataFrame:
         return lazy.pd.concat(self.blocks, ignore_index=True)
@@ -42,6 +58,9 @@ class FakeRayDataset:
     def num_blocks(self) -> int:
         return len(self.blocks)
 
+    def count(self) -> int:
+        return sum(len(block) for block in self.blocks)
+
 
 class FakeRayDataModule:
     Dataset = FakeRayDataset
@@ -49,17 +68,23 @@ class FakeRayDataModule:
     def __init__(self) -> None:
         self.from_arrow_refs_input: list[Any] | None = None
         self.from_pandas_refs_input: list[Any] | None = None
+        self.range_blocks: list[lazy.pd.DataFrame] | None = None
+        self.reverse_mapped_blocks = False
 
     def range(self, num_records: int) -> FakeRayDataset:
-        return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
+        blocks = self.range_blocks or [lazy.pd.DataFrame({"id": list(range(num_records))})]
+        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
 
     def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_arrow_refs_input = refs
-        return FakeRayDataset([_arrow_ref_to_pandas(ref) for ref in refs])
+        return FakeRayDataset(
+            [_arrow_ref_to_pandas(ref) for ref in refs],
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
 
     def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_pandas_refs_input = refs
-        return FakeRayDataset(list(refs))
+        return FakeRayDataset(list(refs), reverse_mapped_blocks=self.reverse_mapped_blocks)
 
 
 def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
@@ -87,7 +112,7 @@ def _designer(
     *,
     tmp_path: Path,
     stub_model_providers: Any,
-    backend: RayBackend,
+    backend: RayBackend | None,
 ) -> DataDesigner:
     return DataDesigner(
         artifact_path=tmp_path,
@@ -106,6 +131,12 @@ def _summary_config_builder(stub_model_configs: Any) -> DataDesignerConfigBuilde
             expr="{{ sku }}:{{ label }}",
         )
     )
+    return config_builder
+
+
+def _summary_seed_config_builder(stub_model_configs: Any, seed_df: lazy.pd.DataFrame) -> DataDesignerConfigBuilder:
+    config_builder = _summary_config_builder(stub_model_configs)
+    config_builder.with_seed_dataset(DataFrameSeedSource(df=seed_df))
     return config_builder
 
 
@@ -150,6 +181,199 @@ def test_explicit_order_column_sorts_stably_and_can_be_dropped(
     assert output_df["summary"].tolist() == ["a:first", "b:second", "c:third", "d:fourth", "e:fifth"]
     if not drop_order_column:
         assert output_df["row_order"].tolist() == [0, 1, 2, 3, 4]
+
+
+def test_hidden_row_id_preserves_input_dataset_order_without_schema_pollution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset(
+        [
+            lazy.pd.DataFrame({"sku": ["a", "b"], "label": ["first", "second"]}),
+            lazy.pd.DataFrame({"sku": ["c"], "label": ["third"]}),
+            lazy.pd.DataFrame({"sku": ["d", "e"], "label": ["fourth", "fifth"]}),
+        ],
+        reverse_mapped_blocks=True,
+    )
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=1, preserve_order=True),
+    )
+
+    output_df = (
+        designer.create(_summary_config_builder(stub_model_configs), input_dataset=input_dataset)
+        .load_dataset()
+        .to_pandas()
+    )
+
+    assert list(output_df.columns) == ["sku", "label", "summary"]
+    assert output_df["sku"].tolist() == ["a", "b", "c", "d", "e"]
+    assert output_df["summary"].tolist() == [
+        "a:first",
+        "b:second",
+        "c:third",
+        "d:fourth",
+        "e:fifth",
+    ]
+    assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+@pytest.mark.parametrize("object_ref_format", ["pandas", "arrow"])
+def test_hidden_row_id_preserves_object_ref_order_without_schema_pollution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+    object_ref_format: str,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray.data.reverse_mapped_blocks = True
+    if object_ref_format == "pandas":
+        input_refs: list[Any] = [
+            lazy.pd.DataFrame({"sku": ["a"], "label": ["first"]}),
+            lazy.pd.DataFrame({"sku": ["b"], "label": ["second"]}),
+            lazy.pd.DataFrame({"sku": ["c"], "label": ["third"]}),
+        ]
+    else:
+        input_refs = [
+            lazy.pa.table({"sku": ["a"], "label": ["first"]}),
+            lazy.pa.table({"sku": ["b"], "label": ["second"]}),
+            lazy.pa.table({"sku": ["c"], "label": ["third"]}),
+        ]
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=1, object_ref_format=object_ref_format, preserve_order=True),
+    )
+
+    output_df = (
+        designer.create(_summary_config_builder(stub_model_configs), input_dataset=input_refs)
+        .load_dataset()
+        .to_pandas()
+    )
+
+    assert output_df.to_dict(orient="records") == [
+        {"sku": "a", "label": "first", "summary": "a:first"},
+        {"sku": "b", "label": "second", "summary": "b:second"},
+        {"sku": "c", "label": "third", "summary": "c:third"},
+    ]
+    assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+def test_hidden_row_id_preserves_arrow_ref_output_order_without_schema_pollution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset(
+        [
+            lazy.pd.DataFrame({"sku": ["a"], "label": ["first"]}),
+            lazy.pd.DataFrame({"sku": ["b"], "label": ["second"]}),
+        ],
+        reverse_mapped_blocks=True,
+    )
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=1, output="arrow_refs", preserve_order=True),
+    )
+
+    results = designer.create(_summary_config_builder(stub_model_configs), input_dataset=input_dataset)
+    output_df = results.load_dataset().to_pandas()
+
+    assert len(results.output) == 1
+    assert output_df.to_dict(orient="records") == [
+        {"sku": "a", "label": "first", "summary": "a:first"},
+        {"sku": "b", "label": "second", "summary": "b:second"},
+    ]
+    assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+def test_hidden_row_id_preserves_from_scratch_order_without_schema_pollution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray.data.range_blocks = [
+        lazy.pd.DataFrame({"id": [0, 1]}),
+        lazy.pd.DataFrame({"id": [2]}),
+        lazy.pd.DataFrame({"id": [3, 4]}),
+    ]
+    fake_ray.data.reverse_mapped_blocks = True
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=1, preserve_order=True),
+    )
+
+    output_df = designer.create(stub_sampler_only_config_builder, num_records=5).load_dataset().to_pandas()
+
+    assert len(output_df) == 5
+    assert list(output_df.columns) == ["uuid", "category", "uniform"]
+    assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+def test_seed_config_without_input_dataset_reads_partition_offsets_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray.data.range_blocks = [
+        lazy.pd.DataFrame({"id": [0, 1]}),
+        lazy.pd.DataFrame({"id": [2, 3]}),
+        lazy.pd.DataFrame({"id": [4]}),
+    ]
+    seed_df = lazy.pd.DataFrame(
+        {
+            "sku": ["a", "b", "c", "d", "e"],
+            "label": ["first", "second", "third", "fourth", "fifth"],
+        }
+    )
+    local_before = _designer(
+        tmp_path=tmp_path / "local-before",
+        stub_model_providers=stub_model_providers,
+        backend=None,
+    )
+    ray_designer = _designer(
+        tmp_path=tmp_path / "ray",
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=2),
+    )
+    local_after = _designer(
+        tmp_path=tmp_path / "local-after",
+        stub_model_providers=stub_model_providers,
+        backend=None,
+    )
+
+    assert (
+        len(local_before.preview(_summary_seed_config_builder(stub_model_configs, seed_df), num_records=1).dataset) == 1
+    )
+    output_df = (
+        ray_designer.create(_summary_seed_config_builder(stub_model_configs, seed_df), num_records=5)
+        .load_dataset()
+        .to_pandas()
+    )
+    assert (
+        len(local_after.preview(_summary_seed_config_builder(stub_model_configs, seed_df), num_records=1).dataset) == 1
+    )
+
+    assert output_df.to_dict(orient="records") == [
+        {"sku": "a", "label": "first", "summary": "a:first"},
+        {"sku": "b", "label": "second", "summary": "b:second"},
+        {"sku": "c", "label": "third", "summary": "c:third"},
+        {"sku": "d", "label": "fourth", "summary": "d:fourth"},
+        {"sku": "e", "label": "fifth", "summary": "e:fifth"},
+    ]
 
 
 def test_pandas_object_refs_preserve_schema_column_order(

--- a/packages/data-designer/tests/integrations/ray/test_semantics.py
+++ b/packages/data-designer/tests/integrations/ray/test_semantics.py
@@ -23,8 +23,7 @@ class FakeRayDataset:
         self.blocks = blocks
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
-        fn_kwargs = kwargs.get("fn_kwargs") or {}
-        return FakeRayDataset([fn(block, **fn_kwargs) for block in self.blocks])
+        return FakeRayDataset(_map_batches_blocks(fn, self.blocks, kwargs))
 
     def to_arrow_refs(self) -> list[str]:
         return [f"arrow-ref-{i}" for i, _ in enumerate(self.blocks)]
@@ -60,6 +59,13 @@ class FakeRayDataModule:
     def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_pandas_refs_input = refs
         return FakeRayDataset(list(refs))
+
+
+def _map_batches_blocks(fn: Any, blocks: list[lazy.pd.DataFrame], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
+    fn_kwargs = kwargs.get("fn_kwargs") or {}
+    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
+    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
+    return [map_fn(block, **fn_kwargs) for block in blocks]
 
 
 def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -15,10 +15,11 @@ import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.run_config import RunConfig
+from data_designer.config.seed import SamplingStrategy
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
-from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError
+from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
 
@@ -234,7 +235,7 @@ def test_driver_preflight_rejects_input_dataset_with_existing_seed_config(
     assert input_dataset.map_batches_called is False
 
 
-def test_driver_preflight_rejects_seed_config_without_input_dataset(
+def test_driver_preflight_rejects_shuffled_seed_config_without_input_dataset(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     stub_model_configs: Any,
@@ -242,7 +243,10 @@ def test_driver_preflight_rejects_seed_config_without_input_dataset(
 ) -> None:
     fake_ray = _install_boundary_ray(monkeypatch)
     config_builder = _input_expression_config_builder(stub_model_configs)
-    config_builder.with_seed_dataset(DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [99], "label": ["seed"]})))
+    config_builder.with_seed_dataset(
+        DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [99], "label": ["seed"]})),
+        sampling_strategy=SamplingStrategy.SHUFFLE,
+    )
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -251,7 +255,41 @@ def test_driver_preflight_rejects_seed_config_without_input_dataset(
         backend=RayBackend(batch_size=1),
     )
 
-    with pytest.raises(RayBackendConfigurationError):
+    with pytest.raises(RayBackendConfigurationError, match="ordered sampling"):
         designer.create(config_builder, num_records=2)
 
     assert fake_ray.data.range_dataset is None
+
+
+def test_worker_failure_includes_block_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    class FailingDatasetBuilder:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        def build_preview(self, *, num_records: int) -> lazy.pd.DataFrame:
+            del num_records
+            raise RuntimeError("worker boom")
+
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    monkeypatch.setattr(ray_backend_module, "DatasetBuilder", FailingDatasetBuilder)
+
+    with pytest.raises(RayDatasetGenerationError, match="range rows 5-6") as exc_info:
+        ray_backend_module._generate_batch(
+            lazy.pd.DataFrame({"id": [5, 6]}),
+            config_builder=_input_expression_config_builder(stub_model_configs),
+            worker_options=_worker_options_from_designer(designer),
+            use_input_dataset=False,
+        )
+
+    assert "2 input row(s)" in str(exc_info.value)
+    assert "worker boom" in str(exc_info.value)

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -14,10 +14,12 @@ import pytest
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.engine.storage.artifact_storage import BatchStage
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
@@ -124,18 +126,17 @@ def test_worker_options_and_map_payload_are_pickle_serializable(
     designer.set_run_config(RunConfig(buffer_size=2))
     worker_options = _worker_options_from_designer(designer)
     config_builder = _input_expression_config_builder(stub_model_configs)
-
-    payload = {
-        "config_builder": config_builder,
-        "worker_options": worker_options,
-        "use_input_dataset": True,
-    }
+    payload = ray_backend_module._compile_ray_execution_payload(
+        config_builder=config_builder,
+        worker_options=worker_options,
+        use_input_dataset=True,
+    )
 
     round_tripped = pickle.loads(pickle.dumps(payload))
 
-    assert round_tripped["use_input_dataset"] is True
-    assert round_tripped["worker_options"].run_config.buffer_size == 2
-    assert round_tripped["config_builder"].get_seed_config() is None
+    assert round_tripped.use_input_dataset is True
+    assert round_tripped.worker_options.run_config.buffer_size == 2
+    assert DataDesignerConfig.model_validate_json(round_tripped.config_json).seed_config is None
 
 
 def test_worker_options_and_map_payload_are_cloudpickle_serializable_when_available(
@@ -152,17 +153,146 @@ def test_worker_options_and_map_payload_are_cloudpickle_serializable_when_availa
     )
     worker_options = _worker_options_from_designer(designer)
     config_builder = _input_expression_config_builder(stub_model_configs)
-
-    payload = {
-        "config_builder": config_builder,
-        "worker_options": worker_options,
-        "use_input_dataset": True,
-    }
+    payload = ray_backend_module._compile_ray_execution_payload(
+        config_builder=config_builder,
+        worker_options=worker_options,
+        use_input_dataset=True,
+    )
 
     round_tripped = cloudpickle.loads(cloudpickle.dumps(payload))
 
-    assert round_tripped["worker_options"].default_provider_name == worker_options.default_provider_name
-    assert round_tripped["config_builder"].get_seed_config() is None
+    assert round_tripped.worker_options.default_provider_name == worker_options.default_provider_name
+    assert DataDesignerConfig.model_validate_json(round_tripped.config_json).seed_config is None
+
+
+def test_in_memory_preview_artifact_storage_keeps_processor_outputs_off_disk() -> None:
+    storage = ray_backend_module._InMemoryPreviewArtifactStorage()
+    dataframe = lazy.pd.DataFrame({"value": [1, 2]})
+
+    path = storage.write_parquet_file(
+        "schema-transform.parquet",
+        dataframe,
+        BatchStage.PROCESSORS_OUTPUTS,
+    )
+
+    assert not path.exists()
+    assert storage.list_processor_names() == ["schema-transform"]
+    assert storage.load_processor_dataset("schema-transform").to_dict(orient="records") == [
+        {"value": 1},
+        {"value": 2},
+    ]
+
+    storage.clear()
+
+    assert storage.list_processor_names() == []
+    assert storage.load_processor_dataset("schema-transform").empty
+
+
+def test_ray_batch_worker_reuses_setup_and_clears_block_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    payload = ray_backend_module._compile_ray_execution_payload(
+        config_builder=_input_expression_config_builder(stub_model_configs),
+        worker_options=_worker_options_from_designer(designer),
+        use_input_dataset=True,
+    )
+    resource_provider_ids: list[int] = []
+    model_registry_ids: list[int] = []
+    artifact_storage_ids: list[int] = []
+    seed_records: list[list[dict[str, Any]]] = []
+    processor_names_seen: list[list[str]] = []
+
+    class RecordingBuilder:
+        def __init__(
+            self,
+            *,
+            data_designer_config: DataDesignerConfig,
+            resource_provider: Any,
+            use_async: bool | None = None,
+        ) -> None:
+            assert use_async is True
+            assert data_designer_config.seed_config is not None
+            self._resource_provider: Any = resource_provider
+            resource_provider_ids.append(id(resource_provider))
+            model_registry_ids.append(id(resource_provider.model_registry))
+            artifact_storage_ids.append(id(resource_provider.artifact_storage))
+            seed_records.append(data_designer_config.seed_config.source.df.to_dict(orient="records"))
+
+        def build_preview(self, *, num_records: int) -> Any:
+            return lazy.pd.DataFrame({"row": list(range(num_records))})
+
+        def process_preview(self, dataset: Any) -> Any:
+            self._resource_provider.artifact_storage.write_parquet_file(
+                "processor.parquet",
+                dataset,
+                BatchStage.PROCESSORS_OUTPUTS,
+            )
+            processor_names_seen.append(self._resource_provider.artifact_storage.list_processor_names())
+            return dataset
+
+    monkeypatch.setattr(ray_backend_module, "DatasetBuilder", RecordingBuilder)
+    worker = ray_backend_module._RayBatchWorker(execution_payload=payload)
+
+    first = worker(lazy.pd.DataFrame({"x": [1], "label": ["a"]}))
+    second = worker(lazy.pd.DataFrame({"x": [2, 3], "label": ["b", "c"]}))
+
+    assert first.to_dict(orient="records") == [{"row": 0}]
+    assert second.to_dict(orient="records") == [{"row": 0}, {"row": 1}]
+    assert len(set(resource_provider_ids)) == 1
+    assert len(set(model_registry_ids)) == 1
+    assert len(set(artifact_storage_ids)) == 1
+    assert seed_records == [
+        [{"x": 1, "label": "a"}],
+        [{"x": 2, "label": "b"}, {"x": 3, "label": "c"}],
+    ]
+    assert processor_names_seen == [["processor"], ["processor"]]
+    assert worker._artifact_storage.list_processor_names() == []
+    assert worker._resource_provider.seed_reader is None
+    for reader in worker._seed_reader_registry._readers.values():
+        assert not hasattr(reader, "source")
+        assert not hasattr(reader, "secret_resolver")
+
+
+def test_ray_execution_payload_is_driver_config_snapshot(
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    payload = ray_backend_module._compile_ray_execution_payload(
+        config_builder=config_builder,
+        worker_options=_worker_options_from_designer(designer),
+        use_input_dataset=True,
+    )
+    config_builder.add_column(
+        ExpressionColumnConfig(
+            name="driver_only",
+            expr="{{ label }}",
+        )
+    )
+
+    output_batch = ray_backend_module._RayBatchWorker(execution_payload=payload)(
+        lazy.pd.DataFrame({"x": [1], "label": ["a"]})
+    )
+
+    assert output_batch.to_dict(orient="records") == [{"x": 1, "label": "a", "x_label": "1-a"}]
+    assert config_builder.get_seed_config() is None
+    assert DataDesignerConfig.model_validate_json(payload.config_json).seed_config is None
 
 
 def test_worker_batch_input_seed_does_not_leak_into_driver_builder(

--- a/reports/ray_backend_architecture_report.html
+++ b/reports/ray_backend_architecture_report.html
@@ -856,15 +856,13 @@ ray_dataset_out = results.load_dataset()</pre>
   <section>
     <h2>Current Limitations</h2>
     <ol>
-      <li><strong>Per-block setup cost:</strong> each Ray block currently creates temp artifact storage, resource providers, registries, and a DatasetBuilder.</li>
-      <li><strong>Per-block model health checks:</strong> workers may repeat checks that should be a driver preflight or cached per worker.</li>
-      <li><strong>No actor reuse:</strong> <code>map_batches</code> uses a function. A callable class or actor-style execution could reuse model clients and resource setup across blocks.</li>
-      <li><strong>Profiler artifact gap:</strong> Ray results are Ray-resident and <code>load_analysis()</code> currently returns <code>None</code>. Full profiler artifact generation remains future distributed/Ray-native work.</li>
-      <li><strong>Automatic ordering:</strong> explicit <code>order_column</code> sorting is supported, but hidden row-id injection for automatic <code>preserve_order=True</code> is still future work.</li>
-      <li><strong>Seed configs without input datasets:</strong> Ray now rejects this unsafe mode before execution. Partition-offset-aware seed readers remain future work; use in-memory Ray inputs for seeded Ray jobs today.</li>
-      <li><strong>From-scratch partitioning:</strong> <code>ray.data.range(num_records)</code> needs explicit block planning for high throughput.</li>
+      <li><strong>Actor lifetime tuning:</strong> callable-class workers now reuse resource providers and model clients, but production deployments still need real-cluster tuning for actor pool sizing, placement, and autoscaling behavior.</li>
+      <li><strong>Profiler artifact scope:</strong> Ray results now expose bounded worker profile summaries, trace events, and worker-local throttle snapshots through <code>load_analysis()</code>. Full local-style <code>DatasetProfilerResults</code> still requires materializing the dataset on the driver and remains unsupported for Ray-resident outputs.</li>
+      <li><strong>Automatic ordering:</strong> automatic hidden row-id preservation is implemented for Ray inputs and from-scratch range datasets, but order preservation still assumes one output row per input row.</li>
+      <li><strong>Seed configs without input datasets:</strong> ordered seed configs now use partition offsets. Shuffled seed sampling without an input dataset remains unsupported in Ray.</li>
+      <li><strong>From-scratch partitioning:</strong> explicit block planning controls exist, but production defaults should still be tuned against real cluster and model-provider behavior.</li>
       <li><strong>Processor side effects:</strong> unsafe processors are now rejected by default, but first-class distributed side-effect semantics are not implemented.</li>
-      <li><strong>Secrets and trust boundary:</strong> provider config and secret resolvers are serialized to workers. That is normal for trusted Ray clusters, but should be documented.</li>
+      <li><strong>Trusted-cluster boundary:</strong> provider config and secret resolvers are serialized to workers. The supported deployment assumption is a trusted single-tenant Ray cluster or equivalent platform isolation.</li>
     </ol>
   </section>
 
@@ -931,16 +929,17 @@ ray_dataset_out = results.load_dataset()</pre>
         </tr>
         <tr>
           <td>Phase D: Error and Metrics Surface</td>
-          <td><span class="good">Metrics done</span></td>
+          <td><span class="good">Metrics and bounded artifacts done</span></td>
           <td>
-            Worker metrics aggregation now uses a Ray-side metrics actor that returns compact usage, row-count,
-            block-count, failed-block, elapsed-time, and model-usage summaries to the Ray result object. Zero-row
-            worker metrics remain zero instead of falling back to requested driver row counts.
+            Worker metrics aggregation now uses a Ray-side actor that returns compact usage, row-count, block-count,
+            failed-block, elapsed-time, model-usage summaries, per-worker profile summaries, bounded trace events,
+            and worker-local throttle snapshots to the Ray result object. Zero-row worker metrics remain zero instead
+            of falling back to requested driver row counts.
           </td>
           <td>
-            Remaining: broader Ray task, serialization, object-store, cancellation, and worker exceptions should carry
-            richer task/block context. Validation counts, retry attribution, and full distributed profiler artifacts
-            remain future work rather than part of the initial Phase D metrics channel.
+            Remaining: broader Ray serialization, object-store, cancellation, and worker exceptions should carry richer
+            task/block context. Validation counts, retry attribution, and full local-style profiler reports remain
+            future work rather than part of the bounded Ray-native artifact channel.
           </td>
         </tr>
         <tr>
@@ -966,19 +965,21 @@ ray_dataset_out = results.load_dataset()</pre>
             rejected processors, success and failure paths, Ray installed and Ray absent.
           </td>
           <td>
-            Remaining for production: expand from fake Ray/test doubles into recurring real-Ray smoke coverage,
-            repeated OpenAI benchmark runs, and an apples-to-apples local async comparison.
+            Recurring opt-in real-Ray smoke coverage and an apples-to-apples OpenAI benchmark script now exist.
+            Remaining for production: run scheduled benchmarks with real credentials, keep trend artifacts, and expand
+            the real-Ray matrix beyond the initial recipe paths.
           </td>
         </tr>
       </tbody>
     </table>
 
     <div class="callout warning">
-      <strong>Sequence constraint:</strong> performance work should not mask correctness gaps. Worker reuse and block
-      planning are high-value optimizations, but they should follow the remaining row-id, seed-offset, error-context,
-      global-throttling, and processor-metadata gates above. Metrics aggregation, no-Ray optional import behavior,
-      Arrow-ref materialization, seeded-mode rejection, and zero-row metrics are no longer open roadmap items in this
-      experimental branch.
+      <strong>Sequence constraint:</strong> performance work should not mask correctness gaps. Worker reuse, block
+      planning, hidden row ids, ordered seed offsets, processor safety metadata, metrics aggregation, bounded
+      Ray-native observability artifacts, global throttling, no-Ray optional import behavior, Arrow-ref
+      materialization, and zero-row metrics are no longer open roadmap items in this experimental branch. Remaining
+      production hardening should focus on broader failure context, validation attribution, cancellation behavior, and
+      real-cluster benchmark trend data.
     </div>
   </section>
 
@@ -988,34 +989,41 @@ ray_dataset_out = results.load_dataset()</pre>
       <div class="card">
         <h3>Phase 1: Correctness Hardening</h3>
         <ul>
-          <li><span class="good">Done:</span> reject seed configs without <code>input_dataset</code> instead of duplicating early rows across Ray batches.</li>
+          <li><span class="good">Done:</span> support ordered seed configs without <code>input_dataset</code> by using partition offsets.</li>
           <li><span class="good">Done:</span> rebuild Arrow-ref result datasets from materialized refs so <code>load_dataset()</code> does not re-run generation.</li>
           <li><span class="good">Done:</span> aggregate Ray worker metrics and preserve zero-row worker totals.</li>
+          <li><span class="good">Done:</span> expose bounded Ray worker profile summaries and trace artifacts without driver dataset materialization.</li>
           <li><span class="good">Done:</span> reject unsupported processors by default and cover the bypass path.</li>
           <li><span class="good">Done:</span> add tests for explicit ordering, ObjectRef input formats, same-process local-then-Ray execution, optional-extra behavior, and metrics aggregation.</li>
-          <li>Remaining: add automatic hidden row-id preservation for Ray inputs and from-scratch generation.</li>
-          <li>Remaining: add partition-offset-aware support for seed configs without requiring <code>input_dataset</code>.</li>
-          <li>Remaining: preflight model health checks on the driver and skip repeated worker checks.</li>
+          <li><span class="good">Done:</span> add automatic hidden row-id preservation for Ray inputs and from-scratch generation.</li>
+          <li><span class="good">Done:</span> preflight model health checks on the driver and skip repeated worker checks by default.</li>
+          <li>Remaining: add shuffled seed sampling for Ray seed configs without <code>input_dataset</code>.</li>
         </ul>
       </div>
       <div class="card">
         <h3>Phase 2: Worker Reuse</h3>
         <ul>
-          <li>Use Ray Data callable classes for <code>map_batches</code> so setup runs once per worker.</li>
-          <li>Reuse model client pools and resource providers per worker.</li>
-          <li>Replace temp artifact storage with an in-memory preview artifact abstraction where possible.</li>
-          <li>Broadcast immutable compiled configs instead of deep-copying builders repeatedly.</li>
+          <li><span class="good">Done:</span> use Ray Data callable classes for <code>map_batches</code> so setup runs once per worker.</li>
+          <li><span class="good">Done:</span> reuse model client pools and resource providers per worker.</li>
+          <li><span class="good">Done:</span> replace temp artifact storage with an in-memory preview artifact abstraction for preview generation.</li>
+          <li><span class="good">Done:</span> broadcast an immutable serialized execution payload instead of deep-copying builders repeatedly.</li>
         </ul>
       </div>
       <div class="card">
         <h3>Phase 3: Cluster Throughput</h3>
         <ul>
-          <li>Expose <code>override_num_blocks</code> / block planning controls.</li>
-          <li>Coordinate provider throttling globally across Ray workers.</li>
-          <li>Support actor placement, CPU/GPU/resource labels, and autoscaling-friendly defaults.</li>
-          <li>Extend Ray-native trace collection beyond the current compact execution metrics actor.</li>
+          <li><span class="good">Done:</span> expose <code>override_num_blocks</code> / block planning controls.</li>
+          <li><span class="good">Done:</span> coordinate provider throttling globally across Ray workers.</li>
+          <li><span class="good">Done:</span> support actor placement, CPU/GPU/resource labels, and autoscaling-friendly execution controls.</li>
+          <li><span class="good">Done:</span> extend Ray-native trace collection beyond the compact execution metrics actor with bounded worker events.</li>
         </ul>
       </div>
+    </div>
+    <div class="callout">
+      <strong>Global throttling design note:</strong> Ray now injects an actor-backed throttle manager proxy before
+      <code>ModelRegistry</code> registers model facades, so <code>ThrottledModelClient</code> acquire/release calls
+      coordinate through one Ray-side state holder. Result metrics include the global throttle snapshot, while
+      observability artifacts can also surface worker-local throttle state when a local manager is used.
     </div>
     <div class="diagram" aria-label="Optimization roadmap">
       <svg viewBox="0 0 1100 260" role="img">
@@ -1062,8 +1070,9 @@ ray_dataset_out = results.load_dataset()</pre>
         model clients and DataDesigner resources once per worker process.
       </li>
       <li>
-        <strong>Extend the distributed metrics channel.</strong> Add validation counts, retry attribution, task traces,
-        and profiler artifact summaries on top of the current worker usage and failed-block aggregation.
+        <strong>Extend the distributed metrics channel.</strong> Add validation counts, retry attribution, object-store
+        events, and cancellation context on top of the current worker usage, failed-block, trace, profile, and
+        throttle-snapshot aggregation.
       </li>
     </ol>
   </section>

--- a/scripts/benchmarks/benchmark_ray_openai.py
+++ b/scripts/benchmarks/benchmark_ray_openai.py
@@ -3,9 +3,14 @@
 
 """Benchmark local and Ray execution with the configured OpenAI provider.
 
-This benchmark intentionally uses only OpenAI model configs/providers while
-exercising a real docs/assets recipe. It is meant for the experimental Ray
-backend report, not as a stable public benchmark suite.
+Live provider calls are intentionally opt-in:
+
+    DATA_DESIGNER_RUN_LIVE_OPENAI_BENCHMARK=1 \
+        python scripts/benchmarks/benchmark_ray_openai.py --run-live --iterations 3
+
+The suite compares local sync, local async, Ray Dataset, and Ray Arrow-ref paths
+against the same docs/assets recipe, batch size, and model concurrency settings.
+It emits line-delimited JSON for logs and can write a machine-readable report.
 """
 
 from __future__ import annotations
@@ -14,94 +19,196 @@ import argparse
 import copy
 import importlib.util
 import json
+import math
+import os
+import statistics
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.default_model_settings import get_default_providers
+from data_designer.config.default_model_settings import (
+    get_default_providers,
+    resolve_seed_default_model_settings,
+)
 from data_designer.config.models import ModelConfig, ModelProvider
+from data_designer.config.run_config import RunConfig
 from data_designer.integrations.ray import RayBackend
 from data_designer.interface.data_designer import DataDesigner
 
-BackendName = Literal["local", "ray"]
+BackendName = Literal["local-sync", "local-async", "ray-dataset", "ray-arrow-refs"]
+RayOutputMode = Literal["dataset", "arrow_refs"]
 
+ALL_BACKENDS: tuple[BackendName, ...] = ("local-sync", "local-async", "ray-dataset", "ray-arrow-refs")
 RESULT_PREFIX = "RAY_OPENAI_BENCHMARK_RESULT="
+LIVE_RUN_ENV = "DATA_DESIGNER_RUN_LIVE_OPENAI_BENCHMARK"
 DEFAULT_RECIPE_PATH = Path("docs/assets/recipes/code_generation/text_to_python.py")
 DEFAULT_NUM_RECORDS = 256
 DEFAULT_BATCH_SIZE = 16
+DEFAULT_ITERATIONS = 1
 DEFAULT_RAY_CPUS = 4
 DEFAULT_MODEL_ALIAS = "openai-text"
+DEFAULT_PROVIDER_NAME = "openai"
+DEFAULT_SEED = 11
+
+
+@dataclass(frozen=True)
+class MetricStats:
+    mean: float
+    stdev: float
+    minimum: float
+    maximum: float
+    n: int
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "mean": self.mean,
+            "stdev": self.stdev,
+            "min": self.minimum,
+            "max": self.maximum,
+            "n": self.n,
+        }
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--recipe-path", type=Path, default=DEFAULT_RECIPE_PATH)
     parser.add_argument("--model-alias", type=str, default=DEFAULT_MODEL_ALIAS)
+    parser.add_argument("--provider-name", type=str, default=DEFAULT_PROVIDER_NAME)
     parser.add_argument("--num-records", type=int, default=DEFAULT_NUM_RECORDS)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--max-parallel-requests", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--ray-cpus", type=int, default=DEFAULT_RAY_CPUS)
-    parser.add_argument("--backends", type=str, default="local,ray", help="Comma-separated subset of: local,ray")
+    parser.add_argument(
+        "--backends",
+        type=str,
+        default="all",
+        help="Comma-separated subset of: local-sync,local-async,ray-dataset,ray-arrow-refs, or all.",
+    )
     parser.add_argument("--artifact-root", type=Path, default=Path("/tmp/dd-ray-openai-benchmark-artifacts"))
     parser.add_argument("--managed-assets-path", type=Path, default=Path("/tmp/dd-ray-openai-benchmark-managed-assets"))
     parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument(
+        "--run-live",
+        action="store_true",
+        default=False,
+        help=f"Allow live provider calls. Also accepted when {LIVE_RUN_ENV}=1.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
+    _validate_args(args)
+    _require_live_opt_in(run_live=args.run_live)
+
     args.artifact_root.mkdir(parents=True, exist_ok=True)
     args.managed_assets_path.mkdir(parents=True, exist_ok=True)
 
+    resolve_seed_default_model_settings()
     selected_backends = _parse_backends(args.backends)
     recipe = _load_recipe(args.recipe_path)
-    openai_providers = _openai_providers()
+    providers = _provider_configs(args.provider_name)
+    _require_provider_credentials(providers)
+
+    setup_config = _build_openai_config(
+        recipe=recipe,
+        model_alias=args.model_alias,
+        provider_name=args.provider_name,
+        max_parallel_requests=args.max_parallel_requests,
+    )
+    expected_columns = [column.name for column in setup_config.get_column_configs()]
     setup = {
         "recipe_path": str(args.recipe_path),
         "model_alias": args.model_alias,
+        "provider_name": args.provider_name,
         "num_records": args.num_records,
         "batch_size": args.batch_size,
+        "max_parallel_requests": args.max_parallel_requests,
+        "iterations": args.iterations,
+        "seed": args.seed,
         "ray_cpus": args.ray_cpus,
         "backends": selected_backends,
         "skip_health_checks": True,
-        "model_configs": _model_config_summary(_build_openai_config(recipe, args.model_alias).model_configs),
-        "providers": [provider.name for provider in openai_providers],
-        "local_execution": "current local default backend",
-        "ray_execution": "RayBackend async worker path",
+        "model_configs": _model_config_summary(setup_config.model_configs),
+        "providers": [provider.name for provider in providers],
+        "expected_columns": expected_columns,
+        "live_run_env": LIVE_RUN_ENV,
     }
     _emit({"type": "setup", **setup})
 
     results: list[dict[str, Any]] = []
-    for backend in selected_backends:
-        result = _run_backend(
-            backend=backend,
-            recipe=recipe,
-            model_alias=args.model_alias,
-            num_records=args.num_records,
-            batch_size=args.batch_size,
-            ray_cpus=args.ray_cpus,
-            artifact_root=args.artifact_root,
-            managed_assets_path=args.managed_assets_path,
-            model_providers=openai_providers,
-        )
-        results.append(result)
-        _emit({"type": "backend_result", **result})
+    for iteration in range(1, args.iterations + 1):
+        iteration_seed = args.seed + iteration - 1
+        for backend in selected_backends:
+            result = _run_backend(
+                backend=backend,
+                iteration=iteration,
+                seed=iteration_seed,
+                recipe=recipe,
+                model_alias=args.model_alias,
+                provider_name=args.provider_name,
+                num_records=args.num_records,
+                batch_size=args.batch_size,
+                max_parallel_requests=args.max_parallel_requests,
+                ray_cpus=args.ray_cpus,
+                artifact_root=args.artifact_root,
+                managed_assets_path=args.managed_assets_path,
+                model_providers=providers,
+                expected_columns=expected_columns,
+            )
+            results.append(result)
+            _emit({"type": "backend_result", **result})
 
     summary = _build_summary(results)
-    if summary is not None:
-        _emit({"type": "summary", **summary})
+    _emit({"type": "summary", **summary})
     if args.output_json is not None:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
-        args.output_json.write_text(json.dumps({"setup": setup, "results": results, "summary": summary}, indent=2))
+        args.output_json.write_text(
+            json.dumps({"setup": setup, "results": results, "summary": summary}, indent=2, default=_json_default)
+        )
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.num_records < 1:
+        raise ValueError("--num-records must be >= 1.")
+    if args.batch_size < 1:
+        raise ValueError("--batch-size must be >= 1.")
+    if args.max_parallel_requests < 1:
+        raise ValueError("--max-parallel-requests must be >= 1.")
+    if args.iterations < 1:
+        raise ValueError("--iterations must be >= 1.")
+    if args.ray_cpus < 1:
+        raise ValueError("--ray-cpus must be >= 1.")
+
+
+def _require_live_opt_in(*, run_live: bool) -> None:
+    if run_live or os.environ.get(LIVE_RUN_ENV) == "1":
+        return
+    raise SystemExit(
+        f"This benchmark performs live provider calls. Re-run with --run-live or set {LIVE_RUN_ENV}=1 to opt in."
+    )
 
 
 def _parse_backends(value: str) -> list[BackendName]:
+    if value.strip() == "all":
+        return list(ALL_BACKENDS)
+
     backends: list[BackendName] = []
+    seen: set[str] = set()
     for raw_backend in value.split(","):
         backend = raw_backend.strip()
-        if backend not in {"local", "ray"}:
-            raise ValueError(f"Unsupported backend {backend!r}. Expected 'local', 'ray', or both.")
-        backends.append(backend)  # type: ignore[arg-type]
+        if backend not in ALL_BACKENDS:
+            raise ValueError(f"Unsupported backend {backend!r}. Expected one of {', '.join(ALL_BACKENDS)} or all.")
+        if backend not in seen:
+            backends.append(backend)  # type: ignore[arg-type]
+            seen.add(backend)
+    if not backends:
+        raise ValueError("At least one backend must be selected.")
     return backends
 
 
@@ -114,16 +221,42 @@ def _load_recipe(recipe_path: Path) -> Any:
     return module
 
 
-def _openai_providers() -> list[ModelProvider]:
-    providers = [provider for provider in get_default_providers() if provider.name == "openai"]
+def _provider_configs(provider_name: str) -> list[ModelProvider]:
+    providers = [provider for provider in get_default_providers() if provider.name == provider_name]
     if not providers:
-        raise RuntimeError("No configured OpenAI model provider found.")
+        raise RuntimeError(f"No configured {provider_name!r} model provider found.")
     return providers
 
 
-def _build_openai_config(recipe: Any, model_alias: str) -> DataDesignerConfigBuilder:
+def _require_provider_credentials(providers: list[ModelProvider]) -> None:
+    missing_keys = [provider.api_key for provider in providers if not _provider_has_api_key(provider)]
+    if missing_keys:
+        keys = ", ".join(str(key) for key in missing_keys)
+        raise SystemExit(f"Provider credentials are missing for: {keys}.")
+
+
+def _provider_has_api_key(provider: ModelProvider) -> bool:
+    api_key = provider.api_key
+    if api_key is None:
+        return False
+    if api_key.isupper() and "_" in api_key:
+        return bool(os.environ.get(api_key))
+    return True
+
+
+def _build_openai_config(
+    *,
+    recipe: Any,
+    model_alias: str,
+    provider_name: str,
+    max_parallel_requests: int,
+) -> DataDesignerConfigBuilder:
     source_builder = recipe.build_config(model_alias=model_alias)
-    openai_model_configs = _openai_model_configs(source_builder.model_configs)
+    openai_model_configs = _provider_model_configs(
+        source_builder.model_configs,
+        provider_name=provider_name,
+        max_parallel_requests=max_parallel_requests,
+    )
     config_builder = DataDesignerConfigBuilder(
         model_configs=openai_model_configs,
         tool_configs=copy.deepcopy(source_builder.tool_configs),
@@ -135,14 +268,27 @@ def _build_openai_config(recipe: Any, model_alias: str) -> DataDesignerConfigBui
     return config_builder
 
 
-def _openai_model_configs(model_configs: list[ModelConfig]) -> list[ModelConfig]:
-    filtered = [
-        model_config.model_copy(deep=True, update={"skip_health_check": True})
-        for model_config in model_configs
-        if model_config.provider == "openai" or model_config.alias.startswith("openai-")
-    ]
+def _provider_model_configs(
+    model_configs: list[ModelConfig],
+    *,
+    provider_name: str,
+    max_parallel_requests: int,
+) -> list[ModelConfig]:
+    filtered = []
+    for model_config in model_configs:
+        if model_config.provider != provider_name and not model_config.alias.startswith(f"{provider_name}-"):
+            continue
+        inference_parameters = model_config.inference_parameters.model_copy(
+            update={"max_parallel_requests": max_parallel_requests}
+        )
+        filtered.append(
+            model_config.model_copy(
+                deep=True,
+                update={"inference_parameters": inference_parameters, "skip_health_check": True},
+            )
+        )
     if not filtered:
-        raise RuntimeError("No OpenAI model configs found in recipe configuration.")
+        raise RuntimeError(f"No {provider_name!r} model configs found in recipe configuration.")
     return filtered
 
 
@@ -163,139 +309,373 @@ def _model_config_summary(model_configs: list[ModelConfig]) -> list[dict[str, An
 def _run_backend(
     *,
     backend: BackendName,
+    iteration: int,
+    seed: int,
     recipe: Any,
     model_alias: str,
+    provider_name: str,
     num_records: int,
     batch_size: int,
+    max_parallel_requests: int,
     ray_cpus: int,
     artifact_root: Path,
     managed_assets_path: Path,
     model_providers: list[ModelProvider],
+    expected_columns: list[str],
 ) -> dict[str, Any]:
-    config_builder = _build_openai_config(recipe, model_alias)
-    artifact_path = artifact_root / f"{backend}-{num_records}-{int(time.time())}"
-    start = time.perf_counter()
-    if backend == "ray":
-        return _run_ray_backend(
+    config_builder = _build_openai_config(
+        recipe=recipe,
+        model_alias=model_alias,
+        provider_name=provider_name,
+        max_parallel_requests=max_parallel_requests,
+    )
+    artifact_path = artifact_root / f"{backend}-iter-{iteration:02d}"
+    if backend in {"local-sync", "local-async"}:
+        return _run_local_backend(
+            backend=backend,
+            use_async=backend == "local-async",
+            iteration=iteration,
+            seed=seed,
             config_builder=config_builder,
             num_records=num_records,
             batch_size=batch_size,
-            ray_cpus=ray_cpus,
+            max_parallel_requests=max_parallel_requests,
             artifact_path=artifact_path,
             managed_assets_path=managed_assets_path,
             model_providers=model_providers,
-            start=start,
+            expected_columns=expected_columns,
         )
-    return _run_local_backend(
+
+    return _run_ray_backend(
+        backend=backend,
+        ray_output="arrow_refs" if backend == "ray-arrow-refs" else "dataset",
+        iteration=iteration,
+        seed=seed,
         config_builder=config_builder,
         num_records=num_records,
+        batch_size=batch_size,
+        max_parallel_requests=max_parallel_requests,
+        ray_cpus=ray_cpus,
         artifact_path=artifact_path,
         managed_assets_path=managed_assets_path,
         model_providers=model_providers,
-        start=start,
+        expected_columns=expected_columns,
     )
 
 
 def _run_local_backend(
     *,
+    backend: BackendName,
+    use_async: bool,
+    iteration: int,
+    seed: int,
     config_builder: DataDesignerConfigBuilder,
     num_records: int,
+    batch_size: int,
+    max_parallel_requests: int,
     artifact_path: Path,
     managed_assets_path: Path,
     model_providers: list[ModelProvider],
-    start: float,
+    expected_columns: list[str],
 ) -> dict[str, Any]:
+    _seed_everything(seed)
     designer = DataDesigner(
         artifact_path=artifact_path,
         managed_assets_path=managed_assets_path,
         model_providers=model_providers,
     )
-    results = designer.create(config_builder, num_records=num_records)
-    output = results.load_dataset()
+    designer.set_run_config(_run_config(batch_size))
+    resource_provider = designer._create_resource_provider("benchmark", config_builder)
+    builder = designer._create_dataset_builder(config_builder.build(), resource_provider, use_async=use_async)
+
+    start = time.perf_counter()
+    raw_output = builder.build_preview(num_records=num_records)
+    output = builder.process_preview(raw_output)
     elapsed_seconds = time.perf_counter() - start
+    metrics = {
+        "total_rows": len(output),
+        "blocks": math.ceil(num_records / batch_size),
+        "failed_blocks": 0,
+        "elapsed_seconds": elapsed_seconds,
+        "model_usage": resource_provider.model_registry.get_model_usage_stats(elapsed_seconds) or None,
+    }
     return _result_payload(
-        backend="local",
+        backend=backend,
+        iteration=iteration,
+        seed=seed,
         output=output,
         elapsed_seconds=elapsed_seconds,
-        metrics=None,
+        metrics=metrics,
         artifact_path=artifact_path,
+        output_mode="pandas",
+        batch_size=batch_size,
+        max_parallel_requests=max_parallel_requests,
+        expected_columns=expected_columns,
+        expected_rows=num_records,
     )
 
 
 def _run_ray_backend(
     *,
+    backend: BackendName,
+    ray_output: RayOutputMode,
+    iteration: int,
+    seed: int,
     config_builder: DataDesignerConfigBuilder,
     num_records: int,
     batch_size: int,
+    max_parallel_requests: int,
     ray_cpus: int,
     artifact_path: Path,
     managed_assets_path: Path,
     model_providers: list[ModelProvider],
-    start: float,
+    expected_columns: list[str],
 ) -> dict[str, Any]:
+    _seed_everything(seed)
     ray = __import__("ray")
-    ray.init(num_cpus=ray_cpus, ignore_reinit_error=True)
+    ray.init(num_cpus=ray_cpus, ignore_reinit_error=True, include_dashboard=False)
     try:
         designer = DataDesigner(
             artifact_path=artifact_path,
             managed_assets_path=managed_assets_path,
             model_providers=model_providers,
-            backend=RayBackend(batch_size=batch_size),
+            backend=RayBackend(batch_size=batch_size, output=ray_output),
         )
+        designer.set_run_config(_run_config(batch_size))
+        start = time.perf_counter()
         results = designer.create(config_builder, num_records=num_records)
         output = results.load_dataset().to_pandas()
+        metrics = results.load_metrics().to_dict()
         elapsed_seconds = time.perf_counter() - start
-        return _result_payload(
-            backend="ray",
+        payload = _result_payload(
+            backend=backend,
+            iteration=iteration,
+            seed=seed,
             output=output,
             elapsed_seconds=elapsed_seconds,
-            metrics=results.load_metrics().to_dict(),
+            metrics=metrics,
             artifact_path=artifact_path,
+            output_mode=ray_output,
+            batch_size=batch_size,
+            max_parallel_requests=max_parallel_requests,
+            expected_columns=expected_columns,
+            expected_rows=num_records,
         )
+        if ray_output == "arrow_refs":
+            payload["arrow_ref_count"] = len(results.output)
+        return payload
     finally:
         ray.shutdown()
+
+
+def _run_config(batch_size: int) -> RunConfig:
+    return RunConfig(
+        buffer_size=batch_size,
+        disable_early_shutdown=True,
+        max_conversation_restarts=0,
+        max_conversation_correction_steps=0,
+    )
+
+
+def _seed_everything(seed: int) -> None:
+    lazy.np.random.seed(seed)
 
 
 def _result_payload(
     *,
     backend: BackendName,
+    iteration: int,
+    seed: int,
     output: Any,
     elapsed_seconds: float,
     metrics: dict[str, Any] | None,
     artifact_path: Path,
+    output_mode: str,
+    batch_size: int,
+    max_parallel_requests: int,
+    expected_columns: list[str],
+    expected_rows: int,
 ) -> dict[str, Any]:
     rows = len(output)
+    null_counts = {str(key): int(value) for key, value in output.isna().sum().to_dict().items()}
+    empty_string_counts = _empty_string_counts(output)
+    missing_columns = [column for column in expected_columns if column not in output.columns]
+    expected_null_counts = {column: null_counts.get(column, rows) for column in expected_columns}
+    validity = {
+        "row_count_matches": rows == expected_rows,
+        "expected_columns_present": not missing_columns,
+        "expected_columns_non_null": all(count == 0 for count in expected_null_counts.values()),
+        "all_output_valid": rows == expected_rows
+        and not missing_columns
+        and all(count == 0 for count in expected_null_counts.values()),
+    }
+    throughput = _throughput_payload(metrics=metrics, elapsed_seconds=elapsed_seconds, rows=rows)
     return {
         "backend": backend,
+        "iteration": iteration,
+        "seed": seed,
         "elapsed_seconds": elapsed_seconds,
         "rows": rows,
         "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
         "columns": list(output.columns),
-        "null_counts": output.isna().sum().to_dict(),
+        "missing_columns": missing_columns,
+        "null_counts": null_counts,
+        "empty_string_counts": empty_string_counts,
+        "validity": validity,
+        "throughput": throughput,
         "metrics": metrics,
         "artifact_path": str(artifact_path),
+        "output_mode": output_mode,
+        "batch_size": batch_size,
+        "max_parallel_requests": max_parallel_requests,
     }
 
 
-def _build_summary(results: list[dict[str, Any]]) -> dict[str, Any] | None:
-    by_backend = {result["backend"]: result for result in results}
-    local = by_backend.get("local")
-    ray = by_backend.get("ray")
-    if local is None or ray is None:
-        return None
-    local_elapsed = float(local["elapsed_seconds"])
-    ray_elapsed = float(ray["elapsed_seconds"])
+def _empty_string_counts(output: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for column in output.columns:
+        series = output[column]
+        if getattr(series.dtype, "kind", None) in {"O", "U", "S"}:
+            counts[str(column)] = int(series.fillna("").astype(str).eq("").sum())
+    return counts
+
+
+def _throughput_payload(*, metrics: dict[str, Any] | None, elapsed_seconds: float, rows: int) -> dict[str, Any]:
+    model_usage = (metrics or {}).get("model_usage") or {}
+    request_counts = _sum_nested_usage(model_usage, "request_usage")
+    token_counts = _sum_nested_usage(model_usage, "token_usage")
+    total_requests = int(request_counts.get("total_requests", 0))
+    total_tokens = int(token_counts.get("total_tokens", 0))
+    retry_count = _sum_first_available_counter(model_usage, ("retry_count", "retries", "total_retries"))
+    throttle_count = _sum_first_available_counter(
+        model_usage,
+        ("throttle_count", "rate_limited_requests", "throttled_requests"),
+    )
     return {
-        "local_elapsed_seconds": local_elapsed,
-        "ray_elapsed_seconds": ray_elapsed,
-        "ray_speedup_vs_local": local_elapsed / ray_elapsed if ray_elapsed > 0 else None,
-        "local_rows_per_second": local["rows_per_second"],
-        "ray_rows_per_second": ray["rows_per_second"],
+        "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
+        "requests_per_minute": total_requests / elapsed_seconds * 60 if elapsed_seconds > 0 else 0,
+        "tokens_per_second": total_tokens / elapsed_seconds if elapsed_seconds > 0 else 0,
+        "successful_requests": int(request_counts.get("successful_requests", 0)),
+        "failed_requests": int(request_counts.get("failed_requests", 0)),
+        "total_requests": total_requests,
+        "input_tokens": int(token_counts.get("input_tokens", 0)),
+        "output_tokens": int(token_counts.get("output_tokens", 0)),
+        "total_tokens": total_tokens,
+        "retry_count": retry_count if retry_count is not None else 0,
+        "retry_count_available": retry_count is not None,
+        "throttle_count": throttle_count if throttle_count is not None else 0,
+        "throttle_count_available": throttle_count is not None,
     }
+
+
+def _sum_nested_usage(model_usage: dict[str, Any], usage_key: str) -> dict[str, int | float]:
+    totals: dict[str, int | float] = {}
+    for stats in model_usage.values():
+        usage = stats.get(usage_key) if isinstance(stats, dict) else None
+        if not isinstance(usage, dict):
+            continue
+        for key, value in usage.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            totals[key] = totals.get(key, 0) + value
+    return totals
+
+
+def _sum_first_available_counter(model_usage: dict[str, Any], counter_names: tuple[str, ...]) -> int | None:
+    total = 0
+    found = False
+    for stats in model_usage.values():
+        if not isinstance(stats, dict):
+            continue
+        for counter_name in counter_names:
+            value = stats.get(counter_name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            total += int(value)
+            found = True
+            break
+    return total if found else None
+
+
+def _build_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
+    per_backend: dict[str, dict[str, Any]] = {}
+    for backend in ALL_BACKENDS:
+        backend_results = [result for result in results if result["backend"] == backend]
+        if not backend_results:
+            continue
+        per_backend[backend] = {
+            "iterations": len(backend_results),
+            "elapsed_seconds": _compute_stats(
+                [float(result["elapsed_seconds"]) for result in backend_results]
+            ).to_dict(),
+            "rows_per_second": _compute_stats(
+                [float(result["rows_per_second"]) for result in backend_results]
+            ).to_dict(),
+            "requests_per_minute": _compute_stats(
+                [float(result["throughput"]["requests_per_minute"]) for result in backend_results]
+            ).to_dict(),
+            "tokens_per_second": _compute_stats(
+                [float(result["throughput"]["tokens_per_second"]) for result in backend_results]
+            ).to_dict(),
+            "failed_requests": sum(int(result["throughput"]["failed_requests"]) for result in backend_results),
+            "retry_count": sum(int(result["throughput"]["retry_count"]) for result in backend_results),
+            "throttle_count": sum(int(result["throughput"]["throttle_count"]) for result in backend_results),
+            "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in backend_results),
+        }
+
+    comparisons = _speedup_comparisons(results, baseline_backend="local-sync")
+    return {
+        "per_backend": per_backend,
+        "comparisons_vs_local_sync": comparisons,
+        "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in results),
+    }
+
+
+def _speedup_comparisons(results: list[dict[str, Any]], *, baseline_backend: BackendName) -> dict[str, Any]:
+    by_iteration_backend = {(result["iteration"], result["backend"]): result for result in results}
+    comparisons: dict[str, Any] = {}
+    for backend in ALL_BACKENDS:
+        if backend == baseline_backend:
+            continue
+        speedups = []
+        for result in results:
+            if result["backend"] != backend:
+                continue
+            baseline = by_iteration_backend.get((result["iteration"], baseline_backend))
+            if baseline is None:
+                continue
+            elapsed = float(result["elapsed_seconds"])
+            if elapsed > 0:
+                speedups.append(float(baseline["elapsed_seconds"]) / elapsed)
+        if speedups:
+            comparisons[backend] = _compute_stats(speedups).to_dict()
+    return comparisons
+
+
+def _compute_stats(values: list[float]) -> MetricStats:
+    if not values:
+        return MetricStats(mean=0.0, stdev=0.0, minimum=0.0, maximum=0.0, n=0)
+    if len(values) == 1:
+        return MetricStats(mean=values[0], stdev=0.0, minimum=values[0], maximum=values[0], n=1)
+    return MetricStats(
+        mean=statistics.mean(values),
+        stdev=statistics.stdev(values),
+        minimum=min(values),
+        maximum=max(values),
+        n=len(values),
+    )
 
 
 def _emit(payload: dict[str, Any]) -> None:
-    print(f"{RESULT_PREFIX}{json.dumps(payload, sort_keys=True)}", flush=True)
+    print(f"{RESULT_PREFIX}{json.dumps(payload, sort_keys=True, default=_json_default)}", flush=True)
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, lazy.np.generic):
+        return value.item()
+    if isinstance(value, lazy.np.ndarray):
+        return value.tolist()
+    return str(value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📋 Summary

Integrates the Ray backend merge train into one tested branch so the conflict resolutions between worker reuse, row semantics, execution controls, throttling, benchmarks, and observability land together. This keeps the verified coordinator state intact instead of merging stale independent PR heads.

## 🔗 Related Issue

Closes #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21. References agent-found #29 for pre-existing strict docs warnings.

## 🔄 Changes

- Adds callable-class Ray workers with reusable resource providers, in-memory preview artifact storage, serialized execution payloads, and safer worker error context.
- Preserves row semantics with hidden row ids, ordered seed partition offsets, Arrow-ref result rebuilds, processor safety metadata, and global provider throttling through a Ray actor-backed proxy.
- Adds block planning, map resource options, actor-pool controls, driver model-health preflight, and worker health-check skipping by default.
- Adds Ray metrics, per-worker metrics, bounded observability artifacts, worker profiles/traces, throttle snapshots, real-Ray smoke coverage, and an OpenAI benchmark harness.
- Updates Ray deployment/trust-boundary docs and the Ray architecture report.

## 🧪 Testing

- [ ] `make test` passes — not run; targeted suites below were run.
- [x] Unit tests added/updated.
- [x] E2E tests added/updated — opt-in real-Ray smoke tests added; skipped unless `DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1`.
- [x] `UV_CACHE_DIR=.uv-cache uv run pytest packages/data-designer/tests/integrations/ray -q` — `76 passed, 3 skipped`.
- [x] `UV_CACHE_DIR=.uv-cache uv run pytest packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py packages/data-designer-engine/tests/engine/models/clients/test_factory.py -q` — `60 passed`.
- [x] `UV_CACHE_DIR=.uv-cache uv run ruff check ...` passed on Ray integration, Ray tests, throttle/model/resource files, and benchmark script.
- [x] `UV_CACHE_DIR=.uv-cache uv run --group docs mkdocs build` passed with pre-existing warnings tracked in #29.

## ✅ Checklist

- [x] Follows commit message conventions.
- [ ] Commits are signed off (DCO) — coordinator merge commits were created locally without signoff.
- [x] Architecture docs updated.