### PR TITLE
test: add shared fake Ray test harness

### DIFF
--- a/packages/data-designer/pyproject.toml
+++ b/packages/data-designer/pyproject.toml
@@ -60,6 +60,13 @@ extend = "../../pyproject.toml"
 testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "session"
 env = ["DISABLE_DATA_DESIGNER_PLUGINS=true"]
+markers = [
+    "ray_fake: fake-Ray and local-contract tests that do not require a real Ray runtime",
+    "ray_worker_boundary: direct worker/payload boundary tests for Ray execution internals",
+    "ray_real_smoke: opt-in smoke tests that require an installed real Ray runtime",
+    "ray_live_provider: opt-in Ray tests that call a live model provider",
+    "ray_benchmark: benchmark helper tests for Ray benchmark scripts",
+]
 
 [tool.uv]
 package = true

--- a/packages/data-designer/tests/integrations/ray/README.md
+++ b/packages/data-designer/tests/integrations/ray/README.md
@@ -1,0 +1,18 @@
+# Ray Integration Test Taxonomy
+
+Ray integration tests use pytest markers so local runs and CI can select the intended runtime surface:
+
+- `ray_fake`: fake-Ray and local contract tests that do not require a real Ray runtime.
+- `ray_worker_boundary`: direct worker and payload boundary tests for Ray execution internals.
+- `ray_real_smoke`: opt-in tests that require an installed real Ray runtime.
+- `ray_live_provider`: opt-in tests that call a live model provider.
+- `ray_benchmark`: benchmark helper tests for Ray benchmark scripts.
+
+Useful commands:
+
+```bash
+uv run pytest packages/data-designer/tests/integrations/ray -m "ray_fake or ray_worker_boundary or ray_benchmark"
+uv run pytest packages/data-designer/tests/integrations/ray -m ray_fake
+DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 uv run pytest packages/data-designer/tests/integrations/ray -m "ray_real_smoke and not ray_live_provider"
+DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 OPENAI_API_KEY=... uv run pytest packages/data-designer/tests/integrations/ray -m ray_live_provider
+```

--- a/packages/data-designer/tests/integrations/ray/conftest.py
+++ b/packages/data-designer/tests/integrations/ray/conftest.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import types
+from collections.abc import Callable
+
+import pytest
+from fake_ray_harness import FakeRayDataModule, install_fake_ray
+
+
+@pytest.fixture
+def fake_ray_installer(monkeypatch: pytest.MonkeyPatch) -> Callable[..., types.ModuleType]:
+    def _install(
+        *,
+        data_module: FakeRayDataModule | None = None,
+        with_remote: bool = False,
+        initialized: bool = True,
+    ) -> types.ModuleType:
+        return install_fake_ray(
+            monkeypatch,
+            data_module=data_module,
+            with_remote=with_remote,
+            initialized=initialized,
+        )
+
+    return _install

