### PR TITLE
fix(docs): clear strict build warnings

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -17,6 +17,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -79,14 +82,20 @@ jobs:
         run: uv run mkdocs build
 
       - name: Deploy to Cloudflare Pages
+        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         id: deploy
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy site/ --project-name=dd-docs-preview --branch=pr-${{ github.event.pull_request.number }}
 
+      - name: Skip Cloudflare Pages deploy
+        if: env.CLOUDFLARE_API_TOKEN == '' || env.CLOUDFLARE_ACCOUNT_ID == ''
+        run: echo "Cloudflare preview secrets are not configured; skipping Pages deploy." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Find existing comment
+        if: steps.deploy.outcome == 'success'
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-comment
         with:
@@ -95,6 +104,7 @@ jobs:
           body-includes: "<!-- docs-preview -->"
 
       - name: Post or update PR comment
+        if: steps.deploy.outcome == 'success'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The skills and workflows in this repository are for **developing** DataDesigner.
 
 ---
 
-This project uses agent-assisted development. Contributors are expected to use agents for investigation, planning, and implementation. The repository includes [skills and guidance](.agents/) that make agents effective contributors.
+This project uses agent-assisted development. Contributors are expected to use agents for investigation, planning, and implementation. The repository includes [skills and guidance](https://github.com/NVIDIA-NeMo/DataDesigner/tree/main/.agents) that make agents effective contributors.
 
 Agents accelerate work; humans stay accountable. People make design decisions and own quality — agents help get there faster.
 
@@ -12,8 +12,8 @@ Agents accelerate work; humans stay accountable. People make design decisions an
 
 1. **Open an issue** using the appropriate [issue template](https://github.com/NVIDIA-NeMo/DataDesigner/issues/new/choose).
 2. **Include investigation output.** If you used an agent, paste its diagnostics. If you didn't, include the troubleshooting you tried.
-3. **For non-trivial changes, create a plan document** at `plans/<issue-number>/` before building. Have your agent draft the plan — it should describe the approach, trade-offs considered, affected subsystems, and a delivery strategy. See existing plans in [`plans/`](plans/) for reference. Submit the plan in a PR for review.
-4. **Once the plan is approved, implement** using agent-assisted development. See [DEVELOPMENT.md](DEVELOPMENT.md) for local setup and workflow.
+3. **For non-trivial changes, create a plan document** at `plans/<issue-number>/` before building. Have your agent draft the plan — it should describe the approach, trade-offs considered, affected subsystems, and a delivery strategy. See existing plans in [`plans/`](https://github.com/NVIDIA-NeMo/DataDesigner/tree/main/plans) for reference. Submit the plan in a PR for review.
+4. **Once the plan is approved, implement** using agent-assisted development. See [DEVELOPMENT.md](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/DEVELOPMENT.md) for local setup and workflow.
 
 ## Before You Open an Issue
 
@@ -38,7 +38,7 @@ Agents accelerate work; humans stay accountable. People make design decisions an
 
 ## Development Skills
 
-The repository includes skills for common development tasks. These are located in [`.agents/skills/`](.agents/skills/) and are automatically discovered by agent harnesses.
+The repository includes skills for common development tasks. These are located in [`.agents/skills/`](https://github.com/NVIDIA-NeMo/DataDesigner/tree/main/.agents/skills) and are automatically discovered by agent harnesses.
 
 | Category      | Skills                             | Purpose                                |
 | ------------- | ---------------------------------- | -------------------------------------- |
@@ -91,16 +91,16 @@ Use `make update-license-headers` to add headers automatically.
 
 ## Signing Off on Your Work (DCO)
 
-When contributing, you must agree that you have authored 100% of the content, that you have the necessary rights to the content, and that the content you contribute may be provided under the project license. All contributors are asked to sign the [Developer Certificate of Origin (DCO)](DCO) when submitting their first pull request. The process is automated by a bot that will comment on the pull request.
+When contributing, you must agree that you have authored 100% of the content, that you have the necessary rights to the content, and that the content you contribute may be provided under the project license. All contributors are asked to sign the [Developer Certificate of Origin (DCO)](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/DCO) when submitting their first pull request. The process is automated by a bot that will comment on the pull request.
 
 ## Code of Conduct
 
-Data Designer follows the Contributor Covenant Code of Conduct. Please read our complete [Code of Conduct](CODE_OF_CONDUCT.md) for full details.
+Data Designer follows the Contributor Covenant Code of Conduct. Please read our complete [Code of Conduct](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/CODE_OF_CONDUCT.md) for full details.
 
 ---
 
 ## Reference
 
-- [AGENTS.md](AGENTS.md) — architecture, layering, design principles
-- [STYLEGUIDE.md](STYLEGUIDE.md) — code style, naming, imports, type annotations
-- [DEVELOPMENT.md](DEVELOPMENT.md) — local setup, testing, day-to-day workflow
+- [AGENTS.md](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/AGENTS.md) — architecture, layering, design principles
+- [STYLEGUIDE.md](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/STYLEGUIDE.md) — code style, naming, imports, type annotations
+- [DEVELOPMENT.md](https://github.com/NVIDIA-NeMo/DataDesigner/blob/main/DEVELOPMENT.md) — local setup, testing, day-to-day workflow

--- a/docs/code_reference/column_configs.md
+++ b/docs/code_reference/column_configs.md
@@ -1,6 +1,6 @@
 # Column Configurations
 
-The `column_configs` module defines configuration objects for all Data Designer column types. Each configuration inherits from [SingleColumnConfig](#data_designer.config.base.SingleColumnConfig), which provides shared arguments like the column `name`, whether to `drop` the column after generation, and the `column_type`.
+The `column_configs` module defines configuration objects for all Data Designer column types. Each configuration inherits from `SingleColumnConfig`, which provides shared arguments like the column `name`, whether to `drop` the column after generation, and the `column_type`.
 
 !!! info "`column_type` is a discriminator field"
     The `column_type` argument is used to identify column types when deserializing the [Data Designer Config](data_designer_config.md) from JSON/YAML. It acts as the discriminator in a [discriminated union](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions), allowing Pydantic to automatically determine which column configuration class to instantiate.

--- a/docs/code_reference/models.md
+++ b/docs/code_reference/models.md
@@ -6,7 +6,7 @@ For more information on how they are used, see below:
 
 - **[Model Providers](../concepts/models/model-providers.md)**
 - **[Model Configs](../concepts/models/model-configs.md)**
-- **[Image Context](../notebooks/4-providing-images-as-context.ipynb)**
-- **[Generating Images](../notebooks/5-generating-images.ipynb)**
+- **[Image Context](../colab_notebooks/4-providing-images-as-context.ipynb)**
+- **[Generating Images](../colab_notebooks/5-generating-images.ipynb)**
 
 ::: data_designer.config.models

--- a/docs/colab_notebooks/README.md
+++ b/docs/colab_notebooks/README.md
@@ -1,0 +1,36 @@
+# Tutorial Notebooks
+
+These notebooks walk through Data Designer's core workflows, from basic synthetic data generation to structured outputs, seed datasets, and image generation.
+
+## Setup
+
+Download the tutorial bundle from the [latest release assets](https://github.com/NVIDIA-NeMo/DataDesigner/releases/latest/download/data_designer_tutorial.zip), extract it, and launch Jupyter from the extracted directory.
+
+```bash
+unzip data_designer_tutorial.zip
+cd data_designer_tutorial
+uv run jupyter notebook
+```
+
+Set an API key for the provider you plan to use before running model-backed cells:
+
+```bash
+export NVIDIA_API_KEY="your-api-key-here"
+export OPENAI_API_KEY="your-api-key-here"
+export OPENROUTER_API_KEY="your-api-key-here"
+```
+
+## Tutorial Series
+
+- [The Basics](1-the-basics.ipynb)
+- [Structured Outputs, Jinja Expressions, and Conditional Generation](2-structured-outputs-and-jinja-expressions.ipynb)
+- [Seeding with an External Dataset](3-seeding-with-a-dataset.ipynb)
+- [Providing Images as Context](4-providing-images-as-context.ipynb)
+- [Generating Images](5-generating-images.ipynb)
+- [Image-to-Image Editing](6-editing-images-with-image-context.ipynb)
+
+## Related Documentation
+
+- [Columns](../concepts/columns.md)
+- [Default Model Settings](../concepts/models/default-model-settings.md)
+- [Config Builder API](../code_reference/config_builder.md)

--- a/docs/concepts/columns.md
+++ b/docs/concepts/columns.md
@@ -112,7 +112,7 @@ Image columns require a model configured with `ImageInferenceParams`. Model-spec
 Image columns also support `multi_modal_context` for autoregressive models that accept image inputs, enabling image-to-image generation workflows.
 
 !!! tip "Tutorials"
-    The image tutorials cover three workflows: [Providing Images as Context](../notebooks/4-providing-images-as-context.ipynb) (image → text), [Generating Images](../notebooks/5-generating-images.ipynb) (text → image), and [Editing Images with Image Context](../notebooks/6-editing-images-with-image-context.ipynb) (image → image).
+    The image tutorials cover three workflows: [Providing Images as Context](../colab_notebooks/4-providing-images-as-context.ipynb) (image → text), [Generating Images](../colab_notebooks/5-generating-images.ipynb) (text → image), and [Editing Images with Image Context](../colab_notebooks/6-editing-images-with-image-context.ipynb) (image → image).
 
 ### 🧬 Embedding Columns
 

--- a/docs/concepts/tool_use_and_mcp.md
+++ b/docs/concepts/tool_use_and_mcp.md
@@ -4,7 +4,7 @@ Tool use lets LLM columns call external tools during generation (e.g., lookups, 
 
 ## Quick Start
 
-1. Configure an MCP provider ([Local](mcp/mcp-providers.md#localstdiomcpprovider-subprocess) or [Remote](mcp/mcp-providers.md#mcpprovider-remote-sse))
+1. Configure an MCP provider ([Local](mcp/mcp-providers.md#localstdiomcpprovider-subprocess) or [Remote](mcp/mcp-providers.md#mcpprovider-remote))
 2. Create a [ToolConfig](mcp/tool-configs.md) referencing your provider
 3. Add `tool_alias` to your [LLM column](mcp/enabling-tools.md)
 

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -288,7 +288,7 @@ The `target_columns` parameter specifies which columns to validate. All target c
 
 ### Configuration Parameters
 
-See more about parameters used to instantiate `ValidationColumnConfig` in the [code reference](../../code_reference/column_configs/#data_designer.config.column_configs.ValidationColumnConfig).
+See more about parameters used to instantiate `ValidationColumnConfig` in the [code reference](../code_reference/column_configs.md#data_designer.config.column_configs.ValidationColumnConfig).
 
 ### Batch Size Considerations
 

--- a/docs/devnotes/posts/text-to-sql.md
+++ b/docs/devnotes/posts/text-to-sql.md
@@ -125,7 +125,7 @@ Rather than relying on LLM creativity alone for diversity, the pipeline samples 
 Standard categorical samplers draw independently from their value lists. Data Designer's `SubcategorySamplerParams` creates hierarchical dependencies --- what we call "Semantic Blueprints" --- that ensure internally consistent records. When `industry_sector` samples "Healthcare", `topic` is drawn only from healthcare-specific subcategories. When `sql_complexity` samples "Beginner", `sql_concept` is restricted to foundational SQL operations. This is the difference between realistic training data and random noise.
 
 !!! note "Code snippets in this post are illustrative"
-    The code blocks below show the key configuration patterns for each pipeline stage. Model aliases (`prompt_gen`, `context_gen`, etc.) and companion files (`prompts.py`, `rubrics.py`) are referenced but not fully defined inline. For a complete, runnable pipeline, see the [Enterprise Text-to-SQL Recipe](../../recipes/code_generation/enterprise_text_to_sql/).
+    The code blocks below show the key configuration patterns for each pipeline stage. Model aliases (`prompt_gen`, `context_gen`, etc.) and companion files (`prompts.py`, `rubrics.py`) are referenced but not fully defined inline. For a complete, runnable pipeline, see the [Enterprise Text-to-SQL Recipe](../../recipes/code_generation/enterprise_text_to_sql.md).
 
 ```python
 import data_designer.config as dd
@@ -370,7 +370,7 @@ The SQL judge rubric explicitly penalizes distractor usage:
 
 > *"The SQL should only JOIN or reference tables that are strictly necessary to answer the prompt. The database context may include distractor tables that look relevant but are not needed -- penalize queries that unnecessarily join or reference these tables."*
 
-Each judge provides a score *and* reasoning for each dimension, making it easy to diagnose why a record scored low. After configuring the five `LLMJudgeColumnConfig` columns (see the [full recipe](../../recipes/code_generation/enterprise_text_to_sql/) for complete judge definitions), expression columns extract numeric scores into flat columns for downstream filtering:
+Each judge provides a score *and* reasoning for each dimension, making it easy to diagnose why a record scored low. After configuring the five `LLMJudgeColumnConfig` columns (see the [full recipe](../../recipes/code_generation/enterprise_text_to_sql.md) for complete judge definitions), expression columns extract numeric scores into flat columns for downstream filtering:
 
 ```python
 config.add_column(dd.ExpressionColumnConfig(

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ results.display_sample_record()
 
 <div class="grid cards" markdown>
 
--   :material-book-open-variant: **[Tutorials](notebooks/README.md)**
+-   :material-book-open-variant: **[Tutorials](colab_notebooks/README.md)**
 
     Step-by-step notebooks covering core features
 

--- a/docs/plugins/example.md
+++ b/docs/plugins/example.md
@@ -37,7 +37,7 @@ data-designer-index-multiplier/
 
 ### Step 2: Create the config class
 
-The configuration class defines what parameters users can set when using your plugin. For column generator plugins, it must inherit from [SingleColumnConfig](../code_reference/column_configs.md#data_designer.config.column_configs.SingleColumnConfig) and include a [discriminator field](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions).
+The configuration class defines what parameters users can set when using your plugin. For column generator plugins, it must inherit from `SingleColumnConfig` and include a [discriminator field](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions).
 
 Create `src/data_designer_index_multiplier/config.py`:
 

--- a/docs/recipes/cards.md
+++ b/docs/recipes/cards.md
@@ -4,7 +4,7 @@ Recipes are a collection of code examples that demonstrate how to leverage Data 
 Each recipe is a self-contained example that can be run independently.
 
 !!! question "New to Data Designer?"
-    Recipes provide working code for specific use cases without detailed explanations. If you're learning Data Designer for the first time, we recommend starting with our [tutorial notebooks](../../notebooks/), which offer step-by-step guidance and explain core concepts. Once you're familiar with the basics, return here for practical, ready-to-use implementations.
+    Recipes provide working code for specific use cases without detailed explanations. If you're learning Data Designer for the first time, we recommend starting with our [tutorial notebooks](../colab_notebooks/README.md), which offer step-by-step guidance and explain core concepts. Once you're familiar with the basics, return here for practical, ready-to-use implementations.
 
 !!! tip Prerequisite
     These recipes use the Open AI model provider by default. Ensure your OpenAI model provider has been set up using the Data Designer CLI before running a recipe.

--- a/docs/recipes/code_generation/enterprise_text_to_sql.md
+++ b/docs/recipes/code_generation/enterprise_text_to_sql.md
@@ -1,9 +1,9 @@
 # Nemotron Super Text to SQL
 
 !!! note "Dev Note"
-    For a deep dive into the pipeline design, distractor injection strategy, quality waterfall analysis, and BIRD benchmark results, see [Engineering an Enterprise-Grade Text-to-SQL Dataset with NeMo Data Designer](../../../devnotes/engineering-an-enterprise-grade-text-to-sql-dataset-with-nemo-data-designer/).
+    For a deep dive into the pipeline design, distractor injection strategy, quality waterfall analysis, and BIRD benchmark results, see [Engineering an Enterprise-Grade Text-to-SQL Dataset with NeMo Data Designer](../../devnotes/posts/text-to-sql.md).
 
-[Download Code :octicons-download-24:](../../../assets/recipes/code_generation/enterprise_text_to_sql.py){ .md-button download="enterprise_text_to_sql.py" }
+[Download Code :octicons-download-24:](../../assets/recipes/code_generation/enterprise_text_to_sql.py){ .md-button download="enterprise_text_to_sql.py" }
 
 ```python
 --8<-- "assets/recipes/code_generation/enterprise_text_to_sql.py"

--- a/docs/recipes/code_generation/text_to_python.md
+++ b/docs/recipes/code_generation/text_to_python.md
@@ -1,4 +1,4 @@
-[Download Code :octicons-download-24:](../../../assets/recipes/code_generation/text_to_python.py){ .md-button download="text_to_python.py" }
+[Download Code :octicons-download-24:](../../assets/recipes/code_generation/text_to_python.py){ .md-button download="text_to_python.py" }
 
 ```python
 --8<-- "assets/recipes/code_generation/text_to_python.py"

--- a/docs/recipes/code_generation/text_to_sql.md
+++ b/docs/recipes/code_generation/text_to_sql.md
@@ -1,6 +1,6 @@
 # Text to SQL
 
-[Download Code :octicons-download-24:](../../../assets/recipes/code_generation/text_to_sql.py){ .md-button download="text_to_sql.py" }
+[Download Code :octicons-download-24:](../../assets/recipes/code_generation/text_to_sql.py){ .md-button download="text_to_sql.py" }
 
 ```python
 --8<-- "assets/recipes/code_generation/text_to_sql.py"

--- a/docs/recipes/mcp_and_tooluse/basic_mcp.md
+++ b/docs/recipes/mcp_and_tooluse/basic_mcp.md
@@ -1,4 +1,4 @@
-[Download Code :octicons-download-24:](../../../assets/recipes/mcp_and_tooluse/basic_mcp.py){ .md-button download="basic_mcp.py" }
+[Download Code :octicons-download-24:](../../assets/recipes/mcp_and_tooluse/basic_mcp.py){ .md-button download="basic_mcp.py" }
 
 ```python
 --8<-- "assets/recipes/mcp_and_tooluse/basic_mcp.py"

--- a/docs/recipes/mcp_and_tooluse/pdf_qa.md
+++ b/docs/recipes/mcp_and_tooluse/pdf_qa.md
@@ -1,4 +1,4 @@
-[Download Code :octicons-download-24:](../../../assets/recipes/mcp_and_tooluse/pdf_qa.py){ .md-button download="pdf_qa.py" }
+[Download Code :octicons-download-24:](../../assets/recipes/mcp_and_tooluse/pdf_qa.py){ .md-button download="pdf_qa.py" }
 
 ```python
 --8<-- "assets/recipes/mcp_and_tooluse/pdf_qa.py"

--- a/docs/recipes/mcp_and_tooluse/search_agent.md
+++ b/docs/recipes/mcp_and_tooluse/search_agent.md
@@ -1,12 +1,12 @@
 # Nemotron Super Search Agent
 
 !!! note "Dev Note"
-    For a deep dive into the pipeline design, production yield analysis, correctness challenges, and key takeaways, see [Search Agent SFT Data: Teaching LLMs to Browse the Web](../../../devnotes/search-agent-sft-data-teaching-llms-to-browse-the-web/).
+    For a deep dive into the pipeline design, production yield analysis, correctness challenges, and key takeaways, see [Search Agent SFT Data: Teaching LLMs to Browse the Web](../../devnotes/posts/search-agent.md).
 
 !!! tip "Seed Dataset"
     This recipe includes built-in demo seeds (3 Wikidata knowledge graph paths) for quick testing. For production use, generate your own seed dataset from Wikidata random walks -- the dev note above describes the seed generation process (SPARQL queries, anti-meta filters, hop range 4-8). Each seed row needs: `seed_entity`, `final_answer_entity`, `readable_path`, `num_hops_in_graph`, and `ground_truth`. Pass your seed file via `--seed-path`.
 
-[Download Code :octicons-download-24:](../../../assets/recipes/mcp_and_tooluse/search_agent.py){ .md-button download="search_agent.py" }
+[Download Code :octicons-download-24:](../../assets/recipes/mcp_and_tooluse/search_agent.py){ .md-button download="search_agent.py" }
 
 ```python
 --8<-- "assets/recipes/mcp_and_tooluse/search_agent.py"

--- a/docs/recipes/qa_and_chat/multi_turn_chat.md
+++ b/docs/recipes/qa_and_chat/multi_turn_chat.md
@@ -1,4 +1,4 @@
-[Download Code :octicons-download-24:](../../../assets/recipes/qa_and_chat/multi_turn_chat.py){ .md-button download="multi_turn_chat.py" }
+[Download Code :octicons-download-24:](../../assets/recipes/qa_and_chat/multi_turn_chat.py){ .md-button download="multi_turn_chat.py" }
 
 ```python
 --8<-- "assets/recipes/qa_and_chat/multi_turn_chat.py"

--- a/docs/recipes/qa_and_chat/product_info_qa.md
+++ b/docs/recipes/qa_and_chat/product_info_qa.md
@@ -1,4 +1,4 @@
-[Download Code :octicons-download-24:](../../../assets/recipes/qa_and_chat/product_info_qa.py){ .md-button download="product_info_qa.py" }
+[Download Code :octicons-download-24:](../../assets/recipes/qa_and_chat/product_info_qa.py){ .md-button download="product_info_qa.py" }
 
 ```python
 --8<-- "assets/recipes/qa_and_chat/product_info_qa.py"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,13 +33,13 @@ nav:
       - Deployment Options: concepts/deployment-options.md
       - Security: concepts/security.md
   - Tutorials:
-      - Overview: notebooks/README.md
-      - The Basics: notebooks/1-the-basics.ipynb
-      - Structured Outputs, Jinja Expressions, and Conditional Generation: notebooks/2-structured-outputs-and-jinja-expressions.ipynb
-      - Seeding with an External Dataset: notebooks/3-seeding-with-a-dataset.ipynb
-      - Providing Images as Context: notebooks/4-providing-images-as-context.ipynb
-      - Generating Images: notebooks/5-generating-images.ipynb
-      - Image-to-Image Editing: notebooks/6-editing-images-with-image-context.ipynb
+      - Overview: colab_notebooks/README.md
+      - The Basics: colab_notebooks/1-the-basics.ipynb
+      - Structured Outputs, Jinja Expressions, and Conditional Generation: colab_notebooks/2-structured-outputs-and-jinja-expressions.ipynb
+      - Seeding with an External Dataset: colab_notebooks/3-seeding-with-a-dataset.ipynb
+      - Providing Images as Context: colab_notebooks/4-providing-images-as-context.ipynb
+      - Generating Images: colab_notebooks/5-generating-images.ipynb
+      - Image-to-Image Editing: colab_notebooks/6-editing-images-with-image-context.ipynb
   - Recipes:
       - Recipe Cards: recipes/cards.md
       - Code Generation:
@@ -129,6 +129,10 @@ watch:
   - packages/data-designer-engine/src/data_designer
   - packages/data-designer/src/data_designer
   - docs/
+
+exclude_docs: |
+  notebook_source/**
+  scripts/**
 
 plugins:
   - search

--- a/packages/data-designer-config/src/data_designer/config/config_builder.py
+++ b/packages/data-designer-config/src/data_designer/config/config_builder.py
@@ -7,6 +7,7 @@ import fnmatch
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 from pydantic import model_validator
 from pygments import highlight
@@ -270,7 +271,7 @@ class DataDesignerConfigBuilder:
         *,
         name: str | None = None,
         column_type: DataDesignerColumnType | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Self:
         """Add a Data Designer column configuration to the current Data Designer configuration.
 
@@ -312,7 +313,7 @@ class DataDesignerConfigBuilder:
         constraint: ColumnConstraintT | None = None,
         *,
         constraint_type: ConstraintType | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Self:
         """Add a constraint to the current Data Designer configuration.
 
@@ -364,7 +365,7 @@ class DataDesignerConfigBuilder:
         processor_config: ProcessorConfigT | None = None,
         *,
         processor_type: ProcessorType | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Self:
         """Add a processor to the current Data Designer configuration.
 
@@ -661,7 +662,7 @@ class DataDesignerConfigBuilder:
         )
         return self
 
-    def write_config(self, path: str | Path, indent: int | None = 2, **kwargs) -> None:
+    def write_config(self, path: str | Path, indent: int | None = 2, **kwargs: Any) -> None:
         """Write the current configuration to a file.
 
         Args:


### PR DESCRIPTION
## 📋 Summary

Fixes the repo-wide documentation warnings that made `mkdocs build --strict` unusable on the Ray backend branch. The patch points tutorial navigation at the checked-in Colab notebooks, excludes generated notebook source helpers from docs builds, repairs stale links, adds missing `**kwargs` annotations for mkdocstrings, and keeps docs-preview CI green when Cloudflare preview secrets are unavailable in the fork.

## 🔗 Related Issue

Fixes #29

## 🔄 Changes

- Point tutorial nav and docs links from stale `notebooks/...` paths to existing `colab_notebooks/...` files.
- Add `docs/colab_notebooks/README.md` as the Tutorials overview page.
- Exclude `docs/notebook_source/**` and `docs/scripts/**` helper files from MkDocs page discovery.
- Repair stale root-doc, recipe download, devnote, MCP, and code-reference links that strict mode reported.
- Annotate `DataDesignerConfigBuilder` variadic keyword parameters with `Any` so Griffe no longer warns.
- Skip Cloudflare Pages deployment and preview comments in docs-preview CI when the required secrets are not configured.

## 🧪 Testing

- [ ] `make test` passes
- [x] Unit tests added/updated (N/A — docs/link validation fix)
- [x] E2E tests added/updated (strict docs build)

Targeted verification:
- [x] `uv run ruff check packages/data-designer-config/src/data_designer/config/config_builder.py`
- [x] `uv run ruff format --check packages/data-designer-config/src/data_designer/config/config_builder.py`
- [x] `uv run --group docs mkdocs build --strict`
- [x] Parsed `.github/workflows/docs-preview.yml` as YAML after the CI fix

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (not applicable)