### PR TITLE
feat: generalize processor safety metadata

### DIFF
--- a/docs/concepts/processors.md
+++ b/docs/concepts/processors.md
@@ -159,6 +159,40 @@ builder.add_processor(
 )
 ```
 
+### Distributed Execution Metadata
+
+Processor config classes should declare class-level `distributed_safety` metadata so distributed backends can decide whether the processor can run over independent partitions:
+
+```python
+from typing import ClassVar, Literal
+
+from data_designer.config import ProcessorDistributedSafety, ProcessorSideEffect
+from data_designer.config.base import ProcessorConfig
+
+
+class MyProcessorConfig(ProcessorConfig):
+    processor_type: Literal["my_processor"] = "my_processor"
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        partition_safe=True,
+        requires_global_order=False,
+        side_effects=ProcessorSideEffect.NONE,
+        reason="Transforms each partition independently.",
+    )
+```
+
+Use these fields to describe processor semantics without naming a specific backend:
+
+| Field | Meaning |
+|-------|---------|
+| `partition_safe` | The processor can run independently on separate data partitions without cross-partition coordination. |
+| `requires_global_order` | The processor needs a globally ordered or complete dataset view. |
+| `side_effects` | Side-effect category: `NONE`, `BATCH_ARTIFACT`, `DATASET_ARTIFACT`, or `EXTERNAL`. |
+| `reason` | Optional explanation for constrained or unsafe distributed execution. |
+
+The Ray backend currently accepts processors that are `partition_safe`, do not require global ordering, and have side effects of `NONE` or `BATCH_ARTIFACT`. Processors that write dataset-level artifacts or external side effects are rejected by default; pass `allow_unsafe_processors=True` only when you have verified the behavior for your workload.
+
+Existing plugins that pass `ray_safe=` to `ProcessorDistributedSafety` still load through a compatibility alias, but new code should use `partition_safe=`.
+
 **Entry point configuration** in `pyproject.toml`:
 
 ```toml

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -38,12 +38,14 @@ Each plugin has three components, and we recommend organizing them into separate
 - **`config.py`** -- Configuration class defining user-facing parameters
     - Column generator plugins: inherit from `SingleColumnConfig` with a `column_type` discriminator
     - Seed reader plugins: inherit from `SeedSource` with a `seed_type` discriminator
-    - Processor plugins: inherit from `ProcessorConfig` with a `processor_type` discriminator
+    - Processor plugins: inherit from `ProcessorConfig` with a `processor_type` discriminator and class-level distributed safety metadata
 - **`impl.py`** -- Implementation class containing the core logic
     - Column generator plugins: inherit from `ColumnGeneratorFullColumn` or `ColumnGeneratorCellByCell`
     - Seed reader plugins: inherit from `SeedReader` or `FileSystemSeedReader` for directory-backed sources
     - Processor plugins: inherit from `Processor` and override callback methods (`process_before_batch`, `process_after_batch`, `process_after_generation`)
 - **`plugin.py`** -- A `Plugin` instance that connects the config and implementation classes
+
+Processor plugins that may run on distributed backends should declare backend-neutral `ProcessorDistributedSafety` metadata. Use `partition_safe`, `requires_global_order`, and `side_effects` to describe the processor's semantics; the Ray backend maps those generic capabilities to its supported execution modes. See [Processors](../concepts/processors.md#distributed-execution-metadata) for the field reference and compatibility notes for older `ray_safe` metadata.
 
 ### 2. Package Your Plugin
 

--- a/packages/data-designer-config/src/data_designer/config/processors.py
+++ b/packages/data-designer-config/src/data_designer/config/processors.py
@@ -7,7 +7,7 @@ import json
 from enum import Enum
 from typing import Any, ClassVar, Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from data_designer.config.base import ConfigBase, ProcessorConfig
 from data_designer.config.errors import InvalidConfigError
@@ -39,10 +39,14 @@ class ProcessorDistributedSafety(ConfigBase):
 
     Processor configs declare this as class-level metadata so execution backends
     can fail closed for processors that have not been reviewed for distributed