--- a/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+
+
+@dataclass(frozen=True)
+class FakeMapBatchesCall:
+    fn: Any
+    kwargs: dict[str, Any]
+
+    @property
+    def fn_constructor_kwargs(self) -> dict[str, Any]:
+        return dict(self.kwargs.get("fn_constructor_kwargs") or {})
+
+    @property
+    def fn_kwargs(self) -> dict[str, Any]:
+        return dict(self.kwargs.get("fn_kwargs") or {})
+
+
+class FakeRayDataset:
+    def __init__(
+        self,
+        blocks: list[Any],
+        *,
+        data_module: FakeRayDataModule | None = None,
+        reverse_mapped_blocks: bool = False,
+    ) -> None:
+        self.blocks = blocks
+        self.data_module = data_module
+        self.reverse_mapped_blocks = reverse_mapped_blocks
+        self.map_batches_kwargs: dict[str, Any] | None = None
+        self.map_batches_fn: Any | None = None
+        self.map_batches_calls: list[FakeMapBatchesCall] = []
+
+    def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
+        if self.data_module is not None:
+            self.data_module.validate_map_batches_kwargs(kwargs)
+        self.map_batches_kwargs = kwargs
+        self.map_batches_fn = fn
+        self.map_batches_calls.append(FakeMapBatchesCall(fn=fn, kwargs=dict(kwargs)))
+        blocks = map_batches_blocks(fn, self.blocks, kwargs)
+        if self.reverse_mapped_blocks:
+            blocks.reverse()
+        return FakeRayDataset(
+            blocks,
+            data_module=self.data_module,
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
+
+    def zip(self, other: FakeRayDataset) -> FakeRayDataset:
+        other_df = other.to_pandas()
+        offset = 0
+        blocks: list[lazy.pd.DataFrame] = []
+        for block in self.blocks:
+            block_df = coerce_pandas_dataframe(block)
+            block_len = len(block_df)
+            other_block = other_df.iloc[offset : offset + block_len].reset_index(drop=True)
+            blocks.append(lazy.pd.concat([block_df.reset_index(drop=True), other_block], axis=1))
+            offset += block_len
+        return FakeRayDataset(
+            blocks,
+            data_module=self.data_module or other.data_module,
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
+
+    def to_arrow_refs(self) -> list[Any]:
+        if self.data_module is None:
+            return list(self.blocks)
+        refs: list[str] = []
+        for block in self.blocks:
+            ref = f"arrow-ref-{len(self.data_module.ref_blocks)}"
+            self.data_module.ref_blocks[ref] = coerce_pandas_dataframe(block)
+            refs.append(ref)
+        return refs
+
+    def to_pandas(self) -> lazy.pd.DataFrame:
+        return lazy.pd.concat([coerce_pandas_dataframe(block) for block in self.blocks], ignore_index=True)
+
+    def sort(self, column: str) -> FakeRayDataset:
+        sorted_df = self.to_pandas().sort_values(column, kind="stable").reset_index(drop=True)
+        return FakeRayDataset([sorted_df], data_module=self.data_module)
+
+    def drop_columns(self, columns: list[str]) -> FakeRayDataset:
+        return FakeRayDataset(
+            [coerce_pandas_dataframe(block).drop(columns=columns) for block in self.blocks],
+            data_module=self.data_module,
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
+
+    def num_blocks(self) -> int:
+        return len(self.blocks)
+
+    def count(self) -> int:
+        return sum(len(coerce_pandas_dataframe(block)) for block in self.blocks)
+
+
+class FakeActorPoolStrategy:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+class FakeRayDataModule:
+    Dataset = FakeRayDataset
+
+    def __init__(
+        self,
+        *,
+        range_blocks: list[lazy.pd.DataFrame] | None = None,
+        reverse_mapped_blocks: bool = False,
+        validate_map_batches: bool = True,
+    ) -> None:
+        self.from_arrow_refs_input: list[Any] | None = None
+        self.from_pandas_refs_input: list[Any] | None = None
+        self.from_pandas_input: Any | None = None
+        self.from_items_input: list[Any] | None = None
+        self.from_items_kwargs: dict[str, Any] | None = None
+        self.range_blocks = range_blocks
+        self.reverse_mapped_blocks = reverse_mapped_blocks
+        self.range_kwargs: dict[str, Any] | None = None
+        self.ref_blocks: dict[str, lazy.pd.DataFrame] = {}
+        self.validate_map_batches = validate_map_batches
+
+    def dataset(
+        self,
+        blocks: list[Any],
+        *,
+        reverse_mapped_blocks: bool | None = None,
+    ) -> FakeRayDataset:
+        return FakeRayDataset(
+            blocks,
+            data_module=self,
+            reverse_mapped_blocks=self.reverse_mapped_blocks
+            if reverse_mapped_blocks is None
+            else reverse_mapped_blocks,
+        )
+
+    def ActorPoolStrategy(self, **kwargs: Any) -> FakeActorPoolStrategy:
+        return FakeActorPoolStrategy(**kwargs)
+
+    def range(self, num_records: int, **kwargs: Any) -> FakeRayDataset:
+        self.range_kwargs = kwargs
+        if self.range_blocks is not None:
+            return self.dataset(list(self.range_blocks))
+        block_count = kwargs.get("override_num_blocks") or 1
+        if num_records > 0:
+            block_count = min(block_count, num_records)
+        blocks = []
+        for index in range(block_count):
+            start = index * num_records // block_count
+            end = (index + 1) * num_records // block_count
+            blocks.append(lazy.pd.DataFrame({"id": list(range(start, end))}))
+        return self.dataset(blocks)
+
+    def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
+        self.from_arrow_refs_input = refs
+        return self.dataset([self._object_ref_to_pandas(ref) for ref in refs])
+
+    def from_items(self, items: list[Any], **kwargs: Any) -> FakeRayDataset:
+        self.from_items_input = items
+        self.from_items_kwargs = kwargs
+        return self.dataset([lazy.pd.DataFrame(items)])
+
+    def from_pandas(self, dataframes: Any) -> FakeRayDataset:
+        self.from_pandas_input = dataframes
+        if isinstance(dataframes, list):
+            return self.dataset(list(dataframes))
+        return self.dataset([dataframes])
+
+    def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
+        self.from_pandas_refs_input = refs
+        return self.dataset(list(refs))
+
+    def validate_map_batches_kwargs(self, kwargs: dict[str, Any]) -> None:
+        if not self.validate_map_batches:
+            return
+        batch_format = kwargs.get("batch_format")
+        if batch_format is not None and batch_format != "pandas":
+            raise AssertionError(f"fake Ray only supports pandas batches, got {batch_format!r}")
+        batch_size = kwargs.get("batch_size")
+        if batch_size is not None and (
+            isinstance(batch_size, bool) or not isinstance(batch_size, int) or batch_size <= 0
+        ):
+            raise AssertionError(f"fake Ray batch_size must be a positive integer, got {batch_size!r}")
+        fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs")
+        if fn_constructor_kwargs is not None and not isinstance(fn_constructor_kwargs, dict):
+            raise AssertionError("fake Ray fn_constructor_kwargs must be a dict when provided")
+        fn_kwargs = kwargs.get("fn_kwargs")
+        if fn_kwargs is not None and not isinstance(fn_kwargs, dict):
+            raise AssertionError("fake Ray fn_kwargs must be a dict when provided")
+
+    def _object_ref_to_pandas(self, ref: Any) -> lazy.pd.DataFrame:
+        if isinstance(ref, str) and ref in self.ref_blocks:
+            return self.ref_blocks[ref]
+        return coerce_pandas_dataframe(ref)
+
+
+class FakeObjectRef:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+class FakeRemoteMethod:
+    def __init__(self, method: Any) -> None:
+        self._method = method
+
+    def remote(self, *args: Any, **kwargs: Any) -> FakeObjectRef:
+        return FakeObjectRef(self._method(*args, **kwargs))
+
+
+class FakeActorHandle:
+    def __init__(self, actor: Any) -> None:
+        self._actor = actor
+
+    def __getattr__(self, name: str) -> FakeRemoteMethod:
+        return FakeRemoteMethod(getattr(self._actor, name))
+
+
+class FakeRemoteClass:
+    def __init__(self, cls: type) -> None:
+        self._cls = cls
+
+    def remote(self, *args: Any, **kwargs: Any) -> FakeActorHandle:
+        return FakeActorHandle(self._cls(*args, **kwargs))
+
+
+def install_fake_ray(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    data_module: FakeRayDataModule | None = None,
+    with_remote: bool = False,
+    initialized: bool = True,
+) -> types.ModuleType:
+    fake_ray = types.ModuleType("ray")
+    fake_ray.data = data_module or FakeRayDataModule()
+    fake_ray.is_initialized = lambda: initialized
+    fake_ray.init = lambda: None
+    fake_ray.get = fake_ray_get
+    if with_remote:
+        fake_ray.remote = lambda cls: FakeRemoteClass(cls)
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    return fake_ray
+
+
+def fake_ray_get(ref: Any) -> Any:
+    if isinstance(ref, FakeObjectRef):
+        return ref.value
+    if isinstance(ref, list):
+        return [fake_ray_get(item) for item in ref]
+    return ref
+
+
+def map_batches_blocks(fn: Any, blocks: list[Any], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
+    fn_kwargs = kwargs.get("fn_kwargs") or {}
+    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
+    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
+    return [coerce_pandas_dataframe(map_fn(coerce_pandas_dataframe(block), **fn_kwargs)) for block in blocks]
+
+
+def coerce_pandas_dataframe(value: Any) -> lazy.pd.DataFrame:
+    if isinstance(value, lazy.pd.DataFrame):
+        return value
+    to_pandas = getattr(value, "to_pandas", None)
+    if callable(to_pandas):
+        return to_pandas()
+    return value

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -3,12 +3,11 @@
 
 from __future__ import annotations
 
-import sys
-import types
 from pathlib import Path
 from typing import Any
 
 import pytest
+from fake_ray_harness import FakeRayDataset, install_fake_ray
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextColumnConfig
@@ -30,195 +29,7 @@ from data_designer.integrations.ray import (
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
 
-
-class FakeRayDataset:
-    def __init__(self, blocks: list[lazy.pd.DataFrame], *, reverse_mapped_blocks: bool = False) -> None:
-        self.blocks = blocks
-        self.reverse_mapped_blocks = reverse_mapped_blocks
-        self.map_batches_kwargs: dict[str, Any] | None = None
-        self.map_batches_fn: Any | None = None
-
-    def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
-        self.map_batches_kwargs = kwargs
-        self.map_batches_fn = fn
-        blocks = _map_batches_blocks(fn, self.blocks, kwargs)
-        if self.reverse_mapped_blocks:
-            blocks.reverse()
-        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
-
-    def zip(self, other: FakeRayDataset) -> FakeRayDataset:
-        other_df = other.to_pandas()
-        offset = 0
-        blocks: list[lazy.pd.DataFrame] = []
-        for block in self.blocks:
-            block_len = len(block)
-            other_block = other_df.iloc[offset : offset + block_len].reset_index(drop=True)
-            blocks.append(lazy.pd.concat([block.reset_index(drop=True), other_block], axis=1))
-            offset += block_len
-        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
-
-    def to_arrow_refs(self) -> list[str]:
-        return [f"arrow-ref-{i}" for i, _ in enumerate(self.blocks)]
-
-    def to_pandas(self) -> lazy.pd.DataFrame:
-        return lazy.pd.concat(self.blocks, ignore_index=True)
-
-    def sort(self, column: str) -> FakeRayDataset:
-        sorted_df = self.to_pandas().sort_values(column, kind="stable").reset_index(drop=True)
-        return FakeRayDataset([sorted_df])
-
-    def drop_columns(self, columns: list[str]) -> FakeRayDataset:
-        return FakeRayDataset([block.drop(columns=columns) for block in self.blocks])
-
-    def num_blocks(self) -> int:
-        return len(self.blocks)
-
-    def count(self) -> int:
-        return sum(len(block) for block in self.blocks)
-
-
-class FakeActorPoolStrategy:
-    def __init__(self, **kwargs: Any) -> None:
-        self.kwargs = kwargs
-
-
-class FakeRayDataModule:
-    Dataset = FakeRayDataset
-
-    def __init__(self) -> None:
-        self.from_arrow_refs_input: list[Any] | None = None
-        self.from_pandas_refs_input: list[Any] | None = None
-        self.from_pandas_input: Any | None = None
-        self.from_items_input: list[Any] | None = None
-        self.reverse_mapped_blocks = False
-        self.range_kwargs: dict[str, Any] | None = None
-
-    def ActorPoolStrategy(self, **kwargs: Any) -> FakeActorPoolStrategy:
-        return FakeActorPoolStrategy(**kwargs)
-
-    def range(self, num_records: int, **kwargs: Any) -> FakeRayDataset:
-        self.range_kwargs = kwargs
-        block_count = kwargs.get("override_num_blocks") or 1
-        if num_records > 0:
-            block_count = min(block_count, num_records)
-        blocks = []
-        for index in range(block_count):
-            start = index * num_records // block_count
-            end = (index + 1) * num_records // block_count
-            blocks.append(lazy.pd.DataFrame({"id": list(range(start, end))}))
-        return FakeRayDataset(blocks)
-
-    def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
-        self.from_arrow_refs_input = refs
-        return FakeRayDataset(
-            [_arrow_ref_to_pandas(ref) for ref in refs],
-            reverse_mapped_blocks=self.reverse_mapped_blocks,
-        )
-
-    def from_items(self, items: list[Any], **_: Any) -> FakeRayDataset:
-        self.from_items_input = items
-        return FakeRayDataset([lazy.pd.DataFrame(items)])
-
-    def from_pandas(self, dataframes: Any) -> FakeRayDataset:
-        self.from_pandas_input = dataframes
-        if isinstance(dataframes, list):
-            return FakeRayDataset(list(dataframes), reverse_mapped_blocks=self.reverse_mapped_blocks)
-        return FakeRayDataset([dataframes], reverse_mapped_blocks=self.reverse_mapped_blocks)
-
-    def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
-        self.from_pandas_refs_input = refs
-        return FakeRayDataset(list(refs), reverse_mapped_blocks=self.reverse_mapped_blocks)
-
-
-class CountingRayDataset:
-    def __init__(
-        self,
-        blocks: list[lazy.pd.DataFrame],
-        data_module: CountingRayDataModule,
-        *,
-        parent: CountingRayDataset | None = None,
-        map_fn: Any | None = None,
-        map_kwargs: dict[str, Any] | None = None,
-    ) -> None:
-        self.blocks = blocks
-        self.data_module = data_module
-        self.parent = parent
-        self.map_fn = map_fn
-        self.map_kwargs = map_kwargs
-
-    def map_batches(self, fn: Any, **kwargs: Any) -> CountingRayDataset:
-        return CountingRayDataset([], self.data_module, parent=self, map_fn=fn, map_kwargs=kwargs)
-
-    def to_arrow_refs(self) -> list[str]:
-        refs: list[str] = []
-        for block in self._evaluate():
-            ref = f"arrow-ref-{len(self.data_module.ref_blocks)}"
-            self.data_module.ref_blocks[ref] = block
-            refs.append(ref)
-        return refs
-
-    def to_pandas(self) -> lazy.pd.DataFrame:
-        return lazy.pd.concat(self._evaluate(), ignore_index=True)
-
-    def num_blocks(self) -> int:
-        if self.parent is None:
-            return len(self.blocks)
-        return self.parent.num_blocks()
-
-    def _evaluate(self) -> list[lazy.pd.DataFrame]:
-        if self.parent is None:
-            return self.blocks
-        if self.map_fn is None:
-            return self.parent._evaluate()
-        return _map_batches_blocks(self.map_fn, self.parent._evaluate(), self.map_kwargs or {})
-
-
-class CountingRayDataModule:
-    Dataset = CountingRayDataset
-
-    def __init__(self) -> None:
-        self.from_arrow_refs_input: list[Any] | None = None
-        self.ref_blocks: dict[str, lazy.pd.DataFrame] = {}
-
-    def range(self, num_records: int) -> CountingRayDataset:
-        return CountingRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})], self)
-
-    def from_arrow_refs(self, refs: list[Any]) -> CountingRayDataset:
-        self.from_arrow_refs_input = refs
-        return CountingRayDataset([self.ref_blocks[ref] for ref in refs], self)
-
-
-def _map_batches_blocks(fn: Any, blocks: list[lazy.pd.DataFrame], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
-    fn_kwargs = kwargs.get("fn_kwargs") or {}
-    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
-    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
-    return [map_fn(block, **fn_kwargs) for block in blocks]
-
-
-def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
-    fake_ray = types.ModuleType("ray")
-    fake_ray.data = FakeRayDataModule()
-    fake_ray.is_initialized = lambda: True
-    fake_ray.init = lambda: None
-    fake_ray.get = lambda refs: refs
-    monkeypatch.setitem(sys.modules, "ray", fake_ray)
-    return fake_ray
-
-
-def _install_counting_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
-    fake_ray = types.ModuleType("ray")
-    fake_ray.data = CountingRayDataModule()
-    fake_ray.is_initialized = lambda: True
-    fake_ray.init = lambda: None
-    fake_ray.get = lambda refs: refs
-    monkeypatch.setitem(sys.modules, "ray", fake_ray)
-    return fake_ray
-
-
-def _arrow_ref_to_pandas(ref: Any) -> lazy.pd.DataFrame:
-    if hasattr(ref, "to_pandas"):
-        return ref.to_pandas()
-    return ref
+pytestmark = pytest.mark.ray_fake
 
 
 def _managed_assets_path(tmp_path: Path) -> Path:
@@ -256,7 +67,7 @@ def test_ray_backend_uses_input_dataset_as_in_memory_seed(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]})])
     config_builder = _input_expression_config_builder(stub_model_configs)
 
