### PR TITLE
feat: add backend runtime context

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -55,6 +55,7 @@ Users declare what their data should look like through config objects (columns, 
 - **PEP 420 namespace packages** allow the three packages to be installed independently while sharing the `data_designer` namespace. This enables lighter installs (e.g., config-only for validation tooling) without import conflicts.
 - **Lazy imports throughout** — `__getattr__`-based lazy loading in `data_designer.config` and `data_designer.interface`, plus `lazy_heavy_imports` for numpy/pandas, keep startup fast.
 - **Dual execution engines** share the same `DatasetBuilder` API. The async engine adds row-group parallelism and DAG-aware scheduling without changing the public interface.
+- **Backend runtime context** is the supported interface-to-backend boundary. Non-local execution backends implement `DataDesignerBackend.create()` and receive a `BackendRuntimeContext`, which exposes model providers, seed readers, secret resolution, MCP providers, run config, person-reader resolution, and resource-provider factories. Backends should use that context instead of inspecting private `DataDesigner` attributes.
 - **`TaskRegistry` subclasses: one instance per class** — `TaskRegistry.__new__` (`registry/base.py`) ensures a single instance of each concrete registry (column generators, profilers, processors). **`ModelRegistry`** and **`MCPRegistry`** are ordinary classes, constructed per run with injected dependencies. **`PluginRegistry`** (`plugins/registry.py`) uses `__new__` so entry points are discovered once per process.
 
 ## Cross-References

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -57,6 +57,7 @@ from data_designer.integrations.ray.observability import (
 from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, RayMapConcurrency
 from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 from data_designer.integrations.ray.throttling import create_ray_throttle_manager
+from data_designer.interface.backends import BackendRuntimeContext
 
 if TYPE_CHECKING:
     from data_designer.config.mcp import MCPProviderT
@@ -356,7 +357,7 @@ class RayBackend:
     def create(
         self,
         *,
-        data_designer: Any,
+        runtime_context: BackendRuntimeContext,
         config_builder: DataDesignerConfigBuilder,
         num_records: int,
         dataset_name: str,
@@ -388,10 +389,10 @@ class RayBackend:
             )
         seed_window: _RaySeedWindow | None = None
         if not use_input_dataset and seed_config is not None:
-            if _should_materialize_seed_on_driver(data_designer=data_designer, seed_config=seed_config):
+            if _should_materialize_seed_on_driver(runtime_context=runtime_context, seed_config=seed_config):
                 input_dataset = ray.data.from_pandas(
                     _materialize_seed_dataframe(
-                        data_designer=data_designer,
+                        runtime_context=runtime_context,
                         seed_config=seed_config,
                         num_records=num_records,
                     )
@@ -399,7 +400,7 @@ class RayBackend:
                 use_input_dataset = True
             else:
                 seed_window = _preflight_seed_window(
-                    data_designer=data_designer,
+                    runtime_context=runtime_context,
                     seed_config=seed_config,
                     num_records=num_records,
                 )
@@ -408,7 +409,7 @@ class RayBackend:
 
         model_aliases = _model_health_check_aliases(config_builder)
         if self.preflight_model_health_check:
-            _run_driver_model_health_check(data_designer, config_builder, model_aliases)
+            _run_driver_model_health_check(runtime_context, config_builder, model_aliases)
 
         block_plan = self.block_planning.resolve(num_records=num_records) if input_dataset is None else None
         dataset = self._resolve_input_dataset(
@@ -422,13 +423,13 @@ class RayBackend:
             dataset = _attach_hidden_row_id_column(ray, dataset, hidden_order_column=hidden_order_column)
         input_blocks = _get_num_blocks(dataset)
         metrics_collector = _create_metrics_collector(ray, max_trace_events=self.max_trace_events)
-        batch_size = self.batch_size or data_designer._run_config.buffer_size
+        batch_size = self.batch_size or runtime_context.run_config.buffer_size
         observability_options = _RayObservabilityOptions(
             profile_workers=self.profile_workers,
             trace_enabled=self.trace_enabled,
         )
         throttle_manager = (
-            create_ray_throttle_manager(ray, data_designer._run_config)
+            create_ray_throttle_manager(ray, runtime_context.run_config)
             if self.global_provider_throttling
             and config_builder.model_configs
             and callable(getattr(ray, "remote", None))
@@ -441,17 +442,17 @@ class RayBackend:
         worker_seed_readers = (
             [DataFrameSeedReader()]
             if use_input_dataset
-            else _clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
+            else _clone_seed_readers_for_worker(runtime_context.seed_readers)
         )
         worker_options = _RayWorkerOptions(
-            model_providers=list(data_designer._model_providers),
-            default_provider_name=data_designer._model_provider_registry.get_default_provider_name(),
-            secret_resolver=data_designer._secret_resolver,
+            model_providers=list(runtime_context.model_providers),
+            default_provider_name=runtime_context.default_provider_name,
+            secret_resolver=runtime_context.secret_resolver,
             seed_readers=worker_seed_readers,
-            managed_assets_path=str(data_designer._managed_assets_path),
-            person_reader=data_designer._person_reader,
-            mcp_providers=list(data_designer._mcp_providers),
-            run_config=data_designer._run_config,
+            managed_assets_path=str(runtime_context.managed_assets_path),
+            person_reader=runtime_context.person_reader,
+            mcp_providers=list(runtime_context.mcp_providers),
+            run_config=runtime_context.run_config,
             throttle_manager=throttle_manager,
         )
         execution_payload = _compile_ray_execution_payload(
@@ -644,7 +645,7 @@ def _model_health_check_aliases(config_builder: DataDesignerConfigBuilder) -> li
 
 
 def _run_driver_model_health_check(
-    data_designer: Any,
+    runtime_context: BackendRuntimeContext,
     config_builder: DataDesignerConfigBuilder,
     model_aliases: list[str],
 ) -> None:
@@ -653,16 +654,9 @@ def _run_driver_model_health_check(
     try:
         with tempfile.TemporaryDirectory(prefix="data-designer-ray-preflight-") as artifact_dir:
             ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
-            resource_provider = create_resource_provider(
+            resource_provider = runtime_context.create_resource_provider(
                 artifact_storage=ArtifactStorage(artifact_path=artifact_dir, dataset_name="ray-preflight"),
                 model_configs=config_builder.model_configs,
-                secret_resolver=data_designer._secret_resolver,
-                model_provider_registry=data_designer._model_provider_registry,
-                seed_reader_registry=data_designer._seed_reader_registry,
-                person_reader=data_designer._person_reader
-                or create_person_reader(str(data_designer._managed_assets_path)),
-                run_config=data_designer._run_config,
-                mcp_providers=list(data_designer._mcp_providers),
                 tool_configs=config_builder.tool_configs,
             )
             resource_provider.model_registry.run_health_check(model_aliases)
@@ -689,7 +683,7 @@ def _clone_config_builder_for_worker(
 
 def _preflight_seed_window(
     *,
-    data_designer: Any,
+    runtime_context: BackendRuntimeContext,
     seed_config: SeedConfig,
     num_records: int,
 ) -> _RaySeedWindow:
@@ -700,9 +694,9 @@ def _preflight_seed_window(
         )
 
     try:
-        seed_reader = SeedReaderRegistry(
-            readers=_clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
-        ).get_reader(seed_config.source, data_designer._secret_resolver)
+        seed_reader = runtime_context.create_seed_reader_registry(
+            seed_readers=_clone_seed_readers_for_worker(runtime_context.seed_readers)
+        ).get_reader(seed_config.source, runtime_context.secret_resolver)
         seed_dataset_size = seed_reader.get_seed_dataset_size()
         index_range = _resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
     except RayBackendConfigurationError:
@@ -720,12 +714,12 @@ def _preflight_seed_window(
     return _RaySeedWindow(start=index_range.start, size=index_range.size)
 
 
-def _should_materialize_seed_on_driver(*, data_designer: Any, seed_config: SeedConfig) -> bool:
+def _should_materialize_seed_on_driver(*, runtime_context: BackendRuntimeContext, seed_config: SeedConfig) -> bool:
     """Return whether Ray should treat a seed source as a materialized input dataset."""
     try:
-        seed_reader = SeedReaderRegistry(
-            readers=_clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
-        ).get_reader(seed_config.source, data_designer._secret_resolver)
+        seed_reader = runtime_context.create_seed_reader_registry(
+            seed_readers=_clone_seed_readers_for_worker(runtime_context.seed_readers)
+        ).get_reader(seed_config.source, runtime_context.secret_resolver)
     except Exception as exc:
         raise RayBackendConfigurationError("RayBackend failed to inspect the seed reader for Ray planning.") from exc
     return isinstance(seed_reader, FileSystemSeedReader)
@@ -733,7 +727,7 @@ def _should_materialize_seed_on_driver(*, data_designer: Any, seed_config: SeedC
 
 def _materialize_seed_dataframe(
     *,
-    data_designer: Any,
+    runtime_context: BackendRuntimeContext,
     seed_config: SeedConfig,
     num_records: int,
 ) -> Any:
@@ -744,9 +738,9 @@ def _materialize_seed_dataframe(
         )
 
     try:
-        seed_reader = SeedReaderRegistry(
-            readers=_clone_seed_readers_for_worker(data_designer._seed_reader_registry._readers.values())
-        ).get_reader(seed_config.source, data_designer._secret_resolver)
+        seed_reader = runtime_context.create_seed_reader_registry(
+            seed_readers=_clone_seed_readers_for_worker(runtime_context.seed_readers)
+        ).get_reader(seed_config.source, runtime_context.secret_resolver)
         seed_dataset_size = seed_reader.get_seed_dataset_size()
         index_range = _resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
     except RayBackendConfigurationError:

--- a/packages/data-designer/src/data_designer/interface/backends.py
+++ b/packages/data-designer/src/data_designer/interface/backends.py
@@ -3,9 +3,137 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, Sequence
 
 from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.mcp import MCPProviderT, ToolConfig
+from data_designer.config.models import ModelConfig, ModelProvider
+from data_designer.config.run_config import RunConfig
+from data_designer.config.seed_source import SeedSource
+from data_designer.engine.model_provider import ModelProviderRegistry
+from data_designer.engine.resources.person_reader import PersonReader, create_person_reader
+from data_designer.engine.resources.resource_provider import ResourceProvider, create_resource_provider
+from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderRegistry
+from data_designer.engine.secret_resolver import SecretResolver
+from data_designer.engine.storage.artifact_storage import ArtifactStorage
+
+if TYPE_CHECKING:
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
+
+
+class BackendRuntimeContext(Protocol):
+    """Stable runtime state exposed to execution backends.
+
+    Backends may depend on this interface for engine resources and runtime
+    configuration, but should not receive or inspect a public ``DataDesigner``
+    instance.
+    """
+
+    @property
+    def model_providers(self) -> tuple[ModelProvider, ...]: ...
+
+    @property
+    def model_provider_registry(self) -> ModelProviderRegistry: ...
+
+    @property
+    def default_provider_name(self) -> str: ...
+
+    @property
+    def secret_resolver(self) -> SecretResolver: ...
+
+    @property
+    def seed_readers(self) -> tuple[SeedReader, ...]: ...
+
+    @property
+    def managed_assets_path(self) -> Path: ...
+
+    @property
+    def person_reader(self) -> PersonReader | None: ...
+
+    @property
+    def mcp_providers(self) -> tuple[MCPProviderT, ...]: ...
+
+    @property
+    def run_config(self) -> RunConfig: ...
+
+    def resolve_person_reader(self) -> PersonReader:
+        """Return the configured person reader or the local managed-assets reader."""
+        ...
+
+    def create_seed_reader_registry(
+        self,
+        *,
+        seed_readers: Sequence[SeedReader] | None = None,
+    ) -> SeedReaderRegistry:
+        """Create a seed-reader registry for a backend-specific execution scope."""
+        ...
+
+    def create_resource_provider(
+        self,
+        *,
+        artifact_storage: ArtifactStorage,
+        model_configs: list[ModelConfig],
+        seed_dataset_source: SeedSource | None = None,
+        seed_readers: Sequence[SeedReader] | None = None,
+        tool_configs: list[ToolConfig] | None = None,
+        throttle_manager: ThrottleManagerLike | None = None,
+    ) -> ResourceProvider:
+        """Create a resource provider from this backend runtime snapshot."""
+        ...
+
+
+@dataclass(frozen=True)
+class DataDesignerRuntimeContext:
+    """Concrete backend runtime context produced by the interface layer."""
+
+    model_providers: tuple[ModelProvider, ...]
+    model_provider_registry: ModelProviderRegistry
+    default_provider_name: str
+    secret_resolver: SecretResolver
+    seed_readers: tuple[SeedReader, ...]
+    managed_assets_path: Path
+    person_reader: PersonReader | None
+    mcp_providers: tuple[MCPProviderT, ...]
+    run_config: RunConfig
+
+    def resolve_person_reader(self) -> PersonReader:
+        if self.person_reader is not None:
+            return self.person_reader
+        return create_person_reader(str(self.managed_assets_path))
+
+    def create_seed_reader_registry(
+        self,
+        *,
+        seed_readers: Sequence[SeedReader] | None = None,
+    ) -> SeedReaderRegistry:
+        effective_seed_readers = self.seed_readers if seed_readers is None else seed_readers
+        return SeedReaderRegistry(readers=effective_seed_readers)
+
+    def create_resource_provider(
+        self,
+        *,
+        artifact_storage: ArtifactStorage,
+        model_configs: list[ModelConfig],
+        seed_dataset_source: SeedSource | None = None,
+        seed_readers: Sequence[SeedReader] | None = None,
+        tool_configs: list[ToolConfig] | None = None,
+        throttle_manager: ThrottleManagerLike | None = None,
+    ) -> ResourceProvider:
+        return create_resource_provider(
+            artifact_storage=artifact_storage,
+            model_configs=model_configs,
+            secret_resolver=self.secret_resolver,
+            model_provider_registry=self.model_provider_registry,
+            seed_reader_registry=self.create_seed_reader_registry(seed_readers=seed_readers),
+            person_reader=self.resolve_person_reader(),
+            seed_dataset_source=seed_dataset_source,
+            run_config=self.run_config,
+            mcp_providers=list(self.mcp_providers),
+            tool_configs=tool_configs,
+            throttle_manager=throttle_manager,
+        )
 
 
 class DataDesignerBackend(Protocol):
@@ -14,7 +142,7 @@ class DataDesignerBackend(Protocol):
     def create(
         self,
         *,
-        data_designer: Any,
+        runtime_context: BackendRuntimeContext,
         config_builder: DataDesignerConfigBuilder,
         num_records: int,
         dataset_name: str,

--- a/packages/data-designer/src/data_designer/interface/data_designer.py
+++ b/packages/data-designer/src/data_designer/interface/data_designer.py
@@ -60,7 +60,7 @@ from data_designer.engine.secret_resolver import (
     SecretResolver,
 )
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
-from data_designer.interface.backends import DataDesignerBackend
+from data_designer.interface.backends import DataDesignerBackend, DataDesignerRuntimeContext
 from data_designer.interface.errors import (
     DataDesignerGenerationError,
     DataDesignerProfilingError,
@@ -227,7 +227,7 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
         """
         if self._backend is not None:
             return self._backend.create(
-                data_designer=self,
+                runtime_context=self._create_backend_runtime_context(),
                 config_builder=config_builder,
                 num_records=num_records,
                 dataset_name=dataset_name,
@@ -502,6 +502,19 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
             run_config=self._run_config,
             mcp_providers=self._mcp_providers,
             tool_configs=config_builder.tool_configs,
+        )
+
+    def _create_backend_runtime_context(self) -> DataDesignerRuntimeContext:
+        return DataDesignerRuntimeContext(
+            model_providers=tuple(self._model_providers),
+            model_provider_registry=self._model_provider_registry,
+            default_provider_name=self._model_provider_registry.get_default_provider_name(),
+            secret_resolver=self._secret_resolver,
+            seed_readers=tuple(self._seed_reader_registry._readers.values()),
+            managed_assets_path=self._managed_assets_path,
+            person_reader=self._person_reader,
+            mcp_providers=tuple(self._mcp_providers),
+            run_config=self._run_config,
         )
 
     def _get_interface_info(self, model_providers: list[ModelProvider]) -> InterfaceInfo:

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -922,7 +922,7 @@ def test_ray_backend_import_is_lazy_when_ray_is_missing(monkeypatch: pytest.Monk
 
     with pytest.raises(ImportError, match="data-designer\\[ray\\]"):
         backend.create(
-            data_designer=object(),
+            runtime_context=object(),
             config_builder=DataDesignerConfigBuilder(model_configs=[]),
             num_records=1,
             dataset_name="dataset",

--- a/packages/data-designer/tests/integrations/ray/test_optional_extra.py
+++ b/packages/data-designer/tests/integrations/ray/test_optional_extra.py
@@ -90,7 +90,7 @@ def test_ray_backend_usage_without_ray_has_optional_extra_message(monkeypatch: p
 
     with pytest.raises(ImportError, match=r"data-designer\[ray\]"):
         backend.create(
-            data_designer=object(),
+            runtime_context=object(),
             config_builder=config_builder,
             num_records=1,
             dataset_name="dataset",

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -78,17 +78,16 @@ def _input_expression_config_builder(stub_model_configs: Any) -> DataDesignerCon
 
 
 def _worker_options_from_designer(data_designer: DataDesigner) -> ray_backend_module._RayWorkerOptions:
+    runtime_context = data_designer._create_backend_runtime_context()
     return ray_backend_module._RayWorkerOptions(
-        model_providers=list(data_designer._model_providers),
-        default_provider_name=data_designer._model_provider_registry.get_default_provider_name(),
-        secret_resolver=data_designer._secret_resolver,
-        seed_readers=ray_backend_module._clone_seed_readers_for_worker(
-            data_designer._seed_reader_registry._readers.values()
-        ),
-        managed_assets_path=str(data_designer._managed_assets_path),
-        person_reader=data_designer._person_reader,
-        mcp_providers=list(data_designer._mcp_providers),
-        run_config=data_designer._run_config,
+        model_providers=list(runtime_context.model_providers),
+        default_provider_name=runtime_context.default_provider_name,
+        secret_resolver=runtime_context.secret_resolver,
+        seed_readers=ray_backend_module._clone_seed_readers_for_worker(runtime_context.seed_readers),
+        managed_assets_path=str(runtime_context.managed_assets_path),
+        person_reader=runtime_context.person_reader,
+        mcp_providers=list(runtime_context.mcp_providers),
+        run_config=runtime_context.run_config,
     )
 
 

--- a/packages/data-designer/tests/interface/test_data_designer.py
+++ b/packages/data-designer/tests/interface/test_data_designer.py
@@ -18,6 +18,7 @@ import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig, SamplerColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.errors import InvalidConfigError
+from data_designer.config.mcp import LocalStdioMCPProvider
 from data_designer.config.models import ModelProvider
 from data_designer.config.processors import DropColumnsProcessorConfig
 from data_designer.config.run_config import JinjaRenderingEngine, RunConfig
@@ -30,14 +31,18 @@ from data_designer.config.seed_source import (
     FileContentsSeedSource,
     HuggingFaceSeedSource,
 )
+from data_designer.engine.resources.person_reader import PersonReader
 from data_designer.engine.resources.seed_reader import (
+    DataFrameSeedReader,
     FileSystemSeedReader,
     SeedReaderError,
     SeedReaderFileSystemContext,
 )
 from data_designer.engine.secret_resolver import CompositeResolver, EnvironmentResolver, PlaintextResolver
+from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.engine.testing.seed_readers import LineFanoutDirectorySeedReader
 from data_designer.engine.testing.stubs import StubHuggingFaceSeedReader
+from data_designer.interface.backends import BackendRuntimeContext, DataDesignerRuntimeContext
 from data_designer.interface.data_designer import DataDesigner
 from data_designer.interface.errors import DataDesignerGenerationError, DataDesignerProfilingError
 
@@ -71,6 +76,30 @@ class CustomDirectorySeedReader(FileSystemSeedReader[DirectorySeedSource]):
             "file_name": str(manifest_row["file_name"]),
             "decorated_path": f"custom::{manifest_row['relative_path']}",
         }
+
+
+class CapturingBackend:
+    def __init__(self) -> None:
+        self.runtime_context: BackendRuntimeContext | None = None
+        self.create_kwargs: dict[str, Any] | None = None
+
+    def create(
+        self,
+        *,
+        runtime_context: BackendRuntimeContext,
+        config_builder: DataDesignerConfigBuilder,
+        num_records: int,
+        dataset_name: str,
+        input_dataset: Any | None = None,
+    ) -> dict[str, Any]:
+        self.runtime_context = runtime_context
+        self.create_kwargs = {
+            "config_builder": config_builder,
+            "num_records": num_records,
+            "dataset_name": dataset_name,
+            "input_dataset": input_dataset,
+        }
+        return {"backend": "captured"}
 
 
 def _add_irrelevant_sampler_column(builder: DataDesignerConfigBuilder) -> None:
@@ -521,6 +550,66 @@ def test_create_dataset_e2e_using_only_sampler_columns(
 
     # display report with no errors
     analysis.to_report()
+
+
+def test_create_passes_backend_runtime_context(
+    stub_artifact_path: Path,
+    stub_model_providers: list[ModelProvider],
+    stub_managed_assets_path: Path,
+) -> None:
+    secret_resolver = PlaintextResolver()
+    run_config = RunConfig(buffer_size=17)
+    seed_reader = DataFrameSeedReader()
+    person_reader = MagicMock(spec=PersonReader)
+    mcp_provider = LocalStdioMCPProvider(name="local-tools", command="python")
+    backend = CapturingBackend()
+    config_builder = DataDesignerConfigBuilder(model_configs=[])
+    input_dataset = object()
+    data_designer = DataDesigner(
+        artifact_path=stub_artifact_path,
+        model_providers=stub_model_providers,
+        secret_resolver=secret_resolver,
+        seed_readers=[seed_reader],
+        managed_assets_path=stub_managed_assets_path,
+        person_reader=person_reader,
+        mcp_providers=[mcp_provider],
+        backend=backend,
+    )
+    data_designer.set_run_config(run_config)
+
+    result = data_designer.create(
+        config_builder,
+        num_records=3,
+        dataset_name="backend-context-test",
+        input_dataset=input_dataset,
+    )
+
+    assert result == {"backend": "captured"}
+    assert backend.create_kwargs == {
+        "config_builder": config_builder,
+        "num_records": 3,
+        "dataset_name": "backend-context-test",
+        "input_dataset": input_dataset,
+    }
+    context = backend.runtime_context
+    assert isinstance(context, DataDesignerRuntimeContext)
+    assert context.model_providers == tuple(stub_model_providers)
+    assert context.default_provider_name == context.model_provider_registry.get_default_provider_name()
+    assert context.secret_resolver is secret_resolver
+    assert context.seed_readers == (seed_reader,)
+    assert context.managed_assets_path == stub_managed_assets_path
+    assert context.resolve_person_reader() is person_reader
+    assert context.mcp_providers == (mcp_provider,)
+    assert context.run_config is run_config
+
+    context_artifact_path = stub_artifact_path / "context-resource-provider"
+    ArtifactStorage.mkdir_if_needed(context_artifact_path)
+    resource_provider = context.create_resource_provider(
+        artifact_storage=ArtifactStorage(artifact_path=context_artifact_path, dataset_name="context"),
+        model_configs=[],
+    )
+    assert resource_provider.person_reader is person_reader
+    assert resource_provider.run_config is run_config
 
 
 def test_create_raises_error_when_builder_fails(


### PR DESCRIPTION
## 📋 Summary

This PR replaces the backend-facing `DataDesigner` hook with a typed runtime context. Ray now receives the context at the interface/backend boundary and uses it for run config, providers, seed readers, MCP providers, person-reader resolution, and resource-provider creation instead of reaching through the public `DataDesigner` object.

## 🔗 Related Issue

Closes #55

## 🔄 Changes

- Added `BackendRuntimeContext` and `DataDesignerRuntimeContext` in `data_designer.interface.backends`.
- Updated `DataDesigner.create()` to pass a runtime context into configured backends.
- Updated `RayBackend` driver preflight, seed planning, throttling setup, and worker payload construction to use the context.
- Added tests for backend context propagation and updated Ray boundary tests for the new hook.
- Documented the backend runtime context as the supported backend extension surface.

## 🔍 Attention Areas

> ⚠️ **Reviewers:** Please pay special attention to the following:

- [`backends.py`](https://github.com/eric-tramel/DataDesigner/blob/codex/issue55-backend-runtime-context/packages/data-designer/src/data_designer/interface/backends.py) — Defines the stable interface/backend runtime context shape.

## 🧪 Testing

- [ ] `make test` passes (not run; targeted tests below)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A - no E2E surface)

Targeted tests run:

- [x] `uv run --group dev ruff check --output-format=full packages/data-designer/src/data_designer/interface/backends.py packages/data-designer/src/data_designer/interface/data_designer.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/interface/test_data_designer.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_optional_extra.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py`
- [x] `uv run --group dev ruff format --check packages/data-designer/src/data_designer/interface/backends.py packages/data-designer/src/data_designer/interface/data_designer.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/interface/test_data_designer.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_optional_extra.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py`
- [x] `uv run --group dev pytest packages/data-designer/tests/interface/test_data_designer.py::test_create_passes_backend_runtime_context packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_optional_extra.py`
- [x] `uv run --group dev pytest packages/data-designer/tests/interface/test_data_designer.py`

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)