### PR TITLE
fix(ray): resolve recipe compatibility bugs

### DIFF
--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/async_scheduler.py
@@ -624,7 +624,13 @@ class AsyncTaskScheduler:
                 continue
             seen_instances.add(gid)
 
-            task = Task(column=col, row_group=rg_id, row_index=None, task_type="from_scratch")
+            strategy = self._graph.get_strategy(col)
+            if strategy == GenerationStrategy.CELL_BY_CELL:
+                await self._dispatch_root_cell_tasks(column=col, row_group=rg_id, row_group_size=rg_size)
+                continue
+
+            task_type = "from_scratch" if gen.can_generate_from_scratch else "batch"
+            task = Task(column=col, row_group=rg_id, row_index=None, task_type=task_type)
             # Also mark the "batch" variant as dispatched to prevent get_ready_tasks
             # from generating a duplicate for this column
             batch_alias = Task(column=col, row_group=rg_id, row_index=None, task_type="batch")
@@ -633,7 +639,7 @@ class AsyncTaskScheduler:
 
             # Acquire stateful lock *before* submission semaphore to preserve
             # row-group ordering. Held until generation completes (_execute_seed_task).
-            if gid in self._stateful_locks:
+            if task_type == "from_scratch" and gid in self._stateful_locks:
                 await self._stateful_locks[gid].acquire()
 
             await self._submission_semaphore.acquire()
@@ -642,14 +648,28 @@ class AsyncTaskScheduler:
             # Also mark all sibling output columns as dispatched (multi-column dedup)
             for sibling_col in self._gen_instance_to_columns.get(gid, []):
                 if sibling_col != col:
-                    self._dispatched.add(
-                        Task(column=sibling_col, row_group=rg_id, row_index=None, task_type="from_scratch")
-                    )
+                    self._dispatched.add(Task(column=sibling_col, row_group=rg_id, row_index=None, task_type=task_type))
                     self._dispatched.add(Task(column=sibling_col, row_group=rg_id, row_index=None, task_type="batch"))
             self._in_flight.add(task)
             if (s := self._rg_states.get(task.row_group)) is not None:
                 s.in_flight_count += 1
-            self._spawn_worker(self._execute_seed_task(task, gid))
+            if task_type == "from_scratch":
+                self._spawn_worker(self._execute_seed_task(task, gid))
+            else:
+                self._spawn_worker(self._execute_task(task))
+
+    async def _dispatch_root_cell_tasks(self, *, column: str, row_group: int, row_group_size: int) -> None:
+        """Dispatch a root cell-by-cell column once per active row."""
+        for row_index in range(row_group_size):
+            task = Task(column=column, row_group=row_group, row_index=row_index, task_type="cell")
+            if task in self._dispatched:
+                continue
+            await self._submission_semaphore.acquire()
+            self._dispatched.add(task)
+            self._in_flight.add(task)
+            if (state := self._rg_states.get(row_group)) is not None:
+                state.in_flight_count += 1
+            self._spawn_worker(self._execute_task(task))
 
     async def _execute_seed_task(self, task: Task, generator_id: int) -> None:
         """Execute a from_scratch task and release stateful lock if held."""

--- a/packages/data-designer-engine/src/data_designer/engine/models/utils.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/utils.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -50,7 +51,7 @@ class ChatMessage:
             result["tool_calls"] = self.tool_calls
         if self.tool_call_id:
             result["tool_call_id"] = self.tool_call_id
-        return result
+        return _to_json_safe(result)
 
     @classmethod
     def as_user(cls, content: str | list[dict[str, Any]]) -> ChatMessage:
@@ -128,3 +129,29 @@ def _text_block(value: Any) -> dict[str, Any]:
     else:
         text_value = str(value)
     return {"type": "text", "text": text_value}