@@ -289,7 +100,7 @@ def test_ray_backend_uses_override_num_blocks_for_from_scratch_dataset(
     stub_sampler_only_config_builder: Any,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -321,7 +132,7 @@ def test_ray_backend_resolves_target_block_size_boundaries(
     max_blocks: int | None,
     expected_blocks: int,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -346,7 +157,7 @@ def test_ray_backend_rejects_block_planning_with_input_dataset(
     stub_sampler_only_config_builder: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
     designer = DataDesigner(
         artifact_path=tmp_path,
@@ -380,7 +191,7 @@ def test_ray_backend_propagates_execution_resource_options(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
     designer = DataDesigner(
         artifact_path=tmp_path,
@@ -415,7 +226,7 @@ def test_ray_backend_actor_pool_uses_autoscaling_strategy_and_constructor_payloa
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
     designer = DataDesigner(
         artifact_path=tmp_path,
@@ -452,7 +263,7 @@ def test_ray_backend_driver_model_health_check_runs_once_and_workers_skip_by_def
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
     preflight_aliases: list[list[str]] = []
     worker_skip_flags: list[list[bool]] = []
@@ -488,7 +299,7 @@ def test_ray_backend_worker_model_health_checks_can_be_requested(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
     worker_skip_flags: list[list[bool]] = []
 
@@ -517,7 +328,7 @@ def test_ray_backend_driver_model_health_check_failure_stops_before_mapping(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
 
     def fail_preflight(_: Any, __: DataDesignerConfigBuilder, ___: list[str]) -> None:
@@ -544,7 +355,7 @@ def test_ray_backend_preserves_input_dataset_order_across_blocks(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset(
         [
             lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]}),
@@ -579,7 +390,7 @@ def test_ray_backend_can_sort_by_explicit_order_column(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset(
         [
             lazy.pd.DataFrame({"row_order": [2], "x": [3], "label": ["c"]}),
@@ -611,7 +422,7 @@ def test_ray_backend_preserve_order_does_not_require_explicit_order_column(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset(
         [
             lazy.pd.DataFrame({"x": [1], "label": ["a"]}),
@@ -642,7 +453,7 @@ def test_ray_backend_uses_pandas_object_refs_as_in_memory_seed(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     input_refs = [lazy.pd.DataFrame({"x": [1], "label": ["a"]}), lazy.pd.DataFrame({"x": [2], "label": ["b"]})]
     config_builder = _input_expression_config_builder(stub_model_configs)
 
@@ -671,7 +482,7 @@ def test_ray_backend_uses_arrow_object_refs_as_in_memory_seed(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     input_refs = [
         lazy.pa.table({"x": [1], "label": ["a"]}),
         lazy.pa.table({"x": [2], "label": ["b"]}),
@@ -703,7 +514,7 @@ def test_ray_backend_rejects_invalid_input_dataset_type(
     stub_sampler_only_config_builder: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -721,7 +532,7 @@ def test_ray_backend_can_return_arrow_refs(
     stub_sampler_only_config_builder: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -746,7 +557,7 @@ def test_ray_backend_arrow_refs_load_dataset_uses_materialized_refs_without_reru
     stub_sampler_only_config_builder: Any,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_counting_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     generate_calls = 0
 
     def generate_batch(batch: lazy.pd.DataFrame, **_: Any) -> lazy.pd.DataFrame:
@@ -781,7 +592,7 @@ def test_ray_backend_arrow_refs_load_dataset_uses_materialized_refs_without_reru
 
 
 def test_ray_backend_arrow_refs_dataset_rebuild_falls_back_to_items(monkeypatch: pytest.MonkeyPatch) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
 
     def fail_from_arrow_refs(refs: list[Any]) -> FakeRayDataset:
         del refs
@@ -807,7 +618,7 @@ def test_ray_backend_materializes_filesystem_seed_reader_fanout_as_input_dataset
     tmp_path: Path,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     seed_dir = tmp_path / "seeds"
     seed_dir.mkdir()
     (seed_dir / "a.txt").write_text("alpha\nbeta", encoding="utf-8")
@@ -866,7 +677,7 @@ def test_ray_backend_dataset_output_wraps_dataset_and_delegates_arrow_refs(
     stub_sampler_only_config_builder: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -890,7 +701,7 @@ def test_ray_backend_rejects_unsafe_processors_by_default(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     config_builder = _input_expression_config_builder(stub_model_configs)
     config_builder.add_processor(
         SchemaTransformProcessorConfig(
@@ -977,7 +788,7 @@ def test_same_process_local_ray_local_runs_do_not_share_backend_state(
     stub_sampler_only_config_builder: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_config_builder = _input_expression_config_builder(stub_model_configs)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
     local_before = DataDesigner(

--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -12,6 +12,8 @@ import pytest
 
 import data_designer.lazy_heavy_imports as lazy
 
+pytestmark = pytest.mark.ray_benchmark
+
 
 def _load_benchmark_module() -> Any:
     repo_root = Path(__file__).resolve().parents[5]

--- a/packages/data-designer/tests/integrations/ray/test_fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/test_fake_ray_harness.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fake_ray_harness import FakeRayDataModule
+
+import data_designer.lazy_heavy_imports as lazy
+
+pytestmark = pytest.mark.ray_fake
+
+
+def test_fake_ray_records_constructor_batch_and_compute_kwargs(
+    fake_ray_installer: Any,
+) -> None:
+    fake_ray = fake_ray_installer()
+    dataset = fake_ray.data.dataset(
+        [
+            lazy.pd.DataFrame({"id": [0, 1]}),
+            lazy.pd.DataFrame({"id": [2]}),
+        ]
+    )
+    compute = fake_ray.data.ActorPoolStrategy(min_size=1, max_size=2)
+
+    class PrefixWorker:
+        def __init__(self, *, prefix: str) -> None:
+            self._prefix = prefix
+
+        def __call__(self, batch: lazy.pd.DataFrame, *, suffix: str) -> lazy.pd.DataFrame:
+            output = batch.copy()
+            output["label"] = [f"{self._prefix}-{value}-{suffix}" for value in output["id"]]
+            return output
+
+    mapped = dataset.map_batches(
+        PrefixWorker,
+        batch_size=2,
+        batch_format="pandas",
+        compute=compute,
+        fn_constructor_kwargs={"prefix": "row"},
+        fn_kwargs={"suffix": "done"},
+    )
+
+    assert dataset.map_batches_fn is PrefixWorker
+    assert dataset.map_batches_kwargs is not None
+    assert dataset.map_batches_kwargs["compute"] is compute
+    assert dataset.map_batches_calls[0].fn_constructor_kwargs == {"prefix": "row"}
+    assert dataset.map_batches_calls[0].fn_kwargs == {"suffix": "done"}
+    assert mapped.to_pandas().to_dict(orient="records") == [
+        {"id": 0, "label": "row-0-done"},
+        {"id": 1, "label": "row-1-done"},
+        {"id": 2, "label": "row-2-done"},
+    ]
+
+
+def test_fake_ray_can_reverse_mapped_blocks() -> None:
+    data_module = FakeRayDataModule(reverse_mapped_blocks=True)
+    dataset = data_module.dataset(
+        [
+            lazy.pd.DataFrame({"id": [0]}),
+            lazy.pd.DataFrame({"id": [1]}),
+        ]
+    )
+
+    mapped = dataset.map_batches(lambda batch: batch, batch_size=1, batch_format="pandas")
+
+    assert mapped.to_pandas()["id"].tolist() == [1, 0]
+
+
+def test_fake_ray_materializes_arrow_refs_without_rerunning_map(
+    fake_ray_installer: Any,
+) -> None:
+    fake_ray = fake_ray_installer()
+    calls = 0
+    dataset = fake_ray.data.range(2)
+
+    def add_generated_column(batch: lazy.pd.DataFrame) -> lazy.pd.DataFrame:
+        nonlocal calls
+        calls += 1
+        output = batch.copy()
+        output["generated"] = calls
+        return output
+
+    refs = dataset.map_batches(add_generated_column, batch_size=2, batch_format="pandas").to_arrow_refs()
+    rebuilt = fake_ray.data.from_arrow_refs(refs)
+
+    assert refs == ["arrow-ref-0"]
+    assert fake_ray.data.from_arrow_refs_input == refs
+    assert rebuilt.to_pandas().to_dict(orient="records") == [
+        {"id": 0, "generated": 1},
+        {"id": 1, "generated": 1},
+    ]
+    assert calls == 1
+
+
+def test_fake_ray_remote_actor_methods_return_object_refs(
+    fake_ray_installer: Any,
+) -> None:
+    fake_ray = fake_ray_installer(with_remote=True)
+
+    class Counter:
+        def __init__(self, *, start: int = 0) -> None:
+            self._value = start
+
+        def add(self, amount: int) -> int:
+            self._value += amount
+            return self._value
+
+    actor = fake_ray.remote(Counter).remote(start=2)
+
+    assert fake_ray.get(actor.add.remote(3)) == 5
+    assert fake_ray.get(actor.add.remote(4)) == 9
+
+
+def test_fake_ray_validates_pandas_batch_contract() -> None:
+    dataset = FakeRayDataModule().dataset([lazy.pd.DataFrame({"id": [0]})])
+
+    with pytest.raises(AssertionError, match="pandas batches"):
+        dataset.map_batches(lambda batch: batch, batch_size=1, batch_format="numpy")
+
+    with pytest.raises(AssertionError, match="positive integer"):
+        dataset.map_batches(lambda batch: batch, batch_size=0, batch_format="pandas")

--- a/packages/data-designer/tests/integrations/ray/test_metrics.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics.py
@@ -8,6 +8,8 @@ import pytest
 from data_designer.integrations.ray import RayDatasetMetrics, RayMetricsError, RayWorkerMetrics
 from data_designer.integrations.ray.metrics import aggregate_ray_metrics, normalize_ray_worker_metrics
 
+pytestmark = pytest.mark.ray_fake
+
 
 def test_aggregate_ray_metrics_sums_worker_metrics_and_model_usage() -> None:
     metrics = aggregate_ray_metrics(

--- a/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-import sys
 import types
 from pathlib import Path
 from typing import Any
 
 import pytest
+from fake_ray_harness import FakeActorHandle, FakeRayDataset, install_fake_ray
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
@@ -18,83 +18,7 @@ from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.integrations.ray.metrics import RayWorkerMetrics, aggregate_ray_metrics
 from data_designer.interface.data_designer import DataDesigner
 
-
-class FakeMetricDataset:
-    def __init__(
-        self,
-        blocks: list[lazy.pd.DataFrame],
-        *,
-        worker_metrics: list[dict[str, Any]] | None = None,
-    ) -> None:
-        self.blocks = blocks
-        self.worker_metrics = worker_metrics or []
-        self.map_batches_kwargs: dict[str, Any] | None = None
-
-    def map_batches(self, fn: Any, **kwargs: Any) -> FakeMetricDataset:
-        self.map_batches_kwargs = kwargs
-        return FakeMetricDataset(
-            _map_batches_blocks(fn, self.blocks, kwargs),
-            worker_metrics=self.worker_metrics,
-        )
-
-    def to_pandas(self) -> lazy.pd.DataFrame:
-        return lazy.pd.concat(self.blocks, ignore_index=True)
-
-    def num_blocks(self) -> int:
-        return len(self.blocks)
-
-
-class FakeRayDataModule:
-    Dataset = FakeMetricDataset
-
-    def range(self, num_records: int) -> FakeMetricDataset:
-        return FakeMetricDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
-
-
-def _map_batches_blocks(fn: Any, blocks: list[lazy.pd.DataFrame], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
-    fn_kwargs = kwargs.get("fn_kwargs") or {}
-    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
-    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
-    return [map_fn(block, **fn_kwargs) for block in blocks]
-
-
-class FakeObjectRef:
-    def __init__(self, value: Any) -> None:
-        self.value = value
-
-
-class FakeRemoteMethod:
-    def __init__(self, method: Any) -> None:
-        self._method = method
-
-    def remote(self, *args: Any, **kwargs: Any) -> FakeObjectRef:
-        return FakeObjectRef(self._method(*args, **kwargs))
-
-
-class FakeActorHandle:
-    def __init__(self, actor: Any) -> None:
-        self._actor = actor
-
-    def __getattr__(self, name: str) -> FakeRemoteMethod:
-        return FakeRemoteMethod(getattr(self._actor, name))
-
-
-class FakeRemoteClass:
-    def __init__(self, cls: type) -> None:
-        self._cls = cls
-
-    def remote(self, *args: Any, **kwargs: Any) -> FakeActorHandle:
-        return FakeActorHandle(self._cls(*args, **kwargs))
-
-
-def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> None:
-    fake_ray = types.ModuleType("ray")
-    fake_ray.data = FakeRayDataModule()
-    fake_ray.is_initialized = lambda: True
-    fake_ray.init = lambda: None
-    fake_ray.remote = lambda cls: FakeRemoteClass(cls)
-    fake_ray.get = lambda ref: ref.value
-    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+pytestmark = pytest.mark.ray_fake
 
 
 def _managed_assets_path(tmp_path: Path) -> Path:
@@ -140,7 +64,7 @@ def test_ray_results_load_metrics_exposes_worker_aggregate(
     ]
     metrics = aggregate_ray_metrics(worker_metrics)
     results = RayDatasetCreationResults(
-        dataset=FakeMetricDataset([lazy.pd.DataFrame({"id": [0]})]),
+        dataset=FakeRayDataset([lazy.pd.DataFrame({"id": [0]})]),
         config_builder=stub_sampler_only_config_builder,
         metrics=metrics,
     )
@@ -173,7 +97,7 @@ def test_ray_results_load_metrics_preserves_zero_worker_total_rows(
         types.SimpleNamespace(snapshot=lambda: [{"total_rows": 0, "blocks": 1, "elapsed_seconds": 0.25}])
     )
     results = RayDatasetCreationResults(
-        dataset=FakeMetricDataset([lazy.pd.DataFrame({"id": [0, 1, 2, 3, 4]})]),
+        dataset=FakeRayDataset([lazy.pd.DataFrame({"id": [0, 1, 2, 3, 4]})]),
         config_builder=stub_sampler_only_config_builder,
         metrics=RayDatasetMetrics(total_rows=5, blocks=1, elapsed_seconds=10.0),
         ray=ray,
@@ -193,7 +117,7 @@ def test_ray_backend_load_metrics_aggregates_worker_emitted_payloads(
     stub_sampler_only_config_builder: DataDesignerConfigBuilder,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch, with_remote=True)
     worker_metrics = [
         {
             "total_rows": 2,
@@ -226,12 +150,11 @@ def test_ray_backend_load_metrics_aggregates_worker_emitted_payloads(
             },
         },
     ]
-    input_dataset = FakeMetricDataset(
+    input_dataset = FakeRayDataset(
         [
             lazy.pd.DataFrame({"id": [0, 1]}),
             lazy.pd.DataFrame({"id": [2]}),
-        ],
-        worker_metrics=worker_metrics,
+        ]
     )
 
     def generate_batch(

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import json
 import types
 from pathlib import Path
-from typing import Any
+
+import pytest
+from fake_ray_harness import FakeActorHandle
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
@@ -19,26 +21,7 @@ from data_designer.integrations.ray import (
 )
 from data_designer.integrations.ray import backend as ray_backend_module
 
-
-class FakeObjectRef:
-    def __init__(self, value: Any) -> None:
-        self.value = value
-
-
-class FakeRemoteMethod:
-    def __init__(self, method: Any) -> None:
-        self._method = method
-
-    def remote(self, *args: Any, **kwargs: Any) -> FakeObjectRef:
-        return FakeObjectRef(self._method(*args, **kwargs))
-
-
-class FakeActorHandle:
-    def __init__(self, actor: Any) -> None:
-        self._actor = actor
-
-    def __getattr__(self, name: str) -> FakeRemoteMethod:
-        return FakeRemoteMethod(getattr(self._actor, name))
+pytestmark = pytest.mark.ray_fake
 
 
 def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(

--- a/packages/data-designer/tests/integrations/ray/test_optional_extra.py
+++ b/packages/data-designer/tests/integrations/ray/test_optional_extra.py
@@ -9,6 +9,8 @@ from types import ModuleType
 
 import pytest
 
+pytestmark = pytest.mark.ray_fake
+
 
 def _clear_modules(monkeypatch: pytest.MonkeyPatch, prefixes: tuple[str, ...]) -> None:
     for module_name in list(sys.modules):

--- a/packages/data-designer/tests/integrations/ray/test_processor_policy.py
+++ b/packages/data-designer/tests/integrations/ray/test_processor_policy.py
@@ -3,12 +3,11 @@
 
 from __future__ import annotations
 
-import sys
-import types
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
 import pytest
+from fake_ray_harness import FakeRayDataset, install_fake_ray
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.base import ProcessorConfig
@@ -26,38 +25,7 @@ from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 from data_designer.interface.data_designer import DataDesigner
 
-
-class FakeRayDataset:
-    def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
-        self.blocks = blocks
-        self.map_batches_kwargs: dict[str, Any] | None = None
-
-    def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
-        self.map_batches_kwargs = kwargs
-        return FakeRayDataset(_map_batches_blocks(fn, self.blocks, kwargs))
-
-    def to_pandas(self) -> lazy.pd.DataFrame:
-        return lazy.pd.concat(self.blocks, ignore_index=True)
-
-    def to_arrow_refs(self) -> list[str]:
-        return [f"arrow-ref-{index}" for index, _ in enumerate(self.blocks)]
-
-    def num_blocks(self) -> int:
-        return len(self.blocks)
-
-
-class FakeRayDataModule:
-    Dataset = FakeRayDataset
-
-    def range(self, num_records: int) -> FakeRayDataset:
-        return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
-
-
-def _map_batches_blocks(fn: Any, blocks: list[lazy.pd.DataFrame], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
-    fn_kwargs = kwargs.get("fn_kwargs") or {}
-    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
-    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
-    return [map_fn(block, **fn_kwargs) for block in blocks]
+pytestmark = pytest.mark.ray_fake
 
 
 class MissingSafetyProcessorConfig(ProcessorConfig):
@@ -90,14 +58,6 @@ class LegacyRaySafeProcessorConfig(ProcessorConfig):
         side_effects=ProcessorSideEffect.NONE,
         reason="Uses legacy compatibility metadata.",
     )
-
-
-def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> None:
-    fake_ray = types.ModuleType("ray")
-    fake_ray.data = FakeRayDataModule()
-    fake_ray.is_initialized = lambda: True
-    fake_ray.init = lambda: None
-    monkeypatch.setitem(sys.modules, "ray", fake_ray)
 
 
 def _managed_assets_path(tmp_path: Path) -> Path:
@@ -144,7 +104,7 @@ def test_ray_backend_allows_drop_columns_processor(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]})])
     config_builder = _input_expression_config_builder(stub_model_configs)
     config_builder.add_processor(DropColumnsProcessorConfig(name="drop-x-label", column_names=["x_label"]))
@@ -165,7 +125,7 @@ def test_ray_backend_rejects_schema_transform_processor_by_default(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
     config_builder = _input_expression_config_builder(stub_model_configs)
     config_builder.add_processor(
@@ -193,7 +153,7 @@ def test_ray_backend_rejects_processor_without_distributed_safety_metadata(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
     config_builder = _input_expression_config_builder(stub_model_configs)
     config_builder.add_processor(MissingSafetyProcessorConfig(name="custom-processor"))
@@ -212,7 +172,7 @@ def test_ray_backend_rejects_partition_unsafe_processor_metadata(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
     config_builder = _input_expression_config_builder(stub_model_configs)
     config_builder.add_processor(PartitionUnsafeProcessorConfig(name="partition-unsafe-processor"))
@@ -231,7 +191,7 @@ def test_ray_backend_rejects_global_order_processor_metadata(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
     config_builder = _input_expression_config_builder(stub_model_configs)
     config_builder.add_processor(GlobalOrderProcessorConfig(name="global-order-processor"))
@@ -257,7 +217,7 @@ def test_ray_backend_allow_unsafe_processors_bypasses_schema_transform_preflight
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
     config_builder = _input_expression_config_builder(stub_model_configs)
     config_builder.add_processor(

--- a/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
+++ b/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
@@ -3,12 +3,11 @@
 
 from __future__ import annotations
 
-import sys
-import types
 from pathlib import Path
 from typing import Any
 
 import pytest
+from fake_ray_harness import install_fake_ray
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
@@ -21,69 +20,7 @@ from data_designer.integrations.ray.metrics import RayWorkerMetrics
 from data_designer.integrations.ray.throttling import RayThrottleManagerProxy, create_ray_throttle_manager
 from data_designer.interface.data_designer import DataDesigner
 
-
-class FakeRayDataset:
-    def __init__(self, blocks: list[lazy.pd.DataFrame]) -> None:
-        self.blocks = blocks
-
-    def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
-        fn_kwargs = kwargs.get("fn_kwargs") or {}
-        fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
-        map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
-        return FakeRayDataset([map_fn(block, **fn_kwargs) for block in self.blocks])
-
-    def to_pandas(self) -> lazy.pd.DataFrame:
-        return lazy.pd.concat(self.blocks, ignore_index=True)
-
-    def num_blocks(self) -> int:
-        return len(self.blocks)
-
-
-class FakeRayDataModule:
-    Dataset = FakeRayDataset
-
-    def range(self, num_records: int) -> FakeRayDataset:
-        return FakeRayDataset([lazy.pd.DataFrame({"id": list(range(num_records))})])
-
-
-class FakeObjectRef:
-    def __init__(self, value: Any) -> None:
-        self.value = value
-
-
-class FakeRemoteMethod:
-    def __init__(self, method: Any) -> None:
-        self._method = method
-
-    def remote(self, *args: Any, **kwargs: Any) -> FakeObjectRef:
-        return FakeObjectRef(self._method(*args, **kwargs))
-
-
-class FakeActorHandle:
-    def __init__(self, actor: Any) -> None:
-        self._actor = actor
-
-    def __getattr__(self, name: str) -> FakeRemoteMethod:
-        return FakeRemoteMethod(getattr(self._actor, name))
-
-
-class FakeRemoteClass:
-    def __init__(self, cls: type) -> None:
-        self._cls = cls
-
-    def remote(self, *args: Any, **kwargs: Any) -> FakeActorHandle:
-        return FakeActorHandle(self._cls(*args, **kwargs))
-
-
-def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
-    fake_ray = types.ModuleType("ray")
-    fake_ray.data = FakeRayDataModule()
-    fake_ray.is_initialized = lambda: True
-    fake_ray.init = lambda: None
-    fake_ray.remote = lambda cls: FakeRemoteClass(cls)
-    fake_ray.get = lambda ref: ref.value
-    monkeypatch.setitem(sys.modules, "ray", fake_ray)
-    return fake_ray
+pytestmark = pytest.mark.ray_fake
 
 
 def _managed_assets_path(tmp_path: Path) -> Path:
@@ -93,7 +30,7 @@ def _managed_assets_path(tmp_path: Path) -> Path:
 
 
 def test_ray_throttle_proxy_coordinates_shared_provider_cap(monkeypatch: pytest.MonkeyPatch) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch, with_remote=True)
     first_worker = create_ray_throttle_manager(fake_ray, RunConfig())
     second_worker = RayThrottleManagerProxy(first_worker._coordinator)
 
@@ -130,7 +67,7 @@ def test_ray_backend_exposes_global_throttle_snapshot_in_metrics(
     stub_sampler_only_config_builder: DataDesignerConfigBuilder,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch, with_remote=True)
 
     def generate_batch(
         batch: lazy.pd.DataFrame,

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -29,6 +29,8 @@ from data_designer.interface.data_designer import DataDesigner
 REAL_RAY_SMOKE_ENV = "DATA_DESIGNER_RUN_REAL_RAY_SMOKE"
 OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
 
+pytestmark = pytest.mark.ray_real_smoke
+
 
 def test_real_ray_markdown_seed_recipe_arrow_refs_smoke(
     tmp_path: Path,
@@ -78,6 +80,7 @@ def test_real_ray_markdown_seed_recipe_arrow_refs_smoke(
         ray.shutdown()
 
 
+@pytest.mark.ray_live_provider
 def test_real_ray_text_to_python_openai_recipe_smoke(tmp_path: Path) -> None:
     ray = _require_real_ray()
     if not os.environ.get(OPENAI_API_KEY_ENV):

--- a/packages/data-designer/tests/integrations/ray/test_semantics.py
+++ b/packages/data-designer/tests/integrations/ray/test_semantics.py
@@ -3,12 +3,11 @@
 
 from __future__ import annotations
 
-import sys
-import types
 from pathlib import Path
 from typing import Any
 
 import pytest
+from fake_ray_harness import FakeRayDataset, install_fake_ray
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig
@@ -18,94 +17,7 @@ from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend
 from data_designer.interface.data_designer import DataDesigner
 
-
-class FakeRayDataset:
-    def __init__(self, blocks: list[lazy.pd.DataFrame], *, reverse_mapped_blocks: bool = False) -> None:
-        self.blocks = blocks
-        self.reverse_mapped_blocks = reverse_mapped_blocks
-
-    def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
-        blocks = _map_batches_blocks(fn, self.blocks, kwargs)
-        if self.reverse_mapped_blocks:
-            blocks.reverse()
-        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
-
-    def zip(self, other: FakeRayDataset) -> FakeRayDataset:
-        other_df = other.to_pandas()
-        offset = 0
-        blocks: list[lazy.pd.DataFrame] = []
-        for block in self.blocks:
-            block_len = len(block)
-            other_block = other_df.iloc[offset : offset + block_len].reset_index(drop=True)
-            blocks.append(lazy.pd.concat([block.reset_index(drop=True), other_block], axis=1))
-            offset += block_len
-        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
-
-    def to_arrow_refs(self) -> list[lazy.pd.DataFrame]:
-        return self.blocks
-
-    def to_pandas(self) -> lazy.pd.DataFrame:
-        return lazy.pd.concat(self.blocks, ignore_index=True)
-
-    def sort(self, column: str) -> FakeRayDataset:
-        sorted_df = self.to_pandas().sort_values(column, kind="stable").reset_index(drop=True)
-        return FakeRayDataset([sorted_df])
-
-    def drop_columns(self, columns: list[str]) -> FakeRayDataset:
-        return FakeRayDataset([block.drop(columns=columns) for block in self.blocks])
-
-    def num_blocks(self) -> int:
-        return len(self.blocks)
-
-    def count(self) -> int:
-        return sum(len(block) for block in self.blocks)
-
-
-class FakeRayDataModule:
-    Dataset = FakeRayDataset
-
-    def __init__(self) -> None:
-        self.from_arrow_refs_input: list[Any] | None = None
-        self.from_pandas_refs_input: list[Any] | None = None
-        self.range_blocks: list[lazy.pd.DataFrame] | None = None
-        self.reverse_mapped_blocks = False
-
-    def range(self, num_records: int) -> FakeRayDataset:
-        blocks = self.range_blocks or [lazy.pd.DataFrame({"id": list(range(num_records))})]
-        return FakeRayDataset(blocks, reverse_mapped_blocks=self.reverse_mapped_blocks)
-
-    def from_arrow_refs(self, refs: list[Any]) -> FakeRayDataset:
-        self.from_arrow_refs_input = refs
-        return FakeRayDataset(
-            [_arrow_ref_to_pandas(ref) for ref in refs],
-            reverse_mapped_blocks=self.reverse_mapped_blocks,
-        )
-
-    def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
-        self.from_pandas_refs_input = refs
-        return FakeRayDataset(list(refs), reverse_mapped_blocks=self.reverse_mapped_blocks)
-
-
-def _map_batches_blocks(fn: Any, blocks: list[lazy.pd.DataFrame], kwargs: dict[str, Any]) -> list[lazy.pd.DataFrame]:
-    fn_kwargs = kwargs.get("fn_kwargs") or {}
-    fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
-    map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
-    return [map_fn(block, **fn_kwargs) for block in blocks]
-
-
-def _install_fake_ray(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
-    fake_ray = types.ModuleType("ray")
-    fake_ray.data = FakeRayDataModule()
-    fake_ray.is_initialized = lambda: True
-    fake_ray.init = lambda: None
-    monkeypatch.setitem(sys.modules, "ray", fake_ray)
-    return fake_ray
-
-
-def _arrow_ref_to_pandas(ref: Any) -> lazy.pd.DataFrame:
-    if hasattr(ref, "to_pandas"):
-        return ref.to_pandas()
-    return ref
+pytestmark = pytest.mark.ray_fake
 
 
 def _managed_assets_path(tmp_path: Path) -> Path:
@@ -161,7 +73,7 @@ def test_explicit_order_column_sorts_stably_and_can_be_dropped(
     drop_order_column: bool,
     expected_columns: list[str],
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset(
         [
             lazy.pd.DataFrame({"row_order": [2, 4], "sku": ["c", "e"], "label": ["third", "fifth"]}),
@@ -195,7 +107,7 @@ def test_hidden_row_id_preserves_input_dataset_order_without_schema_pollution(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset(
         [
             lazy.pd.DataFrame({"sku": ["a", "b"], "label": ["first", "second"]}),
@@ -236,7 +148,7 @@ def test_hidden_row_id_preserves_object_ref_order_without_schema_pollution(
     stub_model_providers: Any,
     object_ref_format: str,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     fake_ray.data.reverse_mapped_blocks = True
     if object_ref_format == "pandas":
         input_refs: list[Any] = [
@@ -276,7 +188,7 @@ def test_hidden_row_id_preserves_arrow_ref_output_order_without_schema_pollution
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_dataset = FakeRayDataset(
         [
             lazy.pd.DataFrame({"sku": ["a"], "label": ["first"]}),
@@ -307,7 +219,7 @@ def test_hidden_row_id_preserves_from_scratch_order_without_schema_pollution(
     stub_sampler_only_config_builder: DataDesignerConfigBuilder,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     fake_ray.data.range_blocks = [
         lazy.pd.DataFrame({"id": [0, 1]}),
         lazy.pd.DataFrame({"id": [2]}),
@@ -333,7 +245,7 @@ def test_seed_config_without_input_dataset_reads_partition_offsets_once(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     fake_ray.data.range_blocks = [
         lazy.pd.DataFrame({"id": [0, 1]}),
         lazy.pd.DataFrame({"id": [2, 3]}),
@@ -388,7 +300,7 @@ def test_pandas_object_refs_preserve_schema_column_order(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     input_refs = [
         lazy.pd.DataFrame({"sku": ["sku-1"], "quantity": [2], "label": ["alpha"]}),
         lazy.pd.DataFrame({"sku": ["sku-2"], "quantity": [5], "label": ["beta"]}),
@@ -421,7 +333,7 @@ def test_arrow_object_refs_preserve_schema_column_order(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    fake_ray = _install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     input_refs = [
         lazy.pa.table({"label": ["alpha"], "sku": ["sku-1"], "quantity": [2]}),
         lazy.pa.table({"label": ["beta"], "sku": ["sku-2"], "quantity": [5]}),
@@ -455,7 +367,7 @@ def test_object_refs_preserve_supported_dtypes_and_nulls(
     stub_model_providers: Any,
     object_ref_format: str,
 ) -> None:
-    _install_fake_ray(monkeypatch)
+    install_fake_ray(monkeypatch)
     input_refs: list[Any]
     if object_ref_format == "pandas":
         input_refs = [

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -25,7 +25,11 @@ from data_designer.integrations.ray import RayBackend, RayBackendConfigurationEr
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
 
+pytestmark = [pytest.mark.ray_fake, pytest.mark.ray_worker_boundary]
 
+
+# Intentionally local: this fake fails if mapping starts, so worker-boundary
+# tests can assert driver-side validation stops before Ray execution planning.
 class BoundaryRayDataset:
     def __init__(self, blocks: list[Any]) -> None:
         self.blocks = blocks


### PR DESCRIPTION
## 📋 Summary
Centralizes the Ray integration tests' fake-Ray dataset, object-ref, map_batches, and actor scaffolding so backend tests share one contract. Also registers selectable Ray pytest markers and documents the commands for fake-Ray, real-Ray smoke, live-provider, and benchmark validation.

## 🔗 Related Issue
Closes #53
Closes #57

## 🔄 Changes
- Added a shared fake-Ray harness and fixture under `packages/data-designer/tests/integrations/ray/`.
- Replaced duplicated fake-Ray dataset/data-module/actor helpers across Ray integration tests with the shared harness.
- Added focused harness tests for map-batches kwargs, block ordering, object refs, actor calls, and validation failures.
- Registered Ray-specific pytest markers and marked each Ray integration test module by runtime taxonomy.
- Documented supported Ray test selection commands in `packages/data-designer/tests/integrations/ray/README.md`.

## 🧪 Testing
- [ ] `make test` passes (not run; targeted Ray validation only)
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A — test infrastructure only)

Targeted checks run:
- [x] `uv run ruff check packages/data-designer/pyproject.toml packages/data-designer/tests/integrations/ray`
- [x] `uv run --package data-designer pytest packages/data-designer/tests/integrations/ray -m "not ray_real_smoke"`
- [x] `uv run --package data-designer pytest packages/data-designer/tests/integrations/ray -m ray_real_smoke`
- [x] `uv run --package data-designer pytest packages/data-designer/tests/integrations/ray -m ray_live_provider`

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A — added Ray test taxonomy notes instead)