### PR TITLE
refactor: share Ray benchmark helpers

### DIFF
--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import pytest
@@ -15,40 +17,66 @@ import data_designer.lazy_heavy_imports as lazy
 pytestmark = pytest.mark.ray_benchmark
 
 
-def _load_benchmark_module() -> Any:
-    repo_root = Path(__file__).resolve().parents[5]
-    script_path = repo_root / "scripts" / "benchmarks" / "benchmark_ray_openai.py"
-    spec = importlib.util.spec_from_file_location("benchmark_ray_openai", script_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Could not load benchmark script from {script_path}.")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[5]
+
+
+def _benchmark_dir() -> Path:
+    return _repo_root() / "scripts" / "benchmarks"
+
+
+def _load_benchmark_module(module_name: str, script_path: Path) -> ModuleType:
+    sys.path.insert(0, str(script_path.parent))
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, script_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Could not load benchmark module from {script_path}.")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(script_path.parent))
+
+
+def _load_common_module() -> ModuleType:
+    return _load_benchmark_module("ray_benchmark_common", _benchmark_dir() / "ray_benchmark_common.py")
+
+
+def test_ray_benchmark_scripts_import_with_shared_helpers() -> None:
+    benchmark_dir = _benchmark_dir()
+
+    modules = {
+        path.stem: _load_benchmark_module(path.stem, path) for path in sorted(benchmark_dir.glob("benchmark_ray_*.py"))
+    }
+
+    assert modules["benchmark_ray_openai"].RESULT_PREFIX == "RAY_OPENAI_BENCHMARK_RESULT="
+    assert modules["benchmark_ray_mock_provider"].RESULT_PREFIX == "RAY_MOCK_PROVIDER_BENCHMARK_RESULT="
+    assert modules["benchmark_ray_streaming_out_of_core"].RESULT_PREFIX == "RAY_STREAMING_OUT_OF_CORE_RESULT="
 
 
 def test_parse_backends_supports_full_apples_to_apples_suite() -> None:
-    benchmark = _load_benchmark_module()
+    benchmark_common = _load_common_module()
 
-    assert benchmark._parse_backends("all") == list(benchmark.ALL_BACKENDS)
-    assert benchmark._parse_backends("local-sync,local-async,ray-dataset,ray-arrow-refs") == [
+    assert benchmark_common.parse_backends("all") == list(benchmark_common.ALL_BACKENDS)
+    assert benchmark_common.parse_backends("local-sync,local-async,ray-dataset,ray-arrow-refs") == [
         "local-sync",
         "local-async",
         "ray-dataset",
         "ray-arrow-refs",
     ]
-    assert benchmark._parse_backends("local-sync,local-sync,ray-dataset") == ["local-sync", "ray-dataset"]
+    assert benchmark_common.parse_backends("local-sync,local-sync,ray-dataset") == ["local-sync", "ray-dataset"]
 
 
 def test_parse_backends_rejects_unknown_backend() -> None:
-    benchmark = _load_benchmark_module()
+    benchmark_common = _load_common_module()
 
     with pytest.raises(ValueError, match="Unsupported backend"):
-        benchmark._parse_backends("local,ray")
+        benchmark_common.parse_backends("local,ray")
 
 
 def test_result_payload_reports_validity_and_provider_counters(tmp_path: Path) -> None:
-    benchmark = _load_benchmark_module()
+    benchmark_common = _load_common_module()
     output = lazy.pd.DataFrame(
         {
             "instruction": ["write code", "debug code"],
@@ -69,7 +97,7 @@ def test_result_payload_reports_validity_and_provider_counters(tmp_path: Path) -
         },
     }
 
-    payload = benchmark._result_payload(
+    payload = benchmark_common.result_payload(
         backend="local-sync",
         iteration=1,
         seed=11,
@@ -82,6 +110,7 @@ def test_result_payload_reports_validity_and_provider_counters(tmp_path: Path) -
         max_parallel_requests=2,
         expected_columns=["instruction", "code_implementation"],
         expected_rows=2,
+        include_retry_throttle=True,
     )
 
     assert payload["validity"] == {
@@ -96,8 +125,28 @@ def test_result_payload_reports_validity_and_provider_counters(tmp_path: Path) -
     assert payload["throughput"]["throttle_count"] == 1
 
 
+def test_failure_payload_preserves_result_shape() -> None:
+    benchmark_common = _load_common_module()
+
+    payload = benchmark_common.failure_payload(
+        backend="ray-dataset",
+        iteration=2,
+        seed=12,
+        elapsed_seconds=3.5,
+        exc=RuntimeError("backend failed"),
+        batch_size=8,
+        max_parallel_requests=4,
+        expected_columns=["a", "b"],
+    )
+
+    assert payload["status"] == "failed"
+    assert payload["missing_columns"] == ["a", "b"]
+    assert payload["validity"]["all_output_valid"] is False
+    assert payload["throughput"]["total_requests"] == 0
+
+
 def test_summary_groups_iterations_and_speedups() -> None:
-    benchmark = _load_benchmark_module()
+    benchmark_common = _load_common_module()
     results = [
         _benchmark_result(backend="local-sync", iteration=1, elapsed_seconds=10.0, rows_per_second=10.0),
         _benchmark_result(backend="local-async", iteration=1, elapsed_seconds=5.0, rows_per_second=20.0),
@@ -107,7 +156,7 @@ def test_summary_groups_iterations_and_speedups() -> None:
         _benchmark_result(backend="ray-dataset", iteration=2, elapsed_seconds=2.0, rows_per_second=50.0),
     ]
 
-    summary = benchmark._build_summary(results)
+    summary = benchmark_common.build_summary(results, include_retry_throttle=True)
 
     assert summary["all_output_valid"] is True
     assert summary["failed_backends"] == []
@@ -118,7 +167,7 @@ def test_summary_groups_iterations_and_speedups() -> None:
 
 
 def test_summary_flags_row_count_mismatch_as_failed_backend() -> None:
-    benchmark = _load_benchmark_module()
+    benchmark_common = _load_common_module()
     result = _benchmark_result(
         backend="ray-dataset",
         iteration=1,
@@ -130,21 +179,40 @@ def test_summary_flags_row_count_mismatch_as_failed_backend() -> None:
     result["metrics"] = {"failed_blocks": 0}
     result["throughput"]["failed_requests"] = 0
 
-    summary = benchmark._build_summary([result])
+    summary = benchmark_common.build_summary([result], include_retry_throttle=True)
 
     assert summary["all_output_valid"] is False
     assert summary["failed_backends"] == ["ray-dataset"]
 
 
 def test_fail_on_invalid_summary_exits_nonzero_unless_allowed() -> None:
-    benchmark = _load_benchmark_module()
+    benchmark_common = _load_common_module()
     summary = {"all_output_valid": False, "failed_backends": ["ray-dataset"]}
 
     with pytest.raises(SystemExit) as exc_info:
-        benchmark._fail_on_invalid_summary(summary=summary, allow_failures=False)
+        benchmark_common.fail_on_invalid_summary(summary=summary, allow_failures=False)
 
     assert exc_info.value.code == 1
-    assert benchmark._fail_on_invalid_summary(summary=summary, allow_failures=True) is None
+    assert benchmark_common.fail_on_invalid_summary(summary=summary, allow_failures=True) is None
+
+
+def test_json_default_serializes_numpy_values() -> None:
+    benchmark_common = _load_common_module()
+
+    assert benchmark_common.json_default(lazy.np.array([1, 2])) == [1, 2]
+    assert benchmark_common.json_default(lazy.np.int64(3)) == 3
+
+
+def test_ray_benchmark_scripts_do_not_call_private_data_designer_builders_directly() -> None:
+    private_methods = {"_create_resource_provider", "_create_dataset_builder"}
+    offenders: list[str] = []
+    for script_path in sorted(_benchmark_dir().glob("benchmark_ray_*.py")):
+        tree = ast.parse(script_path.read_text(encoding="utf-8"), filename=str(script_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in private_methods:
+                offenders.append(f"{script_path.name}:{node.lineno}:{node.attr}")
+
+    assert offenders == []
 
 
 def _benchmark_result(

--- a/scripts/benchmarks/benchmark_ray_mock_provider.py
+++ b/scripts/benchmarks/benchmark_ray_mock_provider.py
@@ -17,7 +17,6 @@ import contextlib
 import hashlib
 import json
 import math
-import os
 import random
 import signal
 import socket
@@ -27,20 +26,15 @@ import time
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Iterator, Literal
+from typing import Any, Iterator
+
+import ray_benchmark_common as benchmark_common
+from ray_benchmark_common import ALL_BACKENDS, BackendName, RayOutputMode
 
 import data_designer.config as dd
-import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.models import ChatCompletionInferenceParams, ModelConfig, ModelProvider
-from data_designer.config.run_config import RunConfig
-from data_designer.integrations.ray import RayBackend
-from data_designer.interface.data_designer import DataDesigner
 
-BackendName = Literal["local-sync", "local-async", "ray-dataset", "ray-arrow-refs"]
-RayOutputMode = Literal["dataset", "arrow_refs"]
-
-ALL_BACKENDS: tuple[BackendName, ...] = ("local-sync", "local-async", "ray-dataset", "ray-arrow-refs")
 RESULT_PREFIX = "RAY_MOCK_PROVIDER_BENCHMARK_RESULT="
 DEFAULT_MODEL_ALIAS = "mock-text"
 DEFAULT_PROVIDER_NAME = "mock-provider"
@@ -51,24 +45,6 @@ DEFAULT_ITERATIONS = 1
 DEFAULT_RAY_CPUS = 4
 DEFAULT_LLM_COLUMNS = 3
 DEFAULT_SEED = 11
-
-
-@dataclass(frozen=True)
-class MetricStats:
-    mean: float
-    stdev: float
-    minimum: float
-    maximum: float
-    n: int
-
-    def to_dict(self) -> dict[str, float | int]:
-        return {
-            "mean": self.mean,
-            "stdev": self.stdev,
-            "min": self.minimum,
-            "max": self.maximum,
-            "n": self.n,
-        }
 
 
 @dataclass(frozen=True)
@@ -311,7 +287,7 @@ def main() -> None:
         chars_per_input_token=args.chars_per_input_token,
         emit_token_text=not args.compact_response_text,
     )
-    selected_backends = _parse_backends(args.backends)
+    selected_backends = benchmark_common.parse_backends(args.backends)
     service = MockTokenProviderService(service_config)
     service.start()
     try:
@@ -375,7 +351,7 @@ def main() -> None:
                         )
                     result["status"] = "ok"
                 except Exception as exc:
-                    result = _failure_payload(
+                    result = benchmark_common.failure_payload(
                         backend=backend,
                         iteration=iteration,
                         seed=iteration_seed,
@@ -385,19 +361,19 @@ def main() -> None:
                         max_parallel_requests=args.max_parallel_requests,
                         expected_columns=expected_columns,
                     )
-                result["mock_service"] = _mock_service_payload(service.snapshot(), elapsed_seconds=result["elapsed_seconds"])
+                result["mock_service"] = _mock_service_payload(
+                    service.snapshot(), elapsed_seconds=result["elapsed_seconds"]
+                )
                 results.append(result)
                 _emit({"type": "backend_result", **result})
 
         summary = _build_summary(results)
         _emit({"type": "summary", **summary})
         if args.output_json is not None:
-            args.output_json.parent.mkdir(parents=True, exist_ok=True)
-            args.output_json.write_text(
-                json.dumps({"setup": setup, "results": results, "summary": summary}, indent=2, default=_json_default)
+            benchmark_common.write_json_report(
+                args.output_json, {"setup": setup, "results": results, "summary": summary}
             )
-        if not args.allow_failures and (summary["failed_backends"] or not summary["all_output_valid"]):
-            raise SystemExit(1)
+        benchmark_common.fail_on_invalid_summary(summary=summary, allow_failures=args.allow_failures)
     finally:
         service.stop()
 
@@ -421,24 +397,6 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--min-output-tokens must be <= --max-output-tokens.")
     if args.chars_per_input_token < 1:
         raise ValueError("--chars-per-input-token must be >= 1.")
-
-
-def _parse_backends(value: str) -> list[BackendName]:
-    if value.strip() == "all":
-        return list(ALL_BACKENDS)
-
-    backends: list[BackendName] = []
-    seen: set[str] = set()
-    for raw_backend in value.split(","):
-        backend = raw_backend.strip()
-        if backend not in ALL_BACKENDS:
-            raise ValueError(f"Unsupported backend {backend!r}. Expected one of {', '.join(ALL_BACKENDS)} or all.")
-        if backend not in seen:
-            backends.append(backend)  # type: ignore[arg-type]
-            seen.add(backend)
-    if not backends:
-        raise ValueError("At least one backend must be selected.")
-    return backends
 
 
 def _build_mock_config(*, llm_columns: int, max_parallel_requests: int) -> DataDesignerConfigBuilder:
@@ -566,41 +524,22 @@ def _run_local_backend(
     model_providers: list[ModelProvider],
     expected_columns: list[str],
 ) -> dict[str, Any]:
-    _seed_everything(seed)
-    with _async_engine_env(enabled=use_async):
-        designer = DataDesigner(
-            artifact_path=artifact_path,
-            managed_assets_path=managed_assets_path,
-            model_providers=model_providers,
-        )
-        designer.set_run_config(_run_config(batch_size))
-        resource_provider = designer._create_resource_provider("mock-benchmark", config_builder)
-        builder = designer._create_dataset_builder(config_builder.build(), resource_provider, use_async=use_async)
-
-        start = time.perf_counter()
-        raw_output = builder.build_preview(num_records=num_records)
-        output = builder.process_preview(raw_output)
-        elapsed_seconds = time.perf_counter() - start
-        metrics = {
-            "total_rows": len(output),
-            "blocks": math.ceil(num_records / batch_size),
-            "failed_blocks": 0,
-            "elapsed_seconds": elapsed_seconds,
-            "model_usage": resource_provider.model_registry.get_model_usage_stats(elapsed_seconds) or None,
-        }
-    return _result_payload(
+    return benchmark_common.run_local_preview_benchmark(
         backend=backend,
+        dataset_name="mock-benchmark",
+        use_async=use_async,
         iteration=iteration,
         seed=seed,
-        output=output,
-        elapsed_seconds=elapsed_seconds,
-        metrics=metrics,
-        artifact_path=artifact_path,
-        output_mode="pandas",
+        config_builder=config_builder,
+        num_records=num_records,
         batch_size=batch_size,
         max_parallel_requests=max_parallel_requests,
+        artifact_path=artifact_path,
+        managed_assets_path=managed_assets_path,
+        model_providers=model_providers,
         expected_columns=expected_columns,
-        expected_rows=num_records,
+        manage_async_engine_env=True,
+        seed_python_random=True,
     )
 
 
@@ -621,176 +560,25 @@ def _run_ray_backend(
     expected_columns: list[str],
     sandbox_safe_ray_init: bool,
 ) -> dict[str, Any]:
-    _seed_everything(seed)
-    os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
-    ray = __import__("ray")
-    if sandbox_safe_ray_init:
-        _patch_ray_sandbox_process_discovery()
-    ray.init(address="local", num_cpus=ray_cpus, ignore_reinit_error=True, include_dashboard=False)
-    try:
-        designer = DataDesigner(
-            artifact_path=artifact_path,
-            managed_assets_path=managed_assets_path,
-            model_providers=model_providers,
-            backend=RayBackend(batch_size=batch_size, output=ray_output),
-        )
-        designer.set_run_config(_run_config(batch_size))
-        start = time.perf_counter()
-        results = designer.create(config_builder, num_records=num_records)
-        output = results.load_dataset().to_pandas()
-        metrics = results.load_metrics().to_dict()
-        elapsed_seconds = time.perf_counter() - start
-        payload = _result_payload(
-            backend=backend,
-            iteration=iteration,
-            seed=seed,
-            output=output,
-            elapsed_seconds=elapsed_seconds,
-            metrics=metrics,
-            artifact_path=artifact_path,
-            output_mode=ray_output,
-            batch_size=batch_size,
-            max_parallel_requests=max_parallel_requests,
-            expected_columns=expected_columns,
-            expected_rows=num_records,
-        )
-        if ray_output == "arrow_refs":
-            payload["arrow_ref_count"] = len(results.output)
-        return payload
-    finally:
-        ray.shutdown()
-
-
-def _run_config(batch_size: int) -> RunConfig:
-    return RunConfig(
-        buffer_size=batch_size,
-        disable_early_shutdown=True,
-        max_conversation_restarts=0,
-        max_conversation_correction_steps=0,
+    return benchmark_common.run_ray_backend_benchmark(
+        backend=backend,
+        ray_output=ray_output,
+        iteration=iteration,
+        seed=seed,
+        config_builder=config_builder,
+        num_records=num_records,
+        batch_size=batch_size,
+        max_parallel_requests=max_parallel_requests,
+        ray_cpus=ray_cpus,
+        artifact_path=artifact_path,
+        managed_assets_path=managed_assets_path,
+        model_providers=model_providers,
+        expected_columns=expected_columns,
+        sandbox_safe_ray_init=sandbox_safe_ray_init,
+        ray_address="local",
+        set_uv_runtime_env=True,
+        seed_python_random=True,
     )
-
-
-def _seed_everything(seed: int) -> None:
-    lazy.np.random.seed(seed)
-    random.seed(seed)
-
-
-def _result_payload(
-    *,
-    backend: BackendName,
-    iteration: int,
-    seed: int,
-    output: Any,
-    elapsed_seconds: float,
-    metrics: dict[str, Any] | None,
-    artifact_path: Path,
-    output_mode: str,
-    batch_size: int,
-    max_parallel_requests: int,
-    expected_columns: list[str],
-    expected_rows: int,
-) -> dict[str, Any]:
-    rows = len(output)
-    null_counts = {str(key): int(value) for key, value in output.isna().sum().to_dict().items()}
-    empty_string_counts = _empty_string_counts(output)
-    missing_columns = [column for column in expected_columns if column not in output.columns]
-    expected_null_counts = {column: null_counts.get(column, rows) for column in expected_columns}
-    validity = {
-        "row_count_matches": rows == expected_rows,
-        "expected_columns_present": not missing_columns,
-        "expected_columns_non_null": all(count == 0 for count in expected_null_counts.values()),
-        "all_output_valid": rows == expected_rows
-        and not missing_columns
-        and all(count == 0 for count in expected_null_counts.values()),
-    }
-    throughput = _throughput_payload(metrics=metrics, elapsed_seconds=elapsed_seconds, rows=rows)
-    return {
-        "backend": backend,
-        "iteration": iteration,
-        "seed": seed,
-        "elapsed_seconds": elapsed_seconds,
-        "rows": rows,
-        "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
-        "columns": list(output.columns),
-        "missing_columns": missing_columns,
-        "null_counts": null_counts,
-        "empty_string_counts": empty_string_counts,
-        "validity": validity,
-        "throughput": throughput,
-        "metrics": metrics,
-        "artifact_path": str(artifact_path),
-        "output_mode": output_mode,
-        "batch_size": batch_size,
-        "max_parallel_requests": max_parallel_requests,
-    }
-
-
-def _failure_payload(
-    *,
-    backend: BackendName,
-    iteration: int,
-    seed: int,
-    elapsed_seconds: float,
-    exc: Exception,
-    batch_size: int,
-    max_parallel_requests: int,
-    expected_columns: list[str],
-) -> dict[str, Any]:
-    return {
-        "backend": backend,
-        "iteration": iteration,
-        "seed": seed,
-        "status": "failed",
-        "error_type": type(exc).__name__,
-        "error": str(exc),
-        "elapsed_seconds": elapsed_seconds,
-        "rows": 0,
-        "rows_per_second": 0,
-        "columns": [],
-        "missing_columns": expected_columns,
-        "null_counts": {},
-        "empty_string_counts": {},
-        "validity": {
-            "row_count_matches": False,
-            "expected_columns_present": False,
-            "expected_columns_non_null": False,
-            "all_output_valid": False,
-        },
-        "throughput": _throughput_payload(metrics=None, elapsed_seconds=elapsed_seconds, rows=0),
-        "metrics": None,
-        "artifact_path": "",
-        "output_mode": "",
-        "batch_size": batch_size,
-        "max_parallel_requests": max_parallel_requests,
-    }
-
-
-def _empty_string_counts(output: Any) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for column in output.columns:
-        series = output[column]
-        if getattr(series.dtype, "kind", None) in {"O", "U", "S"}:
-            counts[str(column)] = int(series.fillna("").astype(str).eq("").sum())
-    return counts
-
-
-def _throughput_payload(*, metrics: dict[str, Any] | None, elapsed_seconds: float, rows: int) -> dict[str, Any]:
-    model_usage = (metrics or {}).get("model_usage") or {}
-    request_counts = _sum_nested_usage(model_usage, "request_usage")
-    token_counts = _sum_nested_usage(model_usage, "token_usage")
-    total_requests = int(request_counts.get("total_requests", 0))
-    total_tokens = int(token_counts.get("total_tokens", 0))
-    return {
-        "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
-        "requests_per_minute": total_requests / elapsed_seconds * 60 if elapsed_seconds > 0 else 0,
-        "tokens_per_second": total_tokens / elapsed_seconds if elapsed_seconds > 0 else 0,
-        "successful_requests": int(request_counts.get("successful_requests", 0)),
-        "failed_requests": int(request_counts.get("failed_requests", 0)),
-        "total_requests": total_requests,
-        "input_tokens": int(token_counts.get("input_tokens", 0)),
-        "output_tokens": int(token_counts.get("output_tokens", 0)),
-        "total_tokens": total_tokens,
-    }
 
 
 def _mock_service_payload(snapshot: dict[str, Any], *, elapsed_seconds: float) -> dict[str, Any]:
@@ -803,91 +591,23 @@ def _mock_service_payload(snapshot: dict[str, Any], *, elapsed_seconds: float) -
     }
 
 
-def _sum_nested_usage(model_usage: dict[str, Any], usage_key: str) -> dict[str, int | float]:
-    totals: dict[str, int | float] = {}
-    for stats in model_usage.values():
-        usage = stats.get(usage_key) if isinstance(stats, dict) else None
-        if not isinstance(usage, dict):
-            continue
-        for key, value in usage.items():
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                continue
-            totals[key] = totals.get(key, 0) + value
-    return totals
-
-
 def _build_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
-    per_backend: dict[str, dict[str, Any]] = {}
-    for backend in ALL_BACKENDS:
-        backend_results = [result for result in results if result["backend"] == backend]
-        if not backend_results:
-            continue
-        per_backend[backend] = {
-            "iterations": len(backend_results),
-            "elapsed_seconds": _compute_stats(
-                [float(result["elapsed_seconds"]) for result in backend_results]
-            ).to_dict(),
-            "rows_per_second": _compute_stats(
-                [float(result["rows_per_second"]) for result in backend_results]
-            ).to_dict(),
-            "tokens_per_second": _compute_stats(
-                [float(result["throughput"]["tokens_per_second"]) for result in backend_results]
-            ).to_dict(),
-            "effective_service_concurrency": _compute_stats(
-                [float(result["mock_service"]["effective_service_concurrency"]) for result in backend_results]
-            ).to_dict(),
-            "max_in_flight": max(int(result["mock_service"]["max_in_flight"]) for result in backend_results),
-            "failed_requests": sum(int(result["throughput"]["failed_requests"]) for result in backend_results),
-            "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in backend_results),
-            "failed": any(result.get("status") == "failed" for result in backend_results),
-        }
-
-    comparisons = _speedup_comparisons(results, baseline_backend="local-sync")
-    return {
-        "per_backend": per_backend,
-        "comparisons_vs_local_sync": comparisons,
-        "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in results),
-        "failed_backends": [
-            result["backend"]
-            for result in results
-            if result.get("status") == "failed" or not result["validity"]["all_output_valid"]
-        ],
-    }
-
-
-def _speedup_comparisons(results: list[dict[str, Any]], *, baseline_backend: BackendName) -> dict[str, Any]:
-    by_iteration_backend = {(result["iteration"], result["backend"]): result for result in results}
-    comparisons: dict[str, Any] = {}
-    for backend in ALL_BACKENDS:
-        if backend == baseline_backend:
-            continue
-        speedups = []
-        for result in results:
-            if result["backend"] != backend:
-                continue
-            baseline = by_iteration_backend.get((result["iteration"], baseline_backend))
-            if baseline is None:
-                continue
-            elapsed = float(result["elapsed_seconds"])
-            if elapsed > 0:
-                speedups.append(float(baseline["elapsed_seconds"]) / elapsed)
-        if speedups:
-            comparisons[backend] = _compute_stats(speedups).to_dict()
-    return comparisons
-
-
-def _compute_stats(values: list[float]) -> MetricStats:
-    if not values:
-        return MetricStats(mean=0.0, stdev=0.0, minimum=0.0, maximum=0.0, n=0)
-    if len(values) == 1:
-        return MetricStats(mean=values[0], stdev=0.0, minimum=values[0], maximum=values[0], n=1)
-    return MetricStats(
-        mean=statistics.mean(values),
-        stdev=statistics.stdev(values),
-        minimum=min(values),
-        maximum=max(values),
-        n=len(values),
+    return benchmark_common.build_summary(
+        results,
+        all_backends=ALL_BACKENDS,
+        include_requests_per_minute=False,
+        extra_backend_stats=_mock_backend_stats,
     )
+
+
+def _mock_backend_stats(backend_results: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "effective_service_concurrency": benchmark_common.compute_stats(
+            [float(result["mock_service"]["effective_service_concurrency"]) for result in backend_results]
+        ).to_dict(),
+        "max_in_flight": max(int(result["mock_service"]["max_in_flight"]) for result in backend_results),
+        "failed": any(result.get("status") == "failed" for result in backend_results),
+    }
 
 
 def _handler_for_service(service: MockTokenProviderService) -> type[BaseHTTPRequestHandler]:
@@ -919,7 +639,7 @@ def _handler_for_service(service: MockTokenProviderService) -> type[BaseHTTPRequ
             del format, args
 
         def _write_json(self, status_code: int, payload: dict[str, Any]) -> None:
-            body = json.dumps(payload, sort_keys=True, default=_json_default).encode("utf-8")
+            body = json.dumps(payload, sort_keys=True, default=benchmark_common.json_default).encode("utf-8")
             self.send_response(status_code)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
@@ -930,7 +650,7 @@ def _handler_for_service(service: MockTokenProviderService) -> type[BaseHTTPRequ
 
 
 def _stable_request_hash(seed: int, payload: dict[str, Any]) -> int:
-    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=_json_default)
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=benchmark_common.json_default)
     digest = hashlib.sha256(f"{seed}:{serialized}".encode("utf-8")).hexdigest()
     return int(digest[:16], 16)
 
@@ -972,19 +692,6 @@ def _free_port() -> int:
 
 
 @contextlib.contextmanager
-def _async_engine_env(*, enabled: bool) -> Iterator[None]:
-    previous_value = os.environ.get("DATA_DESIGNER_ASYNC_ENGINE")
-    os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1" if enabled else "0"
-    try:
-        yield
-    finally:
-        if previous_value is None:
-            os.environ.pop("DATA_DESIGNER_ASYNC_ENGINE", None)
-        else:
-            os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = previous_value
-
-
-@contextlib.contextmanager
 def _timeout_after(seconds: float, label: str) -> Iterator[None]:
     if seconds <= 0 or not hasattr(signal, "SIGALRM"):
         yield
@@ -1006,30 +713,8 @@ def _timeout_after(seconds: float, label: str) -> Iterator[None]:
             signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
 
 
-def _patch_ray_sandbox_process_discovery() -> None:
-    import ray._private.node
-
-    def _sandbox_safe_system_processes(self: object) -> str:
-        all_processes = getattr(self, "all_processes", {})
-        pids: list[str] = []
-        for processes in all_processes.values():
-            if processes:
-                pids.append(str(processes[0].process.pid))
-        return ",".join(pids)
-
-    ray._private.node.Node._get_system_processes_for_resource_isolation = _sandbox_safe_system_processes
-
-
 def _emit(payload: dict[str, Any]) -> None:
-    print(f"{RESULT_PREFIX}{json.dumps(payload, sort_keys=True, default=_json_default)}", flush=True)
-
-
-def _json_default(value: Any) -> Any:
-    if isinstance(value, lazy.np.generic):
-        return value.item()
-    if isinstance(value, lazy.np.ndarray):
-        return value.tolist()
-    return str(value)
+    benchmark_common.emit_result(RESULT_PREFIX, payload)
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/benchmark_ray_openai.py
+++ b/scripts/benchmarks/benchmark_ray_openai.py
@@ -18,30 +18,20 @@ from __future__ import annotations
 import argparse
 import copy
 import importlib.util
-import json
-import math
 import os
-import statistics
-import time
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
-import data_designer.lazy_heavy_imports as lazy
+import ray_benchmark_common as benchmark_common
+from ray_benchmark_common import ALL_BACKENDS, BackendName, RayOutputMode
+
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.default_model_settings import (
     get_default_providers,
     resolve_seed_default_model_settings,
 )
 from data_designer.config.models import ModelConfig, ModelProvider
-from data_designer.config.run_config import RunConfig
-from data_designer.integrations.ray import RayBackend
-from data_designer.interface.data_designer import DataDesigner
 
-BackendName = Literal["local-sync", "local-async", "ray-dataset", "ray-arrow-refs"]
-RayOutputMode = Literal["dataset", "arrow_refs"]
-
-ALL_BACKENDS: tuple[BackendName, ...] = ("local-sync", "local-async", "ray-dataset", "ray-arrow-refs")
 RESULT_PREFIX = "RAY_OPENAI_BENCHMARK_RESULT="
 LIVE_RUN_ENV = "DATA_DESIGNER_RUN_LIVE_OPENAI_BENCHMARK"
 DEFAULT_RECIPE_PATH = Path("docs/assets/recipes/code_generation/text_to_python.py")
@@ -52,24 +42,6 @@ DEFAULT_RAY_CPUS = 4
 DEFAULT_MODEL_ALIAS = "openai-text"
 DEFAULT_PROVIDER_NAME = "openai"
 DEFAULT_SEED = 11
-
-
-@dataclass(frozen=True)
-class MetricStats:
-    mean: float
-    stdev: float
-    minimum: float
-    maximum: float
-    n: int
-
-    def to_dict(self) -> dict[str, float | int]:
-        return {
-            "mean": self.mean,
-            "stdev": self.stdev,
-            "min": self.minimum,
-            "max": self.maximum,
-            "n": self.n,
-        }
 
 
 def parse_args() -> argparse.Namespace:
@@ -116,7 +88,7 @@ def main() -> None:
     args.managed_assets_path.mkdir(parents=True, exist_ok=True)
 
     resolve_seed_default_model_settings()
-    selected_backends = _parse_backends(args.backends)
+    selected_backends = benchmark_common.parse_backends(args.backends)
     recipe = _load_recipe(args.recipe_path)
     providers = _provider_configs(args.provider_name)
     _require_provider_credentials(providers)
@@ -175,10 +147,8 @@ def main() -> None:
     _emit({"type": "summary", **summary})
     if args.output_json is not None:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
-        args.output_json.write_text(
-            json.dumps({"setup": setup, "results": results, "summary": summary}, indent=2, default=_json_default)
-        )
-    _fail_on_invalid_summary(summary=summary, allow_failures=args.allow_failures)
+        benchmark_common.write_json_report(args.output_json, {"setup": setup, "results": results, "summary": summary})
+    benchmark_common.fail_on_invalid_summary(summary=summary, allow_failures=args.allow_failures)
 
 
 def _validate_args(args: argparse.Namespace) -> None:
@@ -200,24 +170,6 @@ def _require_live_opt_in(*, run_live: bool) -> None:
     raise SystemExit(
         f"This benchmark performs live provider calls. Re-run with --run-live or set {LIVE_RUN_ENV}=1 to opt in."
     )
-
-
-def _parse_backends(value: str) -> list[BackendName]:
-    if value.strip() == "all":
-        return list(ALL_BACKENDS)
-
-    backends: list[BackendName] = []
-    seen: set[str] = set()
-    for raw_backend in value.split(","):
-        backend = raw_backend.strip()
-        if backend not in ALL_BACKENDS:
-            raise ValueError(f"Unsupported backend {backend!r}. Expected one of {', '.join(ALL_BACKENDS)} or all.")
-        if backend not in seen:
-            backends.append(backend)  # type: ignore[arg-type]
-            seen.add(backend)
-    if not backends:
-        raise ValueError("At least one backend must be selected.")
-    return backends
 
 
 def _load_recipe(recipe_path: Path) -> Any:
@@ -386,40 +338,21 @@ def _run_local_backend(
     model_providers: list[ModelProvider],
     expected_columns: list[str],
 ) -> dict[str, Any]:
-    _seed_everything(seed)
-    designer = DataDesigner(
+    return benchmark_common.run_local_preview_benchmark(
+        backend=backend,
+        dataset_name="benchmark",
+        use_async=use_async,
+        iteration=iteration,
+        seed=seed,
+        config_builder=config_builder,
+        num_records=num_records,
+        batch_size=batch_size,
+        max_parallel_requests=max_parallel_requests,
         artifact_path=artifact_path,
         managed_assets_path=managed_assets_path,
         model_providers=model_providers,
-    )
-    designer.set_run_config(_run_config(batch_size))
-    resource_provider = designer._create_resource_provider("benchmark", config_builder)
-    builder = designer._create_dataset_builder(config_builder.build(), resource_provider, use_async=use_async)
-
-    start = time.perf_counter()
-    raw_output = builder.build_preview(num_records=num_records)
-    output = builder.process_preview(raw_output)
-    elapsed_seconds = time.perf_counter() - start
-    metrics = {
-        "total_rows": len(output),
-        "blocks": math.ceil(num_records / batch_size),
-        "failed_blocks": 0,
-        "elapsed_seconds": elapsed_seconds,
-        "model_usage": resource_provider.model_registry.get_model_usage_stats(elapsed_seconds) or None,
-    }
-    return _result_payload(
-        backend=backend,
-        iteration=iteration,
-        seed=seed,
-        output=output,
-        elapsed_seconds=elapsed_seconds,
-        metrics=metrics,
-        artifact_path=artifact_path,
-        output_mode="pandas",
-        batch_size=batch_size,
-        max_parallel_requests=max_parallel_requests,
         expected_columns=expected_columns,
-        expected_rows=num_records,
+        include_retry_throttle=True,
     )
 
 
@@ -439,267 +372,35 @@ def _run_ray_backend(
     model_providers: list[ModelProvider],
     expected_columns: list[str],
 ) -> dict[str, Any]:
-    _seed_everything(seed)
-    ray = __import__("ray")
-    ray.init(num_cpus=ray_cpus, ignore_reinit_error=True, include_dashboard=False)
-    try:
-        designer = DataDesigner(
-            artifact_path=artifact_path,
-            managed_assets_path=managed_assets_path,
-            model_providers=model_providers,
-            backend=RayBackend(batch_size=batch_size, output=ray_output),
-        )
-        designer.set_run_config(_run_config(batch_size))
-        start = time.perf_counter()
-        results = designer.create(config_builder, num_records=num_records)
-        output = results.load_dataset().to_pandas()
-        metrics = results.load_metrics().to_dict()
-        elapsed_seconds = time.perf_counter() - start
-        payload = _result_payload(
-            backend=backend,
-            iteration=iteration,
-            seed=seed,
-            output=output,
-            elapsed_seconds=elapsed_seconds,
-            metrics=metrics,
-            artifact_path=artifact_path,
-            output_mode=ray_output,
-            batch_size=batch_size,
-            max_parallel_requests=max_parallel_requests,
-            expected_columns=expected_columns,
-            expected_rows=num_records,
-        )
-        if ray_output == "arrow_refs":
-            payload["arrow_ref_count"] = len(results.output)
-        return payload
-    finally:
-        ray.shutdown()
-
-
-def _run_config(batch_size: int) -> RunConfig:
-    return RunConfig(
-        buffer_size=batch_size,
-        disable_early_shutdown=True,
-        max_conversation_restarts=0,
-        max_conversation_correction_steps=0,
+    return benchmark_common.run_ray_backend_benchmark(
+        backend=backend,
+        ray_output=ray_output,
+        iteration=iteration,
+        seed=seed,
+        config_builder=config_builder,
+        num_records=num_records,
+        batch_size=batch_size,
+        max_parallel_requests=max_parallel_requests,
+        ray_cpus=ray_cpus,
+        artifact_path=artifact_path,
+        managed_assets_path=managed_assets_path,
+        model_providers=model_providers,
+        expected_columns=expected_columns,
+        include_retry_throttle=True,
     )
-
-
-def _seed_everything(seed: int) -> None:
-    lazy.np.random.seed(seed)
-
-
-def _result_payload(
-    *,
-    backend: BackendName,
-    iteration: int,
-    seed: int,
-    output: Any,
-    elapsed_seconds: float,
-    metrics: dict[str, Any] | None,
-    artifact_path: Path,
-    output_mode: str,
-    batch_size: int,
-    max_parallel_requests: int,
-    expected_columns: list[str],
-    expected_rows: int,
-) -> dict[str, Any]:
-    rows = len(output)
-    null_counts = {str(key): int(value) for key, value in output.isna().sum().to_dict().items()}
-    empty_string_counts = _empty_string_counts(output)
-    missing_columns = [column for column in expected_columns if column not in output.columns]
-    expected_null_counts = {column: null_counts.get(column, rows) for column in expected_columns}
-    validity = {
-        "row_count_matches": rows == expected_rows,
-        "expected_columns_present": not missing_columns,
-        "expected_columns_non_null": all(count == 0 for count in expected_null_counts.values()),
-        "all_output_valid": rows == expected_rows
-        and not missing_columns
-        and all(count == 0 for count in expected_null_counts.values()),
-    }
-    throughput = _throughput_payload(metrics=metrics, elapsed_seconds=elapsed_seconds, rows=rows)
-    return {
-        "backend": backend,
-        "iteration": iteration,
-        "seed": seed,
-        "elapsed_seconds": elapsed_seconds,
-        "rows": rows,
-        "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
-        "columns": list(output.columns),
-        "missing_columns": missing_columns,
-        "null_counts": null_counts,
-        "empty_string_counts": empty_string_counts,
-        "validity": validity,
-        "throughput": throughput,
-        "metrics": metrics,
-        "artifact_path": str(artifact_path),
-        "output_mode": output_mode,
-        "batch_size": batch_size,
-        "max_parallel_requests": max_parallel_requests,
-    }
-
-
-def _empty_string_counts(output: Any) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for column in output.columns:
-        series = output[column]
-        if getattr(series.dtype, "kind", None) in {"O", "U", "S"}:
-            counts[str(column)] = int(series.fillna("").astype(str).eq("").sum())
-    return counts
-
-
-def _throughput_payload(*, metrics: dict[str, Any] | None, elapsed_seconds: float, rows: int) -> dict[str, Any]:
-    model_usage = (metrics or {}).get("model_usage") or {}
-    request_counts = _sum_nested_usage(model_usage, "request_usage")
-    token_counts = _sum_nested_usage(model_usage, "token_usage")
-    total_requests = int(request_counts.get("total_requests", 0))
-    total_tokens = int(token_counts.get("total_tokens", 0))
-    retry_count = _sum_first_available_counter(model_usage, ("retry_count", "retries", "total_retries"))
-    throttle_count = _sum_first_available_counter(
-        model_usage,
-        ("throttle_count", "rate_limited_requests", "throttled_requests"),
-    )
-    return {
-        "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
-        "requests_per_minute": total_requests / elapsed_seconds * 60 if elapsed_seconds > 0 else 0,
-        "tokens_per_second": total_tokens / elapsed_seconds if elapsed_seconds > 0 else 0,
-        "successful_requests": int(request_counts.get("successful_requests", 0)),
-        "failed_requests": int(request_counts.get("failed_requests", 0)),
-        "total_requests": total_requests,
-        "input_tokens": int(token_counts.get("input_tokens", 0)),
-        "output_tokens": int(token_counts.get("output_tokens", 0)),
-        "total_tokens": total_tokens,
-        "retry_count": retry_count if retry_count is not None else 0,
-        "retry_count_available": retry_count is not None,
-        "throttle_count": throttle_count if throttle_count is not None else 0,
-        "throttle_count_available": throttle_count is not None,
-    }
-
-
-def _sum_nested_usage(model_usage: dict[str, Any], usage_key: str) -> dict[str, int | float]:
-    totals: dict[str, int | float] = {}
-    for stats in model_usage.values():
-        usage = stats.get(usage_key) if isinstance(stats, dict) else None
-        if not isinstance(usage, dict):
-            continue
-        for key, value in usage.items():
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                continue
-            totals[key] = totals.get(key, 0) + value
-    return totals
-
-
-def _sum_first_available_counter(model_usage: dict[str, Any], counter_names: tuple[str, ...]) -> int | None:
-    total = 0
-    found = False
-    for stats in model_usage.values():
-        if not isinstance(stats, dict):
-            continue
-        for counter_name in counter_names:
-            value = stats.get(counter_name)
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                continue
-            total += int(value)
-            found = True
-            break
-    return total if found else None
 
 
 def _build_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
-    per_backend: dict[str, dict[str, Any]] = {}
-    for backend in ALL_BACKENDS:
-        backend_results = [result for result in results if result["backend"] == backend]
-        if not backend_results:
-            continue
-        per_backend[backend] = {
-            "iterations": len(backend_results),
-            "elapsed_seconds": _compute_stats(
-                [float(result["elapsed_seconds"]) for result in backend_results]
-            ).to_dict(),
-            "rows_per_second": _compute_stats(
-                [float(result["rows_per_second"]) for result in backend_results]
-            ).to_dict(),
-            "requests_per_minute": _compute_stats(
-                [float(result["throughput"]["requests_per_minute"]) for result in backend_results]
-            ).to_dict(),
-            "tokens_per_second": _compute_stats(
-                [float(result["throughput"]["tokens_per_second"]) for result in backend_results]
-            ).to_dict(),
-            "failed_requests": sum(int(result["throughput"]["failed_requests"]) for result in backend_results),
-            "retry_count": sum(int(result["throughput"]["retry_count"]) for result in backend_results),
-            "throttle_count": sum(int(result["throughput"]["throttle_count"]) for result in backend_results),
-            "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in backend_results),
-        }
-
-    comparisons = _speedup_comparisons(results, baseline_backend="local-sync")
-    return {
-        "per_backend": per_backend,
-        "comparisons_vs_local_sync": comparisons,
-        "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in results),
-        "failed_backends": _failed_backends(results),
-    }
-
-
-def _failed_backends(results: list[dict[str, Any]]) -> list[str]:
-    return [
-        str(result["backend"])
-        for result in results
-        if result.get("status") == "failed" or not bool(result["validity"]["all_output_valid"])
-    ]
-
-
-def _fail_on_invalid_summary(*, summary: dict[str, Any], allow_failures: bool) -> None:
-    if allow_failures:
-        return
-    if summary["failed_backends"] or not summary["all_output_valid"]:
-        raise SystemExit(1)
-
-
-def _speedup_comparisons(results: list[dict[str, Any]], *, baseline_backend: BackendName) -> dict[str, Any]:
-    by_iteration_backend = {(result["iteration"], result["backend"]): result for result in results}
-    comparisons: dict[str, Any] = {}
-    for backend in ALL_BACKENDS:
-        if backend == baseline_backend:
-            continue
-        speedups = []
-        for result in results:
-            if result["backend"] != backend:
-                continue
-            baseline = by_iteration_backend.get((result["iteration"], baseline_backend))
-            if baseline is None:
-                continue
-            elapsed = float(result["elapsed_seconds"])
-            if elapsed > 0:
-                speedups.append(float(baseline["elapsed_seconds"]) / elapsed)
-        if speedups:
-            comparisons[backend] = _compute_stats(speedups).to_dict()
-    return comparisons
-
-
-def _compute_stats(values: list[float]) -> MetricStats:
-    if not values:
-        return MetricStats(mean=0.0, stdev=0.0, minimum=0.0, maximum=0.0, n=0)
-    if len(values) == 1:
-        return MetricStats(mean=values[0], stdev=0.0, minimum=values[0], maximum=values[0], n=1)
-    return MetricStats(
-        mean=statistics.mean(values),
-        stdev=statistics.stdev(values),
-        minimum=min(values),
-        maximum=max(values),
-        n=len(values),
+    return benchmark_common.build_summary(
+        results,
+        all_backends=ALL_BACKENDS,
+        include_requests_per_minute=True,
+        include_retry_throttle=True,
     )
 
 
 def _emit(payload: dict[str, Any]) -> None:
-    print(f"{RESULT_PREFIX}{json.dumps(payload, sort_keys=True, default=_json_default)}", flush=True)
-
-
-def _json_default(value: Any) -> Any:
-    if isinstance(value, lazy.np.generic):
-        return value.item()
-    if isinstance(value, lazy.np.ndarray):
-        return value.tolist()
-    return str(value)
+    benchmark_common.emit_result(RESULT_PREFIX, payload)
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/benchmark_ray_streaming_out_of_core.py
+++ b/scripts/benchmarks/benchmark_ray_streaming_out_of_core.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import platform
 import resource
 import time
 from pathlib import Path
 from typing import Any
+
+import ray_benchmark_common as benchmark_common
 
 import data_designer.config as dd
 import data_designer.lazy_heavy_imports as lazy
@@ -83,20 +84,17 @@ def main() -> None:
     args.artifact_root.mkdir(parents=True, exist_ok=True)
     args.managed_assets_path.mkdir(parents=True, exist_ok=True)
     _reset_output_dir(args.parquet_output)
-    os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
 
-    ray = __import__("ray")
-    if args.sandbox_safe_ray_init:
-        _patch_ray_sandbox_process_discovery()
-    ray.init(address="local", num_cpus=args.ray_cpus, ignore_reinit_error=True, include_dashboard=False)
-    try:
+    with benchmark_common.ray_session(
+        ray_cpus=args.ray_cpus,
+        sandbox_safe_ray_init=args.sandbox_safe_ray_init,
+        ray_address="local",
+        set_uv_runtime_env=True,
+    ) as ray:
         payload = _run_streaming_case(ray, args)
-    finally:
-        ray.shutdown()
 
     if args.output_json is not None:
-        args.output_json.parent.mkdir(parents=True, exist_ok=True)
-        args.output_json.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n")
+        benchmark_common.write_json_report(args.output_json, payload, sort_keys=True, trailing_newline=True)
     _emit(payload)
 
 
@@ -392,22 +390,8 @@ def _validate_args(args: argparse.Namespace) -> None:
             raise ValueError(f"--{field_name.replace('_', '-')} must be >= 1.")
 
 
-def _patch_ray_sandbox_process_discovery() -> None:
-    import ray._private.node
-
-    def _sandbox_safe_system_processes(self: object) -> str:
-        all_processes = getattr(self, "all_processes", {})
-        pids: list[str] = []
-        for processes in all_processes.values():
-            if processes:
-                pids.append(str(processes[0].process.pid))
-        return ",".join(pids)
-
-    ray._private.node.Node._get_system_processes_for_resource_isolation = _sandbox_safe_system_processes
-
-
 def _emit(payload: dict[str, Any]) -> None:
-    print(f"{RESULT_PREFIX}{json.dumps(payload, sort_keys=True, default=str)}", flush=True)
+    benchmark_common.emit_result(RESULT_PREFIX, payload)
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/ray_benchmark_common.py
+++ b/scripts/benchmarks/ray_benchmark_common.py
@@ -1,0 +1,570 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for Ray benchmark scripts.
+
+The local sync/async benchmark baselines intentionally use DataDesigner private
+builder construction methods so they can time the same compiled config path
+without the public facade's result packaging. Keep that benchmark-only coupling
+centralized here; individual ``benchmark_ray_*.py`` scripts should call these
+helpers instead of private ``DataDesigner`` methods directly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import math
+import os
+import random
+import statistics
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.models import ModelProvider
+from data_designer.config.run_config import RunConfig
+from data_designer.integrations.ray import RayBackend
+from data_designer.interface.data_designer import DataDesigner
+
+BackendName = Literal["local-sync", "local-async", "ray-dataset", "ray-arrow-refs"]
+RayOutputMode = Literal["dataset", "arrow_refs"]
+SummaryExtrasBuilder = Callable[[list[dict[str, Any]]], dict[str, Any]]
+
+ALL_BACKENDS: tuple[BackendName, ...] = ("local-sync", "local-async", "ray-dataset", "ray-arrow-refs")
+
+
+@dataclass(frozen=True)
+class MetricStats:
+    mean: float
+    stdev: float
+    minimum: float
+    maximum: float
+    n: int
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "mean": self.mean,
+            "stdev": self.stdev,
+            "min": self.minimum,
+            "max": self.maximum,
+            "n": self.n,
+        }
+
+
+def parse_backends(value: str, *, all_backends: tuple[BackendName, ...] = ALL_BACKENDS) -> list[BackendName]:
+    if value.strip() == "all":
+        return list(all_backends)
+
+    backends: list[BackendName] = []
+    seen: set[str] = set()
+    for raw_backend in value.split(","):
+        backend = raw_backend.strip()
+        if backend not in all_backends:
+            raise ValueError(f"Unsupported backend {backend!r}. Expected one of {', '.join(all_backends)} or all.")
+        if backend not in seen:
+            backends.append(backend)  # type: ignore[arg-type]
+            seen.add(backend)
+    if not backends:
+        raise ValueError("At least one backend must be selected.")
+    return backends
+
+
+def run_local_preview_benchmark(
+    *,
+    backend: BackendName,
+    dataset_name: str,
+    use_async: bool,
+    iteration: int,
+    seed: int,
+    config_builder: DataDesignerConfigBuilder,
+    num_records: int,
+    batch_size: int,
+    max_parallel_requests: int,
+    artifact_path: Path,
+    managed_assets_path: Path,
+    model_providers: list[ModelProvider],
+    expected_columns: list[str],
+    manage_async_engine_env: bool = False,
+    seed_python_random: bool = False,
+    include_retry_throttle: bool = False,
+) -> dict[str, Any]:
+    seed_everything(seed, seed_python_random=seed_python_random)
+    context = async_engine_env(enabled=use_async) if manage_async_engine_env else contextlib.nullcontext()
+    with context:
+        designer = DataDesigner(
+            artifact_path=artifact_path,
+            managed_assets_path=managed_assets_path,
+            model_providers=model_providers,
+        )
+        designer.set_run_config(run_config(batch_size))
+
+        resource_provider = designer._create_resource_provider(dataset_name, config_builder)
+        builder = designer._create_dataset_builder(config_builder.build(), resource_provider, use_async=use_async)
+
+        start = time.perf_counter()
+        raw_output = builder.build_preview(num_records=num_records)
+        output = builder.process_preview(raw_output)
+        elapsed_seconds = time.perf_counter() - start
+        metrics = {
+            "total_rows": len(output),
+            "blocks": math.ceil(num_records / batch_size),
+            "failed_blocks": 0,
+            "elapsed_seconds": elapsed_seconds,
+            "model_usage": resource_provider.model_registry.get_model_usage_stats(elapsed_seconds) or None,
+        }
+    return result_payload(
+        backend=backend,
+        iteration=iteration,
+        seed=seed,
+        output=output,
+        elapsed_seconds=elapsed_seconds,
+        metrics=metrics,
+        artifact_path=artifact_path,
+        output_mode="pandas",
+        batch_size=batch_size,
+        max_parallel_requests=max_parallel_requests,
+        expected_columns=expected_columns,
+        expected_rows=num_records,
+        include_retry_throttle=include_retry_throttle,
+    )
+
+
+def run_ray_backend_benchmark(
+    *,
+    backend: BackendName,
+    ray_output: RayOutputMode,
+    iteration: int,
+    seed: int,
+    config_builder: DataDesignerConfigBuilder,
+    num_records: int,
+    batch_size: int,
+    max_parallel_requests: int,
+    ray_cpus: int,
+    artifact_path: Path,
+    managed_assets_path: Path,
+    model_providers: list[ModelProvider],
+    expected_columns: list[str],
+    sandbox_safe_ray_init: bool = False,
+    ray_address: str | None = None,
+    set_uv_runtime_env: bool = False,
+    seed_python_random: bool = False,
+    include_retry_throttle: bool = False,
+) -> dict[str, Any]:
+    seed_everything(seed, seed_python_random=seed_python_random)
+    with ray_session(
+        ray_cpus=ray_cpus,
+        sandbox_safe_ray_init=sandbox_safe_ray_init,
+        ray_address=ray_address,
+        set_uv_runtime_env=set_uv_runtime_env,
+    ):
+        designer = DataDesigner(
+            artifact_path=artifact_path,
+            managed_assets_path=managed_assets_path,
+            model_providers=model_providers,
+            backend=RayBackend(batch_size=batch_size, output=ray_output),
+        )
+        designer.set_run_config(run_config(batch_size))
+        start = time.perf_counter()
+        results = designer.create(config_builder, num_records=num_records)
+        output = results.load_dataset().to_pandas()
+        metrics = results.load_metrics().to_dict()
+        elapsed_seconds = time.perf_counter() - start
+        payload = result_payload(
+            backend=backend,
+            iteration=iteration,
+            seed=seed,
+            output=output,
+            elapsed_seconds=elapsed_seconds,
+            metrics=metrics,
+            artifact_path=artifact_path,
+            output_mode=ray_output,
+            batch_size=batch_size,
+            max_parallel_requests=max_parallel_requests,
+            expected_columns=expected_columns,
+            expected_rows=num_records,
+            include_retry_throttle=include_retry_throttle,
+        )
+        if ray_output == "arrow_refs":
+            payload["arrow_ref_count"] = len(results.output)
+        return payload
+
+
+@contextlib.contextmanager
+def ray_session(
+    *,
+    ray_cpus: int,
+    sandbox_safe_ray_init: bool = False,
+    ray_address: str | None = None,
+    set_uv_runtime_env: bool = False,
+) -> Iterator[Any]:
+    if set_uv_runtime_env:
+        os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+    ray = __import__("ray")
+    if sandbox_safe_ray_init:
+        patch_ray_sandbox_process_discovery()
+    init_kwargs: dict[str, Any] = {
+        "num_cpus": ray_cpus,
+        "ignore_reinit_error": True,
+        "include_dashboard": False,
+    }
+    if ray_address is not None:
+        init_kwargs["address"] = ray_address
+    ray.init(**init_kwargs)
+    try:
+        yield ray
+    finally:
+        ray.shutdown()
+
+
+def run_config(batch_size: int) -> RunConfig:
+    return RunConfig(
+        buffer_size=batch_size,
+        disable_early_shutdown=True,
+        max_conversation_restarts=0,
+        max_conversation_correction_steps=0,
+    )
+
+
+def seed_everything(seed: int, *, seed_python_random: bool = False) -> None:
+    lazy.np.random.seed(seed)
+    if seed_python_random:
+        random.seed(seed)
+
+
+def result_payload(
+    *,
+    backend: BackendName,
+    iteration: int,
+    seed: int,
+    output: Any,
+    elapsed_seconds: float,
+    metrics: dict[str, Any] | None,
+    artifact_path: Path,
+    output_mode: str,
+    batch_size: int,
+    max_parallel_requests: int,
+    expected_columns: list[str],
+    expected_rows: int,
+    include_retry_throttle: bool = False,
+) -> dict[str, Any]:
+    rows = len(output)
+    null_counts = {str(key): int(value) for key, value in output.isna().sum().to_dict().items()}
+    empty_string_counts = empty_string_counts_for_output(output)
+    missing_columns = [column for column in expected_columns if column not in output.columns]
+    expected_null_counts = {column: null_counts.get(column, rows) for column in expected_columns}
+    validity = {
+        "row_count_matches": rows == expected_rows,
+        "expected_columns_present": not missing_columns,
+        "expected_columns_non_null": all(count == 0 for count in expected_null_counts.values()),
+        "all_output_valid": rows == expected_rows
+        and not missing_columns
+        and all(count == 0 for count in expected_null_counts.values()),
+    }
+    throughput = throughput_payload(
+        metrics=metrics,
+        elapsed_seconds=elapsed_seconds,
+        rows=rows,
+        include_retry_throttle=include_retry_throttle,
+    )
+    return {
+        "backend": backend,
+        "iteration": iteration,
+        "seed": seed,
+        "elapsed_seconds": elapsed_seconds,
+        "rows": rows,
+        "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
+        "columns": list(output.columns),
+        "missing_columns": missing_columns,
+        "null_counts": null_counts,
+        "empty_string_counts": empty_string_counts,
+        "validity": validity,
+        "throughput": throughput,
+        "metrics": metrics,
+        "artifact_path": str(artifact_path),
+        "output_mode": output_mode,
+        "batch_size": batch_size,
+        "max_parallel_requests": max_parallel_requests,
+    }
+
+
+def failure_payload(
+    *,
+    backend: BackendName,
+    iteration: int,
+    seed: int,
+    elapsed_seconds: float,
+    exc: Exception,
+    batch_size: int,
+    max_parallel_requests: int,
+    expected_columns: list[str],
+    include_retry_throttle: bool = False,
+) -> dict[str, Any]:
+    return {
+        "backend": backend,
+        "iteration": iteration,
+        "seed": seed,
+        "status": "failed",
+        "error_type": type(exc).__name__,
+        "error": str(exc),
+        "elapsed_seconds": elapsed_seconds,
+        "rows": 0,
+        "rows_per_second": 0,
+        "columns": [],
+        "missing_columns": expected_columns,
+        "null_counts": {},
+        "empty_string_counts": {},
+        "validity": {
+            "row_count_matches": False,
+            "expected_columns_present": False,
+            "expected_columns_non_null": False,
+            "all_output_valid": False,
+        },
+        "throughput": throughput_payload(
+            metrics=None,
+            elapsed_seconds=elapsed_seconds,
+            rows=0,
+            include_retry_throttle=include_retry_throttle,
+        ),
+        "metrics": None,
+        "artifact_path": "",
+        "output_mode": "",
+        "batch_size": batch_size,
+        "max_parallel_requests": max_parallel_requests,
+    }
+
+
+def empty_string_counts_for_output(output: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for column in output.columns:
+        series = output[column]
+        if getattr(series.dtype, "kind", None) in {"O", "U", "S"}:
+            counts[str(column)] = int(series.fillna("").astype(str).eq("").sum())
+    return counts
+
+
+def throughput_payload(
+    *,
+    metrics: dict[str, Any] | None,
+    elapsed_seconds: float,
+    rows: int,
+    include_retry_throttle: bool = False,
+) -> dict[str, Any]:
+    model_usage = (metrics or {}).get("model_usage") or {}
+    request_counts = sum_nested_usage(model_usage, "request_usage")
+    token_counts = sum_nested_usage(model_usage, "token_usage")
+    total_requests = int(request_counts.get("total_requests", 0))
+    total_tokens = int(token_counts.get("total_tokens", 0))
+    payload = {
+        "rows_per_second": rows / elapsed_seconds if elapsed_seconds > 0 else 0,
+        "requests_per_minute": total_requests / elapsed_seconds * 60 if elapsed_seconds > 0 else 0,
+        "tokens_per_second": total_tokens / elapsed_seconds if elapsed_seconds > 0 else 0,
+        "successful_requests": int(request_counts.get("successful_requests", 0)),
+        "failed_requests": int(request_counts.get("failed_requests", 0)),
+        "total_requests": total_requests,
+        "input_tokens": int(token_counts.get("input_tokens", 0)),
+        "output_tokens": int(token_counts.get("output_tokens", 0)),
+        "total_tokens": total_tokens,
+    }
+    if include_retry_throttle:
+        retry_count = sum_first_available_counter(model_usage, ("retry_count", "retries", "total_retries"))
+        throttle_count = sum_first_available_counter(
+            model_usage,
+            ("throttle_count", "rate_limited_requests", "throttled_requests"),
+        )
+        payload.update(
+            {
+                "retry_count": retry_count if retry_count is not None else 0,
+                "retry_count_available": retry_count is not None,
+                "throttle_count": throttle_count if throttle_count is not None else 0,
+                "throttle_count_available": throttle_count is not None,
+            }
+        )
+    return payload
+
+
+def sum_nested_usage(model_usage: dict[str, Any], usage_key: str) -> dict[str, int | float]:
+    totals: dict[str, int | float] = {}
+    for stats in model_usage.values():
+        usage = stats.get(usage_key) if isinstance(stats, dict) else None
+        if not isinstance(usage, dict):
+            continue
+        for key, value in usage.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            totals[key] = totals.get(key, 0) + value
+    return totals
+
+
+def sum_first_available_counter(model_usage: dict[str, Any], counter_names: tuple[str, ...]) -> int | None:
+    total = 0
+    found = False
+    for stats in model_usage.values():
+        if not isinstance(stats, dict):
+            continue
+        for counter_name in counter_names:
+            value = stats.get(counter_name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            total += int(value)
+            found = True
+            break
+    return total if found else None
+
+
+def build_summary(
+    results: list[dict[str, Any]],
+    *,
+    all_backends: tuple[BackendName, ...] = ALL_BACKENDS,
+    baseline_backend: BackendName = "local-sync",
+    include_requests_per_minute: bool = True,
+    include_retry_throttle: bool = False,
+    extra_backend_stats: SummaryExtrasBuilder | None = None,
+) -> dict[str, Any]:
+    per_backend: dict[str, dict[str, Any]] = {}
+    for backend in all_backends:
+        backend_results = [result for result in results if result["backend"] == backend]
+        if not backend_results:
+            continue
+        backend_summary = {
+            "iterations": len(backend_results),
+            "elapsed_seconds": compute_stats(
+                [float(result["elapsed_seconds"]) for result in backend_results]
+            ).to_dict(),
+            "rows_per_second": compute_stats(
+                [float(result["rows_per_second"]) for result in backend_results]
+            ).to_dict(),
+            "tokens_per_second": compute_stats(
+                [float(result["throughput"]["tokens_per_second"]) for result in backend_results]
+            ).to_dict(),
+            "failed_requests": sum(int(result["throughput"]["failed_requests"]) for result in backend_results),
+            "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in backend_results),
+        }
+        if include_requests_per_minute:
+            backend_summary["requests_per_minute"] = compute_stats(
+                [float(result["throughput"]["requests_per_minute"]) for result in backend_results]
+            ).to_dict()
+        if include_retry_throttle:
+            backend_summary["retry_count"] = sum(int(result["throughput"]["retry_count"]) for result in backend_results)
+            backend_summary["throttle_count"] = sum(
+                int(result["throughput"]["throttle_count"]) for result in backend_results
+            )
+        if extra_backend_stats is not None:
+            backend_summary.update(extra_backend_stats(backend_results))
+        per_backend[backend] = backend_summary
+
+    comparisons = speedup_comparisons(results, all_backends=all_backends, baseline_backend=baseline_backend)
+    return {
+        "per_backend": per_backend,
+        "comparisons_vs_local_sync": comparisons,
+        "all_output_valid": all(bool(result["validity"]["all_output_valid"]) for result in results),
+        "failed_backends": failed_backends(results),
+    }
+
+
+def failed_backends(results: list[dict[str, Any]]) -> list[str]:
+    return [
+        str(result["backend"])
+        for result in results
+        if result.get("status") == "failed" or not bool(result["validity"]["all_output_valid"])
+    ]
+
+
+def fail_on_invalid_summary(*, summary: dict[str, Any], allow_failures: bool) -> None:
+    if allow_failures:
+        return
+    if summary["failed_backends"] or not summary["all_output_valid"]:
+        raise SystemExit(1)
+
+
+def speedup_comparisons(
+    results: list[dict[str, Any]],
+    *,
+    all_backends: tuple[BackendName, ...] = ALL_BACKENDS,
+    baseline_backend: BackendName,
+) -> dict[str, Any]:
+    by_iteration_backend = {(result["iteration"], result["backend"]): result for result in results}
+    comparisons: dict[str, Any] = {}
+    for backend in all_backends:
+        if backend == baseline_backend:
+            continue
+        speedups = []
+        for result in results:
+            if result["backend"] != backend:
+                continue
+            baseline = by_iteration_backend.get((result["iteration"], baseline_backend))
+            if baseline is None:
+                continue
+            elapsed = float(result["elapsed_seconds"])
+            if elapsed > 0:
+                speedups.append(float(baseline["elapsed_seconds"]) / elapsed)
+        if speedups:
+            comparisons[backend] = compute_stats(speedups).to_dict()
+    return comparisons
+
+
+def compute_stats(values: list[float]) -> MetricStats:
+    if not values:
+        return MetricStats(mean=0.0, stdev=0.0, minimum=0.0, maximum=0.0, n=0)
+    if len(values) == 1:
+        return MetricStats(mean=values[0], stdev=0.0, minimum=values[0], maximum=values[0], n=1)
+    return MetricStats(
+        mean=statistics.mean(values),
+        stdev=statistics.stdev(values),
+        minimum=min(values),
+        maximum=max(values),
+        n=len(values),
+    )
+
+
+def emit_result(prefix: str, payload: dict[str, Any]) -> None:
+    print(f"{prefix}{json.dumps(payload, sort_keys=True, default=json_default)}", flush=True)
+
+
+def write_json_report(
+    path: Path, payload: dict[str, Any], *, sort_keys: bool = False, trailing_newline: bool = False
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(payload, indent=2, sort_keys=sort_keys, default=json_default)
+    if trailing_newline:
+        content += "\n"
+    path.write_text(content)
+
+
+def json_default(value: Any) -> Any:
+    if isinstance(value, lazy.np.generic):
+        return value.item()
+    if isinstance(value, lazy.np.ndarray):
+        return value.tolist()
+    return str(value)
+
+
+@contextlib.contextmanager
+def async_engine_env(*, enabled: bool) -> Iterator[None]:
+    previous_value = os.environ.get("DATA_DESIGNER_ASYNC_ENGINE")
+    os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1" if enabled else "0"
+    try:
+        yield
+    finally:
+        if previous_value is None:
+            os.environ.pop("DATA_DESIGNER_ASYNC_ENGINE", None)
+        else:
+            os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = previous_value
+
+
+def patch_ray_sandbox_process_discovery() -> None:
+    import ray._private.node
+
+    def _sandbox_safe_system_processes(self: object) -> str:
+        all_processes = getattr(self, "all_processes", {})
+        pids: list[str] = []
+        for processes in all_processes.values():
+            if processes:
+                pids.append(str(processes[0].process.pid))
+        return ",".join(pids)
+
+    ray._private.node.Node._get_system_processes_for_resource_isolation = _sandbox_safe_system_processes


### PR DESCRIPTION
## 📋 Summary
Centralizes duplicated Ray benchmark runner, payload, summary, JSON, and Ray startup behavior in a shared benchmark helper. This keeps benchmark-only private DataDesigner builder access in one documented place and adds a guard so individual Ray benchmark scripts do not call those private methods directly.

## 🔗 Related Issue
Fixes #68
Fixes #71
Part of #85

## 🔄 Changes
- Added `scripts/benchmarks/ray_benchmark_common.py` for backend parsing, local/Ray benchmark runners, result and failure payloads, throughput summaries, JSON defaults, async env handling, and Ray sandbox startup helpers.
- Updated OpenAI, mock-provider, and streaming Ray benchmarks to reuse the shared helpers while preserving their existing result prefixes and payload keys.
- Expanded `ray_benchmark` tests to cover the shared helpers, import all Ray benchmark scripts, and statically reject direct private `DataDesigner` builder calls in `benchmark_ray_*.py` scripts.

## 🧪 Testing
- [x] `uv run --all-packages pytest packages/data-designer/tests/integrations/ray -m ray_benchmark`
- [x] `PYTHONPYCACHEPREFIX=/tmp/codex-pycache python3 -m py_compile scripts/benchmarks/ray_benchmark_common.py scripts/benchmarks/benchmark_ray_openai.py scripts/benchmarks/benchmark_ray_mock_provider.py scripts/benchmarks/benchmark_ray_streaming_out_of_core.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py`
- [x] `uv run ruff format --check scripts/benchmarks/ray_benchmark_common.py scripts/benchmarks/benchmark_ray_openai.py scripts/benchmarks/benchmark_ray_mock_provider.py scripts/benchmarks/benchmark_ray_streaming_out_of_core.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py`
- [x] `uv run ruff check scripts/benchmarks/ray_benchmark_common.py scripts/benchmarks/benchmark_ray_openai.py scripts/benchmarks/benchmark_ray_mock_provider.py scripts/benchmarks/benchmark_ray_streaming_out_of_core.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py`
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A — benchmark helper/static guard change)

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — benchmark helper boundary documented in code)