+
+
+def _to_json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _to_json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_to_json_safe(item) for item in value]
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {field.name: _to_json_safe(getattr(value, field.name)) for field in dataclasses.fields(value)}
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _to_json_safe(model_dump(mode="json"))
+        except TypeError:
+            return _to_json_safe(model_dump())
+
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        return _to_json_safe(to_dict())
+
+    return str(value)

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py
@@ -240,6 +240,67 @@ async def test_scheduler_dispatches_seeds_first() -> None:
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_scheduler_dispatches_root_cell_columns_per_row() -> None:
+    """Root cell-by-cell columns must run as row tasks, not from-scratch tasks."""
+    provider = _mock_provider()
+    configs = [LLMTextColumnConfig(name="cell_out", prompt="Write a constant.", model_alias=MODEL_ALIAS)]
+    strategies = {"cell_out": GenerationStrategy.CELL_BY_CELL}
+    generators = {"cell_out": MockCellGenerator(config=_expr_config("cell_out"), resource_provider=provider)}
+    graph = ExecutionGraph.create(configs, strategies)
+    row_groups = [(0, 2)]
+    tracker = CompletionTracker.with_graph(graph, row_groups)
+    scheduler = AsyncTaskScheduler(
+        generators=generators,
+        graph=graph,
+        tracker=tracker,
+        row_groups=row_groups,
+        trace=True,
+    )
+
+    await scheduler.run()
+
+    traces = sorted(scheduler.traces, key=lambda trace: trace.row_index if trace.row_index is not None else -1)
+    assert [(trace.task_type, trace.row_index, trace.status) for trace in traces] == [
+        ("cell", 0, "ok"),
+        ("cell", 1, "ok"),
+    ]
+    assert tracker.is_row_group_complete(0, 2, ["cell_out"])
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_scheduler_dispatches_root_full_column_without_from_scratch_support() -> None:
+    """Root full-column generators that are not from-scratch receive the row-group dataframe."""
+    storage = MagicMock()
+    buffer_mgr = RowGroupBufferManager(storage)
+    provider = _mock_provider()
+    configs = [ExpressionColumnConfig(name="batch_out", expr="constant")]
+    strategies = {"batch_out": GenerationStrategy.FULL_COLUMN}
+    generators = {
+        "batch_out": MockFullColumnGenerator(config=_expr_config("batch_out"), resource_provider=provider),
+    }
+    graph = ExecutionGraph.create(configs, strategies)
+    row_groups = [(0, 2)]
+    tracker = CompletionTracker.with_graph(graph, row_groups)
+    scheduler = AsyncTaskScheduler(
+        generators=generators,
+        graph=graph,
+        tracker=tracker,
+        row_groups=row_groups,
+        buffer_manager=buffer_mgr,
+        trace=True,
+    )
+
+    await scheduler.run()
+
+    assert [(trace.task_type, trace.row_index, trace.status) for trace in scheduler.traces] == [("batch", None, "ok")]
+    assert buffer_mgr.get_dataframe(0).to_dict(orient="records") == [
+        {"batch_out": "batch_val"},
+        {"batch_out": "batch_val"},
+    ]
+    assert tracker.is_row_group_complete(0, 2, ["batch_out"])
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_scheduler_with_buffer_manager() -> None:
     """Scheduler writes results to buffer manager and checkpoints."""
     storage = MagicMock()

--- a/packages/data-designer-engine/tests/engine/models/test_model_utils.py
+++ b/packages/data-designer-engine/tests/engine/models/test_model_utils.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+
 from data_designer.engine.models.utils import ChatMessage, prompt_to_messages
+from data_designer.engine.processing.ginja.record import sanitize_record
 
 
 def test_prompt_to_messages() -> None:
@@ -21,3 +26,32 @@ def test_prompt_to_messages() -> None:
         ChatMessage.as_system(stub_system_prompt),
         ChatMessage.as_user([mult_modal_context, {"type": "text", "text": "hello"}]),
     ]
+
+
+def test_chat_message_trace_dict_is_json_safe_for_record_rendering() -> None:
+    @dataclass
+    class ToolArguments:
+        query: str
+
+    message = ChatMessage.as_assistant(
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {
+                    "name": "search_docs",
+                    "arguments": ToolArguments(query="ray backend"),
+                },
+            }
+        ]
+    )
+
+    record = {
+        "topic_candidates": {"topics": ["ray"]},
+        "topic_candidates__trace": [message.to_dict()],
+    }
+
+    sanitized = sanitize_record(record)
+
+    assert sanitized["topic_candidates"]["topics"] == ["ray"]
+    assert sanitized["topic_candidates__trace"][0]["tool_calls"][0]["function"]["arguments"] == {"query": "ray backend"}

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -29,7 +29,12 @@ from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
 from data_designer.engine.model_provider import resolve_model_provider_registry
 from data_designer.engine.resources.person_reader import PersonReader, create_person_reader
 from data_designer.engine.resources.resource_provider import create_resource_provider