-    semantics.
+    semantics. Legacy ``ray_safe`` constructor input is accepted as a deprecated
+    alias for ``partition_safe`` to preserve compatibility with existing
+    processor plugins.
     """
 
-    ray_safe: bool = Field(description="Whether the processor is safe to run independently on Ray Data blocks.")
+    partition_safe: bool = Field(
+        description="Whether the processor is safe to run independently on distributed data partitions.",
+    )
     requires_global_order: bool = Field(
         default=False,
         description="Whether the processor requires a globally ordered or complete dataset view.",
@@ -55,6 +59,29 @@ class ProcessorDistributedSafety(ConfigBase):
         default=None,
         description="Human-readable explanation for unsafe or constrained distributed execution.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _translate_legacy_ray_safe(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or "ray_safe" not in data:
+            return data
+
+        values = dict(data)
+        ray_safe = values.pop("ray_safe")
+        partition_safe = values.get("partition_safe")
+        if partition_safe is not None and partition_safe != ray_safe:
+            raise ValueError("ray_safe is a deprecated alias for partition_safe and cannot disagree with it")
+        values["partition_safe"] = ray_safe
+        return values
+
+    @property
+    def ray_safe(self) -> bool:
+        """Deprecated compatibility alias for ``partition_safe``."""
+        return self.partition_safe
+
+    @ray_safe.setter
+    def ray_safe(self, value: bool) -> None:
+        self.partition_safe = value
 
 
 def get_processor_config_from_kwargs(processor_type: ProcessorType, **kwargs: Any) -> ProcessorConfig:
@@ -91,7 +118,7 @@ class DropColumnsProcessorConfig(ProcessorConfig):
     column_names: list[str] = Field(description="List of column names to drop from the output dataset.")
     processor_type: Literal[ProcessorType.DROP_COLUMNS] = ProcessorType.DROP_COLUMNS
     distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
-        ray_safe=True,
+        partition_safe=True,
         requires_global_order=False,
         side_effects=ProcessorSideEffect.BATCH_ARTIFACT,
         reason="Drops columns independently per batch; dropped-column artifacts are batch-local.",
@@ -139,10 +166,10 @@ class SchemaTransformProcessorConfig(ProcessorConfig):
     )
     processor_type: Literal[ProcessorType.SCHEMA_TRANSFORM] = ProcessorType.SCHEMA_TRANSFORM
     distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
-        ray_safe=False,
+        partition_safe=True,
         requires_global_order=False,
         side_effects=ProcessorSideEffect.DATASET_ARTIFACT,
-        reason="Writes processor output artifacts that RayBackend does not collect from worker-local storage.",
+        reason="Writes dataset-level processor output artifacts that require backend artifact collection.",
     )
 
     @field_validator("template")

--- a/packages/data-designer-config/tests/config/test_processors.py
+++ b/packages/data-designer-config/tests/config/test_processors.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import pytest
 from pydantic import ValidationError
 
@@ -8,13 +10,15 @@ from data_designer.config.errors import InvalidConfigError
 from data_designer.config.processors import (
     DropColumnsProcessorConfig,
     ProcessorConfig,
+    ProcessorDistributedSafety,
+    ProcessorSideEffect,
     ProcessorType,
     SchemaTransformProcessorConfig,
     get_processor_config_from_kwargs,
 )
 
 
-def test_drop_columns_processor_config_creation():
+def test_drop_columns_processor_config_creation() -> None:
     config = DropColumnsProcessorConfig(name="drop_columns_processor", column_names=["col1", "col2"])
 
     assert config.column_names == ["col1", "col2"]
@@ -22,13 +26,13 @@ def test_drop_columns_processor_config_creation():
     assert isinstance(config, ProcessorConfig)
 
 
-def test_drop_columns_processor_config_validation():
+def test_drop_columns_processor_config_validation() -> None:
     # Test missing required field raises error
     with pytest.raises(ValidationError, match="Field required"):
         DropColumnsProcessorConfig(name="drop_columns_processor")
 
 
-def test_drop_columns_processor_config_serialization():
+def test_drop_columns_processor_config_serialization() -> None:
     config = DropColumnsProcessorConfig(name="drop_columns_processor", column_names=["col1", "col2"])
 
     # Serialize to dict
@@ -40,7 +44,7 @@ def test_drop_columns_processor_config_serialization():
     assert config_restored.column_names == config.column_names
 
 
-def test_schema_transform_processor_config_creation():
+def test_schema_transform_processor_config_creation() -> None:
     config = SchemaTransformProcessorConfig(
         name="output_format_processor",
         template={"text": "{{ col1 }}"},
@@ -51,7 +55,7 @@ def test_schema_transform_processor_config_creation():
     assert isinstance(config, ProcessorConfig)
 
 
-def test_schema_transform_processor_config_validation():
+def test_schema_transform_processor_config_validation() -> None:
     # Test missing required field raises error
     with pytest.raises(ValidationError, match="Field required"):
         SchemaTransformProcessorConfig(name="schema_transform_processor")
@@ -61,7 +65,7 @@ def test_schema_transform_processor_config_validation():
         SchemaTransformProcessorConfig(name="schema_transform_processor", template={"text": {1, 2, 3}})
 
 
-def test_schema_transform_processor_config_serialization():
+def test_schema_transform_processor_config_serialization() -> None:
     config = SchemaTransformProcessorConfig(
         name="schema_transform_processor",
         template={"text": "{{ col1 }}"},
@@ -76,7 +80,53 @@ def test_schema_transform_processor_config_serialization():
     assert config_restored.template == config.template
 
 
-def test_get_processor_config_from_kwargs():
+def test_processor_distributed_safety_uses_backend_neutral_partition_field() -> None:
+    safety = ProcessorDistributedSafety(
+        partition_safe=True,
+        side_effects=ProcessorSideEffect.NONE,
+        reason="Can run per partition.",
+    )
+
+    assert safety.partition_safe is True
+    assert safety.ray_safe is True
+    assert safety.model_dump() == {
+        "partition_safe": True,
+        "requires_global_order": False,
+        "side_effects": "none",
+        "reason": "Can run per partition.",
+    }
+
+
+def test_processor_distributed_safety_accepts_legacy_ray_safe_alias() -> None:
+    safety = ProcessorDistributedSafety(
+        ray_safe=False,
+        side_effects=ProcessorSideEffect.EXTERNAL,
+        reason="Legacy plugin metadata.",
+    )
+
+    assert safety.partition_safe is False
+    assert safety.ray_safe is False
+    assert "ray_safe" not in ProcessorDistributedSafety.model_fields
+    assert "ray_safe" not in safety.model_dump()
+
+
+def test_processor_distributed_safety_rejects_conflicting_legacy_alias() -> None:
+    with pytest.raises(ValueError, match="deprecated alias"):
+        ProcessorDistributedSafety(
+            partition_safe=True,
+            ray_safe=False,
+            side_effects=ProcessorSideEffect.NONE,
+        )
+
+
+def test_builtin_processor_distributed_safety_metadata_is_backend_neutral() -> None:
+    assert DropColumnsProcessorConfig.distributed_safety.partition_safe is True
+    assert SchemaTransformProcessorConfig.distributed_safety.partition_safe is True
+    assert SchemaTransformProcessorConfig.distributed_safety.side_effects == "dataset_artifact"
+    assert "RayBackend" not in (SchemaTransformProcessorConfig.distributed_safety.reason or "")
+
+
+def test_get_processor_config_from_kwargs() -> None:
     # Test successful creation
     config_drop_columns = get_processor_config_from_kwargs(
         ProcessorType.DROP_COLUMNS,

--- a/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
@@ -5,25 +5,33 @@ from __future__ import annotations
 
 from data_designer.config.base import ProcessorConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.processors import ProcessorDistributedSafety
+from data_designer.config.processors import ProcessorDistributedSafety, ProcessorSideEffect
 from data_designer.integrations.ray.errors import RayBackendConfigurationError
+
+_RAY_SUPPORTED_SIDE_EFFECTS = frozenset(
+    {
+        ProcessorSideEffect.NONE.value,
+        ProcessorSideEffect.BATCH_ARTIFACT.value,
+    }
+)
 
 
 def validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
-    """Validate that configured processors are explicitly safe for Ray execution."""
+    """Validate configured processor capabilities against Ray execution constraints."""
     unsupported: list[str] = []
     for processor in config_builder.get_processor_configs():
         safety = _get_distributed_safety(processor)
-        if safety is None or not safety.ray_safe or safety.requires_global_order:
+        if safety is None or not _is_supported_by_ray(safety):
             unsupported.append(_format_processor_violation(processor, safety))
 
     if not unsupported:
         return
 
     raise RayBackendConfigurationError(
-        "RayBackend supports only processors explicitly declared distributed-safe. "
+        "RayBackend supports only processors whose distributed_safety metadata is compatible "
+        "with partitioned execution. "
         f"Unsupported processor(s): {'; '.join(unsupported)}. "
-        "Review the processor's distributed_safety metadata, or pass "
+        "Review the processor's partition safety and side-effect metadata, or pass "
         "allow_unsafe_processors=True to bypass this experimental guard."
     )
 
@@ -35,6 +43,14 @@ def _get_distributed_safety(processor: ProcessorConfig) -> ProcessorDistributedS
     return None
 
 
+def _is_supported_by_ray(safety: ProcessorDistributedSafety) -> bool:
+    return (
+        safety.partition_safe
+        and not safety.requires_global_order
+        and safety.side_effects in _RAY_SUPPORTED_SIDE_EFFECTS
+    )
+
+
 def _format_processor_violation(processor: ProcessorConfig, safety: ProcessorDistributedSafety | None) -> str:
     processor_type = getattr(processor.processor_type, "value", processor.processor_type)
     label = f"{processor.name} ({processor_type})"
@@ -42,11 +58,14 @@ def _format_processor_violation(processor: ProcessorConfig, safety: ProcessorDis
         return f"{label}: missing distributed_safety metadata"
 
     reasons: list[str] = []
-    if not safety.ray_safe:
-        reasons.append("ray_safe=False")
+    if not safety.partition_safe:
+        reasons.append("partition_safe=False")
     if safety.requires_global_order:
         reasons.append("requires_global_order=True")
-    reasons.append(f"side_effects={safety.side_effects}")
+    if safety.side_effects in _RAY_SUPPORTED_SIDE_EFFECTS:
+        reasons.append(f"side_effects={safety.side_effects}")
+    else:
+        reasons.append(f"side_effects={safety.side_effects} unsupported by RayBackend")
     if safety.reason is not None:
         reasons.append(f"reason={safety.reason}")
     return f"{label}: {', '.join(reasons)}"

--- a/packages/data-designer/tests/integrations/ray/test_processor_policy.py
+++ b/packages/data-designer/tests/integrations/ray/test_processor_policy.py
@@ -23,6 +23,7 @@ from data_designer.config.processors import (
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError
 from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 from data_designer.interface.data_designer import DataDesigner
 
 
@@ -66,10 +67,28 @@ class MissingSafetyProcessorConfig(ProcessorConfig):
 class GlobalOrderProcessorConfig(ProcessorConfig):
     processor_type: Literal["global_order"] = "global_order"
     distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
-        ray_safe=True,
+        partition_safe=True,
         requires_global_order=True,
         side_effects=ProcessorSideEffect.NONE,
         reason="Requires a globally ordered dataset.",
+    )
+
+
+class PartitionUnsafeProcessorConfig(ProcessorConfig):
+    processor_type: Literal["partition_unsafe"] = "partition_unsafe"
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        partition_safe=False,
+        side_effects=ProcessorSideEffect.NONE,
+        reason="Requires cross-partition state.",
+    )
+
+
+class LegacyRaySafeProcessorConfig(ProcessorConfig):
+    processor_type: Literal["legacy_ray_safe"] = "legacy_ray_safe"
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        ray_safe=True,
+        side_effects=ProcessorSideEffect.NONE,
+        reason="Uses legacy compatibility metadata.",
     )
 
 
@@ -162,9 +181,8 @@ def test_ray_backend_rejects_schema_transform_processor_by_default(
 
     message = str(exc_info.value)
     assert "schema-transform (schema_transform)" in message
-    assert "ray_safe=False" in message
-    assert "side_effects=dataset_artifact" in message
-    assert "worker-local storage" in message
+    assert "side_effects=dataset_artifact unsupported by RayBackend" in message
+    assert "artifact collection" in message
     assert "allow_unsafe_processors=True" in message
     assert input_dataset.map_batches_kwargs is None
 
@@ -188,6 +206,25 @@ def test_ray_backend_rejects_processor_without_distributed_safety_metadata(
     assert input_dataset.map_batches_kwargs is None
 
 
+def test_ray_backend_rejects_partition_unsafe_processor_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    _install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    config_builder.add_processor(PartitionUnsafeProcessorConfig(name="partition-unsafe-processor"))
+    designer = _designer(tmp_path, stub_model_providers, backend=RayBackend())
+
+    with pytest.raises(RayBackendConfigurationError, match="partition_safe=False") as exc_info:
+        designer.create(config_builder, input_dataset=input_dataset)
+
+    assert "partition-unsafe-processor (partition_unsafe)" in str(exc_info.value)
+    assert input_dataset.map_batches_kwargs is None
+
+
 def test_ray_backend_rejects_global_order_processor_metadata(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -205,6 +242,13 @@ def test_ray_backend_rejects_global_order_processor_metadata(
 
     assert "global-order-processor (global_order)" in str(exc_info.value)
     assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_processor_policy_accepts_legacy_ray_safe_metadata(stub_model_configs: Any) -> None:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_processor(LegacyRaySafeProcessorConfig(name="legacy-processor"))
+
+    validate_ray_safe_processors(config_builder)
 
 
 def test_ray_backend_allow_unsafe_processors_bypasses_schema_transform_preflight(


### PR DESCRIPTION
## 📋 Summary

Generalizes processor distributed-safety metadata from the Ray-specific `ray_safe` field to backend-neutral partition safety and side-effect capabilities. Ray processor validation now interprets those generic capabilities while existing plugins that construct metadata with `ray_safe=` continue to load through a compatibility alias.

## 🔗 Related Issue

Closes #67
Part of #82

## 🔄 Changes

- Add `partition_safe` to `ProcessorDistributedSafety` and translate legacy `ray_safe=` input into the new field without serializing `ray_safe` as model data.
- Update built-in processor metadata to use backend-neutral wording and side-effect constraints.
- Update Ray processor policy to reject unsupported processors based on partition safety, global ordering, and generic side-effect categories.
- Document distributed processor metadata for processor plugin authors, including Ray interpretation and legacy `ray_safe` compatibility.
- Extend focused config and Ray policy tests for partition safety, side effects, missing metadata, global ordering, bypass behavior, and legacy metadata.

## 🔍 Attention Areas

- `ProcessorDistributedSafety` now serializes `partition_safe` instead of `ray_safe`; `ray_safe=` remains accepted as deprecated constructor input for compatibility.

## 🧪 Testing

- [ ] `make test` passes (not run; targeted tests were run for this scoped change)
- [x] `uv run --group dev pytest packages/data-designer-config/tests/config/test_processors.py packages/data-designer/tests/integrations/ray/test_processor_policy.py`
- [x] `uv run --group dev ruff check packages/data-designer-config/src/data_designer/config/processors.py packages/data-designer/src/data_designer/integrations/ray/processor_policy.py packages/data-designer-config/tests/config/test_processors.py packages/data-designer/tests/integrations/ray/test_processor_policy.py`
- [x] `uv run --group dev ruff format --check packages/data-designer-config/src/data_designer/config/processors.py packages/data-designer/src/data_designer/integrations/ray/processor_policy.py packages/data-designer-config/tests/config/test_processors.py packages/data-designer/tests/integrations/ray/test_processor_policy.py`
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A - config, policy, and docs only)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A - processor/plugin docs updated; no architecture doc change needed)