-from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderRegistry
+from data_designer.engine.resources.seed_reader import (
+    DataFrameSeedReader,
+    FileSystemSeedReader,
+    SeedReader,
+    SeedReaderRegistry,
+)
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage, BatchStage
 from data_designer.engine.storage.media_storage import StorageMode
@@ -368,7 +373,8 @@ class RayBackend:
                 )
             ray.init()
 
-        use_input_dataset = input_dataset is not None
+        external_input_dataset = input_dataset is not None
+        use_input_dataset = external_input_dataset
         seed_config = config_builder.get_seed_config()
         if use_input_dataset and seed_config is not None:
             raise RayBackendConfigurationError(
@@ -380,11 +386,23 @@ class RayBackend:
                 "range dataset. Remove override_num_blocks, target_block_size, min_blocks, max_blocks, "
                 "and read_concurrency when passing input_dataset."
             )
-        seed_window = (
-            _preflight_seed_window(data_designer=data_designer, seed_config=seed_config, num_records=num_records)
-            if not use_input_dataset and seed_config is not None
-            else None
-        )
+        seed_window: _RaySeedWindow | None = None
+        if not use_input_dataset and seed_config is not None:
+            if _should_materialize_seed_on_driver(data_designer=data_designer, seed_config=seed_config):
+                input_dataset = ray.data.from_pandas(
+                    _materialize_seed_dataframe(
+                        data_designer=data_designer,
+                        seed_config=seed_config,
+                        num_records=num_records,
+                    )
+                )
+                use_input_dataset = True
+            else:
+                seed_window = _preflight_seed_window(
+                    data_designer=data_designer,
+                    seed_config=seed_config,
+                    num_records=num_records,
+                )
         if not self.allow_unsafe_processors:
             validate_ray_safe_processors(config_builder)
 
@@ -420,11 +438,16 @@ class RayBackend:
             config_builder,
             worker_model_health_checks=self.worker_model_health_checks,
         )
+        worker_seed_readers = (
+            [DataFrameSeedReader()]
+            if use_input_dataset
+            else _clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
+        )
         worker_options = _RayWorkerOptions(
             model_providers=list(data_designer._model_providers),
             default_provider_name=data_designer._model_provider_registry.get_default_provider_name(),
             secret_resolver=data_designer._secret_resolver,
-            seed_readers=_clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values()),
+            seed_readers=worker_seed_readers,
             managed_assets_path=str(data_designer._managed_assets_path),
             person_reader=data_designer._person_reader,
             mcp_providers=list(data_designer._mcp_providers),
@@ -479,7 +502,7 @@ class RayBackend:
 
         output_blocks = len(output) if output is not None else _get_num_blocks(mapped)
         metrics = RayDatasetMetrics(
-            total_rows=num_records if input_dataset is None else 0,
+            total_rows=num_records if not external_input_dataset else 0,
             blocks=output_blocks or input_blocks or (block_plan.planned_blocks if block_plan is not None else 0) or 0,
             elapsed_seconds=time.perf_counter() - start_time,
         )
@@ -697,6 +720,66 @@ def _preflight_seed_window(
     return _RaySeedWindow(start=index_range.start, size=index_range.size)
 
 
+def _should_materialize_seed_on_driver(*, data_designer: Any, seed_config: SeedConfig) -> bool:
+    """Return whether Ray should treat a seed source as a materialized input dataset."""
+    try:
+        seed_reader = SeedReaderRegistry(
+            readers=_clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
+        ).get_reader(seed_config.source, data_designer._secret_resolver)
+    except Exception as exc:
+        raise RayBackendConfigurationError("RayBackend failed to inspect the seed reader for Ray planning.") from exc
+    return isinstance(seed_reader, FileSystemSeedReader)
+
+
+def _materialize_seed_dataframe(
+    *,
+    data_designer: Any,
+    seed_config: SeedConfig,
+    num_records: int,
+) -> Any:
+    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
+        raise RayBackendConfigurationError(
+            "RayBackend driver-materialized filesystem seed configs currently support only ordered sampling. "
+            "Pass the seed data as input_dataset or use the local backend for shuffled seed sampling."
+        )
+
+    try:
+        seed_reader = SeedReaderRegistry(
+            readers=_clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
+        ).get_reader(seed_config.source, data_designer._secret_resolver)
+        seed_dataset_size = seed_reader.get_seed_dataset_size()
+        index_range = _resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayBackendConfigurationError("RayBackend failed to materialize the seed config for Ray input.") from exc
+
+    batch_reader = seed_reader.create_batch_reader(batch_size=num_records, index_range=index_range, shuffle=False)
+    output = lazy.pd.DataFrame()
+    empty_batch_reads = 0
+    while len(output) < num_records:
+        try:
+            seed_batch = batch_reader.read_next_batch().to_pandas().reset_index(drop=True)
+        except StopIteration:
+            batch_reader = seed_reader.create_batch_reader(
+                batch_size=num_records,
+                index_range=index_range,
+                shuffle=False,
+            )
+            continue
+
+        if len(seed_batch) == 0:
+            empty_batch_reads += 1
+            if empty_batch_reads > max(num_records * 2, 1):
+                raise RayBackendConfigurationError(
+                    "RayBackend filesystem seed materialization did not produce any rows after repeated reads."
+                )
+            continue
+        output = lazy.pd.concat([output, seed_batch], ignore_index=True)
+
+    return output.iloc[:num_records].reset_index(drop=True)
+
+
 def _resolve_seed_config_index_range(*, seed_config: SeedConfig, seed_dataset_size: int) -> IndexRange:
     if seed_dataset_size <= 0:
         raise RayBackendConfigurationError("RayBackend seed config resolved to an empty seed dataset.")
@@ -783,9 +866,31 @@ def _dataset_from_arrow_refs(ray: Any, refs: list[Any]) -> Any:
     try:
         return from_arrow_refs(refs)
     except Exception as exc:
-        raise RayDatasetGenerationError(
-            "RayBackend failed to rebuild a Ray Dataset from materialized Arrow ObjectRefs."
-        ) from exc
+        try:
+            return _dataset_from_arrow_refs_via_items(ray, refs)
+        except Exception:
+            raise RayDatasetGenerationError(
+                "RayBackend failed to rebuild a Ray Dataset from materialized Arrow ObjectRefs."
+            ) from exc
+
+
+def _dataset_from_arrow_refs_via_items(ray: Any, refs: list[Any]) -> Any:
+    from_items = getattr(ray.data, "from_items", None)
+    if not callable(from_items):
+        raise RayDatasetGenerationError("RayBackend fallback requires ray.data.from_items.")
+    records: list[dict[str, Any]] = []
+    for table in ray.get(refs):
+        to_pylist = getattr(table, "to_pylist", None)
+        if callable(to_pylist):
+            records.extend(to_pylist())
+            continue
+        to_pandas = getattr(table, "to_pandas", None)
+        if callable(to_pandas):
+            records.extend(to_pandas().to_dict(orient="records"))
+            continue
+        raise RayDatasetGenerationError("RayBackend Arrow ObjectRef fallback expected PyArrow tables with to_pylist().")
+    kwargs = {"override_num_blocks": len(refs)} if refs else {}
+    return from_items(records, **kwargs)
 
 
 def _compile_ray_execution_payload(
@@ -900,7 +1005,12 @@ def _merge_driver_and_worker_metrics(
 
 
 def _clone_seed_readers_for_worker(readers: Iterable[SeedReader]) -> list[SeedReader]:
-    return [_clone_seed_reader_for_worker(reader) for reader in readers]
+    clones = [_clone_seed_reader_for_worker(reader) for reader in readers]
+    seed_types = {reader.get_seed_type() for reader in clones}
+    dataframe_reader = DataFrameSeedReader()
+    if dataframe_reader.get_seed_type() not in seed_types:
+        clones.append(dataframe_reader)
+    return clones
 
 
 def _clone_seed_reader_for_worker(reader: SeedReader) -> SeedReader:
@@ -1074,6 +1184,12 @@ class _RayBatchWorker:
         self._seed_reader_registry: SeedReaderRegistry = SeedReaderRegistry(
             readers=copy.deepcopy(worker_options.seed_readers)
         )
+        dataframe_seed_reader = DataFrameSeedReader()
+        if (
+            execution_payload.use_input_dataset
+            and dataframe_seed_reader.get_seed_type() not in self._seed_reader_registry._readers
+        ):
+            self._seed_reader_registry.add_reader(dataframe_seed_reader)
         self._resource_provider: Any = create_resource_provider(
             artifact_storage=self._artifact_storage,
             model_configs=self._base_config.model_configs or [],
@@ -1453,8 +1569,16 @@ def _get_ray_task_context() -> str | None:
         return None
 
     context_values: list[str] = []
-    for attr in ("task_id", "actor_id", "worker_id"):
-        value = getattr(runtime_context, attr, None)
+    for attr, method_name in (
+        ("task_id", "get_task_id"),
+        ("actor_id", "get_actor_id"),
+        ("worker_id", "get_worker_id"),
+    ):
+        try:
+            method = getattr(runtime_context, method_name, None)
+            value = method() if callable(method) else getattr(runtime_context, attr, None)
+        except Exception:
+            continue
         if value is None:
             continue
         context_values.append(f"{attr}={value}")

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -15,9 +15,11 @@ from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextC
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.processors import SchemaTransformProcessorConfig
 from data_designer.config.run_config import RunConfig
+from data_designer.config.seed_source import DirectorySeedSource
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.engine.testing.seed_readers import LineFanoutDirectorySeedReader
 from data_designer.integrations.ray import (
     RayBackend,
     RayBackendConfigurationError,
@@ -86,6 +88,8 @@ class FakeRayDataModule:
     def __init__(self) -> None:
         self.from_arrow_refs_input: list[Any] | None = None
         self.from_pandas_refs_input: list[Any] | None = None
+        self.from_pandas_input: Any | None = None
+        self.from_items_input: list[Any] | None = None
         self.reverse_mapped_blocks = False
         self.range_kwargs: dict[str, Any] | None = None
 
@@ -110,6 +114,16 @@ class FakeRayDataModule:
             [_arrow_ref_to_pandas(ref) for ref in refs],
             reverse_mapped_blocks=self.reverse_mapped_blocks,
         )
+
+    def from_items(self, items: list[Any], **_: Any) -> FakeRayDataset:
+        self.from_items_input = items
+        return FakeRayDataset([lazy.pd.DataFrame(items)])
+
+    def from_pandas(self, dataframes: Any) -> FakeRayDataset:
+        self.from_pandas_input = dataframes
+        if isinstance(dataframes, list):
+            return FakeRayDataset(list(dataframes), reverse_mapped_blocks=self.reverse_mapped_blocks)
+        return FakeRayDataset([dataframes], reverse_mapped_blocks=self.reverse_mapped_blocks)
 
     def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_pandas_refs_input = refs
@@ -186,6 +200,7 @@ def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     fake_ray.data = FakeRayDataModule()
     fake_ray.is_initialized = lambda: True
     fake_ray.init = lambda: None
+    fake_ray.get = lambda refs: refs
     monkeypatch.setitem(sys.modules, "ray", fake_ray)
     return fake_ray
 
@@ -195,6 +210,7 @@ def _install_counting_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     fake_ray.data = CountingRayDataModule()
     fake_ray.is_initialized = lambda: True
     fake_ray.init = lambda: None
+    fake_ray.get = lambda refs: refs
     monkeypatch.setitem(sys.modules, "ray", fake_ray)
     return fake_ray
 
@@ -762,6 +778,67 @@ def test_ray_backend_arrow_refs_load_dataset_uses_materialized_refs_without_reru
         {"id": 1, "generated": 1},
     ]
     assert generate_calls == 1
+
+
+def test_ray_backend_arrow_refs_dataset_rebuild_falls_back_to_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+
+    def fail_from_arrow_refs(refs: list[Any]) -> FakeRayDataset:
+        del refs
+        raise ValueError("nested schema unification failed")
+
+    fake_ray.data.from_arrow_refs = fail_from_arrow_refs
+    refs = [
+        lazy.pa.table({"payload": [{"a": 1}]}),
+        lazy.pa.table({"payload": [{"b": "two"}]}),
+    ]
+
+    dataset = ray_backend_module._dataset_from_arrow_refs(fake_ray, refs)
+
+    assert fake_ray.data.from_items_input == [{"payload": {"a": 1}}, {"payload": {"b": "two"}}]
+    assert dataset.to_pandas().to_dict(orient="records") == [
+        {"payload": {"a": 1}},
+        {"payload": {"b": "two"}},
+    ]
+
+
+def test_ray_backend_materializes_filesystem_seed_reader_fanout_as_input_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = _install_fake_ray(monkeypatch)
+    seed_dir = tmp_path / "seeds"
+    seed_dir.mkdir()
+    (seed_dir / "a.txt").write_text("alpha\nbeta", encoding="utf-8")
+    (seed_dir / "b.txt").write_text("gamma\ndelta", encoding="utf-8")
+
+    config_builder = DataDesignerConfigBuilder(model_configs=[])
+    config_builder.with_seed_dataset(DirectorySeedSource(path=str(seed_dir), file_pattern="*.txt"))
+    config_builder.add_column(
+        ExpressionColumnConfig(
+            name="line_label",
+            expr="{{ relative_path }}:{{ line_index }}:{{ line }}",
+        )
+    )
+    designer = DataDesigner(
+        artifact_path=tmp_path / "artifacts",
+        model_providers=stub_model_providers,
+        seed_readers=[LineFanoutDirectorySeedReader()],
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=3),
+    )
+
+    output_df = designer.create(config_builder, num_records=3).load_dataset().to_pandas()
+
+    assert fake_ray.data.from_pandas_input is not None
+    assert fake_ray.data.range_kwargs is None
+    assert output_df.to_dict(orient="records") == [
+        {"relative_path": "a.txt", "line_index": 0, "line": "alpha", "line_label": "a.txt:0:alpha"},
+        {"relative_path": "a.txt", "line_index": 1, "line": "beta", "line_label": "a.txt:1:beta"},
+        {"relative_path": "b.txt", "line_index": 0, "line": "gamma", "line_label": "b.txt:0:gamma"},
+    ]
 
 
 def test_ray_results_to_arrow_refs_wraps_materialization_failures(

--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -108,10 +108,41 @@ def test_summary_groups_iterations_and_speedups() -> None:
     summary = benchmark._build_summary(results)
 
     assert summary["all_output_valid"] is True
+    assert summary["failed_backends"] == []
     assert summary["per_backend"]["local-sync"]["iterations"] == 2
     assert summary["per_backend"]["local-async"]["rows_per_second"]["mean"] == 22.5
     assert summary["comparisons_vs_local_sync"]["local-async"]["mean"] == 2.0
     assert summary["comparisons_vs_local_sync"]["ray-dataset"]["mean"] == 3.25
+
+
+def test_summary_flags_row_count_mismatch_as_failed_backend() -> None:
+    benchmark = _load_benchmark_module()
+    result = _benchmark_result(
+        backend="ray-dataset",
+        iteration=1,
+        elapsed_seconds=4.0,
+        rows_per_second=25.0,
+    )
+    result["validity"]["row_count_matches"] = False
+    result["validity"]["all_output_valid"] = False
+    result["metrics"] = {"failed_blocks": 0}
+    result["throughput"]["failed_requests"] = 0
+
+    summary = benchmark._build_summary([result])
+
+    assert summary["all_output_valid"] is False
+    assert summary["failed_backends"] == ["ray-dataset"]
+
+
+def test_fail_on_invalid_summary_exits_nonzero_unless_allowed() -> None:
+    benchmark = _load_benchmark_module()
+    summary = {"all_output_valid": False, "failed_backends": ["ray-dataset"]}
+
+    with pytest.raises(SystemExit) as exc_info:
+        benchmark._fail_on_invalid_summary(summary=summary, allow_failures=False)
+
+    assert exc_info.value.code == 1
+    assert benchmark._fail_on_invalid_summary(summary=summary, allow_failures=True) is None
 
 
 def _benchmark_result(

--- a/scripts/benchmarks/benchmark_ray_openai.py
+++ b/scripts/benchmarks/benchmark_ray_openai.py
@@ -98,6 +98,12 @@ def parse_args() -> argparse.Namespace:
         default=False,
         help=f"Allow live provider calls. Also accepted when {LIVE_RUN_ENV}=1.",
     )
+    parser.add_argument(
+        "--allow-failures",
+        action="store_true",
+        default=False,
+        help="Exit 0 even if a backend produces invalid output.",
+    )
     return parser.parse_args()
 
 
@@ -138,6 +144,7 @@ def main() -> None:
         "providers": [provider.name for provider in providers],
         "expected_columns": expected_columns,
         "live_run_env": LIVE_RUN_ENV,
+        "allow_failures": args.allow_failures,
     }
     _emit({"type": "setup", **setup})
 
@@ -171,6 +178,7 @@ def main() -> None:
         args.output_json.write_text(
             json.dumps({"setup": setup, "results": results, "summary": summary}, indent=2, default=_json_default)
         )
+    _fail_on_invalid_summary(summary=summary, allow_failures=args.allow_failures)
 
 
 def _validate_args(args: argparse.Namespace) -> None:
@@ -628,7 +636,23 @@ def _build_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
         "per_backend": per_backend,
         "comparisons_vs_local_sync": comparisons,
         "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in results),
+        "failed_backends": _failed_backends(results),
     }
+
+
+def _failed_backends(results: list[dict[str, Any]]) -> list[str]:
+    return [
+        str(result["backend"])
+        for result in results
+        if result.get("status") == "failed" or not bool(result["validity"]["all_output_valid"])
+    ]
+
+
+def _fail_on_invalid_summary(*, summary: dict[str, Any], allow_failures: bool) -> None:
+    if allow_failures:
+        return
+    if summary["failed_backends"] or not summary["all_output_valid"]:
+        raise SystemExit(1)
 
 
 def _speedup_comparisons(results: list[dict[str, Any]], *, baseline_backend: BackendName) -> dict[str, Any]:


### PR DESCRIPTION
## 📋 Summary

Fixes the Ray backend bugs found during recipe and benchmark smoke testing. The patch makes root async tasks dispatch with the correct strategy, supports filesystem seed-reader fanout by materializing seed rows before Ray execution, hardens Arrow-ref dataset loading for nested schemas, and makes traced tool-call messages safe for downstream record rendering.

## 🔗 Related Issue

Fixes #31
Fixes #33
Fixes #34
Fixes #35

## 🔄 Changes

- Dispatch root cell-by-cell columns per row and root non-from-scratch full-column generators as batch tasks.
- Materialize filesystem seed-reader outputs before Ray execution so custom 1:N seed readers work without shipping inline reader classes to Ray workers.
- Add Arrow-ref load fallback through row items when `ray.data.from_arrow_refs()` cannot rebuild nested schemas.
- Normalize `ChatMessage.to_dict()` output into JSON-safe trace records for MCP/tool traces.
- Fail `benchmark_ray_openai.py` on invalid benchmark output unless `--allow-failures` is set.
- Add regression tests for scheduler root dispatch, Ray seed fanout, Arrow-ref fallback, trace serialization, and benchmark validity failure.

## 🧪 Testing

- [ ] `make test` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (targeted Ray recipe smoke)

Targeted verification:
- [x] `.venv/bin/python -m pytest packages/data-designer-engine/tests/engine/models/test_model_utils.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer-engine/tests/engine/dataset_builders/test_async_scheduler.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py` (`79 passed`)
- [x] `.venv/bin/ruff check` on modified files
- [x] `.venv/bin/ruff format --check` on modified files
- [x] Ray recipe smoke: `plugin_development/markdown_seed_reader` with `output="arrow_refs"` (`4` rows, `failed_blocks=0`)
- [x] Ray recipe smoke: `trace_ingestion/agent_rollout_distillation` with `output="arrow_refs"` (`1` row, `failed_blocks=0`)
- [x] Ray recipe smoke: `mcp_and_tooluse/pdf_qa` with `output="arrow_refs"` (`1` row, `failed_blocks=0`)
- [x] Mock provider Ray benchmark smoke, `64` rows across `ray-dataset,ray-arrow-refs` (`all_output_valid=true`)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)