### PR TITLE
feat: add engine block execution API

### DIFF
--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+import os
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterator, Protocol
+
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.data_designer_config import DataDesignerConfig
+from data_designer.config.run_config import RunConfig
+from data_designer.config.seed import SeedConfig
+from data_designer.config.seed_source_dataframe import DataFrameSeedSource
+from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
+from data_designer.engine.dataset_builders.errors import DatasetGenerationError
+from data_designer.engine.errors import DataDesignerError
+from data_designer.engine.model_provider import resolve_model_provider_registry
+from data_designer.engine.models.usage import ModelUsageStats
+from data_designer.engine.resources.person_reader import PersonReader, create_person_reader
+from data_designer.engine.resources.resource_provider import ResourceProvider, create_resource_provider
+from data_designer.engine.resources.seed_reader import SeedReader, SeedReaderRegistry
+from data_designer.engine.secret_resolver import SecretResolver
+from data_designer.engine.storage.artifact_storage import ArtifactStorage
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from data_designer.config.mcp import MCPProviderT
+    from data_designer.config.models import ModelProvider
+    from data_designer.engine.dataset_builders.utils.task_model import TaskTrace
+    from data_designer.engine.models.clients.throttle_manager import ThrottleManagerLike
+
+
+class BlockRuntimeContext(Protocol):
+    """Protocol for backend runtime snapshots accepted by block execution."""
+
+    model_providers: list[ModelProvider]
+    default_provider_name: str
+    secret_resolver: SecretResolver
+    seed_readers: list[SeedReader]
+    managed_assets_path: str | Path
+    person_reader: PersonReader | None
+    mcp_providers: list[MCPProviderT]
+    run_config: RunConfig
+    throttle_manager: ThrottleManagerLike | None
+
+
+@dataclass(frozen=True)
+class DataDesignerBlockRuntimeContext:
+    """Backend-neutral resources needed to construct an engine block runtime."""
+
+    model_providers: list[ModelProvider]
+    default_provider_name: str
+    secret_resolver: SecretResolver
+    seed_readers: list[SeedReader]
+    managed_assets_path: str | Path
+    person_reader: PersonReader | None = None
+    mcp_providers: list[MCPProviderT] = field(default_factory=list)
+    run_config: RunConfig = field(default_factory=RunConfig)
+    throttle_manager: ThrottleManagerLike | None = None
+
+
+@dataclass(frozen=True)
+class BlockExecutionOptions:
+    """Execution options for one backend block."""
+
+    use_async: bool = True
+    dataset_name: str = "dataset-block"
+    current_batch_number: int | None = None
+
+
+@dataclass(frozen=True)
+class BlockExecutionResult:
+    """Result of executing one dataset block."""
+
+    dataframe: pd.DataFrame
+    raw_dataframe: pd.DataFrame
+    task_traces: list[TaskTrace]
+    model_usage_stats: dict[str, dict[str, Any]]
+    model_usage_deltas: dict[str, ModelUsageStats]
+    processor_artifacts: dict[str, pd.DataFrame]
+    input_rows: int
+    output_rows: int
+    dropped_rows: int
+    all_rows_dropped: bool
+    partial_rows_dropped: bool
+    artifact_storage: ArtifactStorage | None = None
+
+
+def execute_dataset_block(
+    *,
+    config_builder: DataDesignerConfigBuilder | None = None,
+    data_designer_config: DataDesignerConfig | None = None,
+    runtime_context: BlockRuntimeContext | None = None,
+    resource_provider: ResourceProvider | None = None,
+    input_frame: pd.DataFrame | None = None,
+    num_records: int | None = None,
+    options: BlockExecutionOptions | None = None,
+    artifact_storage: ArtifactStorage | None = None,
+) -> BlockExecutionResult:
+    """Execute one in-memory dataset block for a backend.
+
+    The API owns block-local seed injection, resource-provider construction, generator
+    execution, post-processing, task traces, and model usage snapshots. Backends may
+    pass either a reusable runtime context or a fully constructed resource provider.
+    """
+    block_options = options or BlockExecutionOptions()
+    block_builder, block_config = _resolve_block_config(
+        config_builder=config_builder,
+        data_designer_config=data_designer_config,
+        input_frame=input_frame,
+    )
+    block_num_records = _resolve_num_records(input_frame=input_frame, num_records=num_records)
+
+    if artifact_storage is not None:
+        return _execute_with_storage(
+            data_designer_config=block_config,
+            config_builder=block_builder,
+            runtime_context=runtime_context,
+            resource_provider=resource_provider,
+            artifact_storage=artifact_storage,
+            num_records=block_num_records,
+            options=block_options,
+            return_storage=True,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="data-designer-block-") as artifact_dir:
+        ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
+        temp_storage = ArtifactStorage(artifact_path=artifact_dir, dataset_name=block_options.dataset_name)
+        return _execute_with_storage(
+            data_designer_config=block_config,
+            config_builder=block_builder,
+            runtime_context=runtime_context,
+            resource_provider=resource_provider,
+            artifact_storage=temp_storage,
+            num_records=block_num_records,
+            options=block_options,
+            return_storage=False,
+        )
+
+
+def _resolve_block_config(
+    *,
+    config_builder: DataDesignerConfigBuilder | None,
+    data_designer_config: DataDesignerConfig | None,
+    input_frame: pd.DataFrame | None,
+) -> tuple[DataDesignerConfigBuilder | None, DataDesignerConfig]:
+    if (config_builder is None) == (data_designer_config is None):
+        raise ValueError("Provide exactly one of config_builder or data_designer_config.")
+
+    if config_builder is not None:
+        block_builder = copy.deepcopy(config_builder)
+        if input_frame is not None:
+            block_builder.with_seed_dataset(DataFrameSeedSource(df=input_frame.copy()))
+        return block_builder, block_builder.build()
+
+    block_config = copy.deepcopy(data_designer_config)
+    if input_frame is not None:
+        block_config.seed_config = SeedConfig(source=DataFrameSeedSource(df=input_frame.copy()))
+    return None, block_config
+
+
+def _resolve_num_records(*, input_frame: pd.DataFrame | None, num_records: int | None) -> int:
+    if input_frame is not None:
+        return len(input_frame)
+    if num_records is None:
+        raise ValueError("num_records is required when input_frame is not provided.")
+    return num_records
+
+
+def _execute_with_storage(
+    *,
+    data_designer_config: DataDesignerConfig,
+    config_builder: DataDesignerConfigBuilder | None,
+    runtime_context: BlockRuntimeContext | None,
+    resource_provider: ResourceProvider | None,
+    artifact_storage: ArtifactStorage,
+    num_records: int,
+    options: BlockExecutionOptions,
+    return_storage: bool,
+) -> BlockExecutionResult:
+    if (runtime_context is None) == (resource_provider is None):
+        raise ValueError("Provide exactly one of runtime_context or resource_provider.")
+
+    start_time = time.perf_counter()
+    try:
+        with _async_engine_environment(options.use_async):
+            block_resource_provider = resource_provider or _create_resource_provider(
+                config_builder=config_builder,
+                data_designer_config=data_designer_config,
+                runtime_context=runtime_context,
+                artifact_storage=artifact_storage,
+            )
+            usage_snapshot = block_resource_provider.model_registry.get_model_usage_snapshot()
+            builder = DatasetBuilder(
+                data_designer_config=data_designer_config,
+                resource_provider=block_resource_provider,
+                use_async=options.use_async,
+            )
+            raw_dataframe, dataframe = builder.build_block(
+                num_records=num_records,
+                current_batch_number=options.current_batch_number,
+            )
+            elapsed = time.perf_counter() - start_time
+            model_usage_stats = block_resource_provider.model_registry.get_model_usage_stats(elapsed)
+            model_usage_deltas = block_resource_provider.model_registry.get_usage_deltas(usage_snapshot)
+            processor_artifacts = _load_processor_artifacts(artifact_storage)
+            output_rows = len(dataframe)
+            dropped_rows = max(num_records - output_rows, 0)
+            return BlockExecutionResult(
+                dataframe=dataframe,
+                raw_dataframe=raw_dataframe,
+                task_traces=builder.task_traces,
+                model_usage_stats=model_usage_stats,
+                model_usage_deltas=model_usage_deltas,
+                processor_artifacts=processor_artifacts,
+                input_rows=num_records,
+                output_rows=output_rows,
+                dropped_rows=dropped_rows,
+                all_rows_dropped=num_records > 0 and output_rows == 0,
+                partial_rows_dropped=0 < output_rows < num_records,
+                artifact_storage=artifact_storage if return_storage else None,
+            )
+    except DataDesignerError:
+        raise
+    except Exception as exc:
+        raise DatasetGenerationError(f"🛑 Failed to execute dataset block: {exc}") from exc
+
+
+def _create_resource_provider(
+    *,
+    config_builder: DataDesignerConfigBuilder | None,
+    data_designer_config: DataDesignerConfig,
+    runtime_context: BlockRuntimeContext | None,
+    artifact_storage: ArtifactStorage,
+) -> ResourceProvider:
+    if runtime_context is None:
+        raise ValueError("runtime_context is required when resource_provider is not provided.")
+
+    seed_source = data_designer_config.seed_config.source if data_designer_config.seed_config is not None else None
+    return create_resource_provider(
+        artifact_storage=artifact_storage,
+        model_configs=data_designer_config.model_configs,
+        secret_resolver=runtime_context.secret_resolver,
+        model_provider_registry=resolve_model_provider_registry(
+            runtime_context.model_providers,
+            runtime_context.default_provider_name,
+        ),
+        seed_reader_registry=SeedReaderRegistry(readers=copy.deepcopy(runtime_context.seed_readers)),
+        person_reader=runtime_context.person_reader or create_person_reader(runtime_context.managed_assets_path),
+        seed_dataset_source=seed_source,
+        run_config=copy.deepcopy(runtime_context.run_config),
+        mcp_providers=runtime_context.mcp_providers,
+        tool_configs=(config_builder.tool_configs if config_builder is not None else data_designer_config.tool_configs),
+        throttle_manager=getattr(runtime_context, "throttle_manager", None),
+    )
+
+
+def _load_processor_artifacts(artifact_storage: ArtifactStorage) -> dict[str, pd.DataFrame]:
+    artifacts: dict[str, pd.DataFrame] = {}
+    for processor_name in artifact_storage.list_processor_names():
+        artifacts[processor_name] = artifact_storage.load_processor_dataset(processor_name)
+    return artifacts
+
+
+@contextmanager
+def _async_engine_environment(enabled: bool) -> Iterator[None]:
+    previous = os.environ.get("DATA_DESIGNER_ASYNC_ENGINE")
+    if enabled:
+        os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("DATA_DESIGNER_ASYNC_ENGINE", None)
+        else:
+            os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = previous

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py
@@ -475,7 +475,18 @@ class DatasetBuilder:
         return scheduler, buffer_manager
 
     def process_preview(self, dataset: pd.DataFrame) -> pd.DataFrame:
-        df = self._processor_runner.run_post_batch(dataset.copy(), current_batch_number=None)
+        return self.process_block(dataset, current_batch_number=None)
+
+    def build_block(
+        self, *, num_records: int, current_batch_number: int | None = None
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Build one in-memory execution block and run block-level processors."""
+        raw_dataset = self.build_preview(num_records=num_records)
+        return raw_dataset, self.process_block(raw_dataset, current_batch_number=current_batch_number)
+
+    def process_block(self, dataset: pd.DataFrame, *, current_batch_number: int | None = None) -> pd.DataFrame:
+        """Run post-batch and after-generation processors for an in-memory block."""
+        df = self._processor_runner.run_post_batch(dataset.copy(), current_batch_number=current_batch_number)
         return self._processor_runner.run_after_generation_on_df(df)
 
     def _has_image_columns(self) -> bool:

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextColumnConfig, SamplerColumnConfig
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.processors import ProcessorType
+from data_designer.config.run_config import RunConfig
+from data_designer.config.sampler_params import SamplerType
+from data_designer.engine.dataset_builders import block_execution as block_execution_module
+from data_designer.engine.dataset_builders.block_execution import (
+    BlockExecutionOptions,
+    DataDesignerBlockRuntimeContext,
+    execute_dataset_block,
+)
+from data_designer.engine.dataset_builders.utils.task_model import TaskTrace
+from data_designer.engine.resources.seed_reader import DataFrameSeedReader
+from data_designer.engine.secret_resolver import PlaintextResolver
+
+
+def _managed_assets_path(tmp_path: Path) -> Path:
+    path = tmp_path / "managed-assets"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _runtime_context(tmp_path: Path, stub_model_providers: Any) -> DataDesignerBlockRuntimeContext:
+    return DataDesignerBlockRuntimeContext(
+        model_providers=list(stub_model_providers),
+        default_provider_name="provider-1",
+        secret_resolver=PlaintextResolver(),
+        seed_readers=[DataFrameSeedReader()],
+        managed_assets_path=_managed_assets_path(tmp_path),
+        run_config=RunConfig(buffer_size=2),
+    )
+
+
+def test_execute_dataset_block_generates_from_scratch_and_applies_drop_processor(
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(
+        SamplerColumnConfig(name="kind", sampler_type=SamplerType.CATEGORY, params={"values": ["A"]})
+    )
+    config_builder.add_column(ExpressionColumnConfig(name="label", expr="{{ kind }}"))
+    config_builder.add_processor(processor_type=ProcessorType.DROP_COLUMNS, name="drop-kind", column_names=["kind"])
+
+    result = execute_dataset_block(
+        config_builder=config_builder,
+        runtime_context=_runtime_context(tmp_path, stub_model_providers),
+        num_records=3,
+        options=BlockExecutionOptions(use_async=False),
+    )
+
+    assert result.input_rows == 3
+    assert result.output_rows == 3
+    assert result.dropped_rows == 0
+    assert result.raw_dataframe.columns.to_list() == ["kind", "label"]
+    assert result.dataframe.to_dict(orient="records") == [{"label": "A"}, {"label": "A"}, {"label": "A"}]
+
+
+def test_execute_dataset_block_uses_input_frame_as_seed(
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="x_label", expr="{{ x }}-{{ label }}"))
+    input_frame = lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]})
+
+    result = execute_dataset_block(
+        config_builder=config_builder,
+        runtime_context=_runtime_context(tmp_path, stub_model_providers),
+        input_frame=input_frame,
+        options=BlockExecutionOptions(use_async=False),
+    )
+
+    assert result.input_rows == 2
+    assert result.output_rows == 2
+    assert result.dataframe.to_dict(orient="records") == [
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+    ]
+    assert input_frame.to_dict(orient="records") == [{"x": 1, "label": "a"}, {"x": 2, "label": "b"}]
+
+
+def test_execute_dataset_block_uses_model_columns(
+    stub_resource_provider: Any, stub_model_configs: Any, stub_model_providers: Any
+) -> None:
+    stub_resource_provider.model_registry.get_model_config.return_value = stub_model_configs[0]
+    stub_resource_provider.model_registry.get_model_provider.return_value = stub_model_providers[0]
+    stub_resource_provider.model_registry.get_model_usage_stats.return_value = {}
+    stub_resource_provider.model_registry.get_usage_deltas.return_value = {}
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(
+        SamplerColumnConfig(name="seed", sampler_type=SamplerType.CATEGORY, params={"values": ["topic"]})
+    )
+    config_builder.add_column(LLMTextColumnConfig(name="text", prompt="{{ seed }}", model_alias="stub-model"))
+
+    result = execute_dataset_block(
+        config_builder=config_builder,
+        resource_provider=stub_resource_provider,
+        num_records=1,
+        options=BlockExecutionOptions(use_async=False),
+    )
+
+    assert result.output_rows == 1
+    assert result.dataframe["text"].to_list() == ["Generated summary text"]
+    stub_resource_provider.model_registry.get_model.assert_called()
+
+
+@pytest.mark.parametrize(
+    ("processed", "expected_dropped", "expected_all", "expected_partial"),
+    [
+        (lazy.pd.DataFrame({"value": []}), 3, True, False),
+        (lazy.pd.DataFrame({"value": [1, 2]}), 1, False, True),
+    ],
+)
+def test_execute_dataset_block_reports_row_outcomes_and_task_traces(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_resource_provider: Any,
+    stub_model_configs: Any,
+    processed: Any,
+    expected_dropped: int,
+    expected_all: bool,
+    expected_partial: bool,
+) -> None:
+    trace = TaskTrace(column="value", row_group=0, row_index=None, task_type="batch", status="ok")
+
+    class StubBuilder:
+        def __init__(self, **_: Any) -> None:
+            self.task_traces = [trace]
+
+        def build_block(self, *, num_records: int, current_batch_number: int | None = None) -> Any:
+            del current_batch_number
+            return lazy.pd.DataFrame({"value": list(range(num_records))}), processed
+
+    stub_resource_provider.model_registry.get_model_usage_stats.return_value = {}
+    stub_resource_provider.model_registry.get_usage_deltas.return_value = {}
+    monkeypatch.setattr(block_execution_module, "DatasetBuilder", StubBuilder)
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="value", expr="1"))
+
+    result = execute_dataset_block(
+        config_builder=config_builder,
+        resource_provider=stub_resource_provider,
+        num_records=3,
+        options=BlockExecutionOptions(use_async=False),
+    )
+
+    assert result.input_rows == 3
+    assert result.output_rows == len(processed)
+    assert result.dropped_rows == expected_dropped
+    assert result.all_rows_dropped is expected_all
+    assert result.partial_rows_dropped is expected_partial
+    assert result.task_traces == [trace]

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -15,8 +15,6 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
 
-from pydantic import PrivateAttr
-
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import CustomColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
@@ -25,10 +23,8 @@ from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy, SeedConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.column_generators.utils.generator_classification import column_type_is_model_generated
-from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
-from data_designer.engine.model_provider import resolve_model_provider_registry
-from data_designer.engine.resources.person_reader import PersonReader, create_person_reader
-from data_designer.engine.resources.resource_provider import create_resource_provider
+from data_designer.engine.dataset_builders.block_execution import BlockExecutionOptions, execute_dataset_block
+from data_designer.engine.resources.person_reader import PersonReader
 from data_designer.engine.resources.seed_reader import (
     DataFrameSeedReader,
     FileSystemSeedReader,
@@ -36,8 +32,7 @@ from data_designer.engine.resources.seed_reader import (
     SeedReaderRegistry,
 )
 from data_designer.engine.secret_resolver import SecretResolver
-from data_designer.engine.storage.artifact_storage import ArtifactStorage, BatchStage
-from data_designer.engine.storage.media_storage import StorageMode
+from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import (
     RayDatasetMetrics,
@@ -990,6 +985,12 @@ def _merge_driver_and_worker_metrics(
 ) -> RayDatasetMetrics:
     return RayDatasetMetrics(
         total_rows=worker_metrics.total_rows,
+        input_rows=worker_metrics.input_rows,
+        output_rows=worker_metrics.output_rows,
+        dropped_rows=worker_metrics.dropped_rows,
+        all_rows_dropped_blocks=worker_metrics.all_rows_dropped_blocks,
+        partial_rows_dropped_blocks=worker_metrics.partial_rows_dropped_blocks,
+        empty_input_blocks=worker_metrics.empty_input_blocks,
         blocks=worker_metrics.blocks,
         failed_blocks=worker_metrics.failed_blocks,
         elapsed_seconds=worker_metrics.elapsed_seconds,
@@ -1016,147 +1017,6 @@ def _clone_seed_reader_for_worker(reader: SeedReader) -> SeedReader:
     return clone
 
 
-class _InMemoryPreviewArtifactStorage(ArtifactStorage):
-    """ArtifactStorage implementation for Ray preview batches.
-
-    Ray workers use ``DatasetBuilder.build_preview()``, which returns the main
-    dataset in memory. Processor preview artifacts may still be written through
-    the storage interface, so this class keeps those frames in memory and avoids
-    per-block temporary filesystem setup.
-    """
-
-    _frames: dict[tuple[str, str, str], Any] = PrivateAttr(default_factory=dict)
-    _metadata: dict[str, Any] = PrivateAttr(default_factory=dict)
-
-    def __init__(self, *, dataset_name: str = "ray-block") -> None:
-        super().__init__(artifact_path=Path.cwd(), dataset_name=dataset_name)
-        self.set_media_storage_mode(StorageMode.DATAFRAME)
-
-    def clear(self) -> None:
-        self._frames.clear()
-        self._metadata.clear()
-
-    def load_dataset(self, batch_stage: BatchStage = BatchStage.FINAL_RESULT) -> Any:
-        frames = [self._copy_dataframe(frame) for _, frame in self._iter_stage_frames(batch_stage)]
-        if not frames:
-            return lazy.pd.DataFrame()
-        return lazy.pd.concat(frames, ignore_index=True)
-
-    def load_processor_dataset(self, processor_name: str) -> Any:
-        frames = [
-            self._copy_dataframe(frame)
-            for (stage, subfolder, parquet_file_name), frame in self._frames.items()
-            if stage == BatchStage.PROCESSORS_OUTPUTS.value
-            and (subfolder == processor_name or (not subfolder and Path(parquet_file_name).stem == processor_name))
-        ]
-        if not frames:
-            return lazy.pd.DataFrame()
-        return lazy.pd.concat(frames, ignore_index=True)
-
-    def list_processor_names(self) -> list[str]:
-        names = {
-            subfolder or Path(parquet_file_name).stem
-            for (stage, subfolder, parquet_file_name) in self._frames
-            if stage == BatchStage.PROCESSORS_OUTPUTS.value
-        }
-        return sorted(names)
-
-    def load_dataset_with_dropped_columns(self) -> Any:
-        dataset = self.load_dataset()
-        dropped = self.load_dataset(BatchStage.DROPPED_COLUMNS)
-        if len(dropped) == 0:
-            return dataset
-        return lazy.pd.concat([dataset, dropped], axis=1)
-
-    def move_partial_result_to_final_file_path(self, batch_number: int) -> Path:
-        partial_file_name = self.create_batch_file_path(batch_number, BatchStage.PARTIAL_RESULT).name
-        partial_key = (BatchStage.PARTIAL_RESULT.value, "", partial_file_name)
-        final_key = (BatchStage.FINAL_RESULT.value, "", partial_file_name)
-        frame = self._frames.pop(partial_key)
-        self._frames[final_key] = frame
-        return self.create_batch_file_path(batch_number, BatchStage.FINAL_RESULT)
-
-    def write_batch_to_parquet_file(
-        self,
-        batch_number: int,
-        dataframe: Any,
-        batch_stage: BatchStage,
-        subfolder: str | None = None,
-    ) -> Path:
-        file_path = self.create_batch_file_path(batch_number, batch_stage)
-        self.write_parquet_file(file_path.name, dataframe, batch_stage, subfolder=subfolder)
-        return file_path
-
-    def write_parquet_file(
-        self,
-        parquet_file_name: str,
-        dataframe: Any,
-        batch_stage: BatchStage,
-        subfolder: str | None = None,
-    ) -> Path:
-        subfolder = subfolder or ""
-        stage = self._stage_value(batch_stage)
-        self._frames[(stage, subfolder, parquet_file_name)] = self._copy_dataframe(dataframe)
-        stage_path = self._get_stage_path(batch_stage)
-        return stage_path / subfolder / parquet_file_name if subfolder else stage_path / parquet_file_name
-
-    def get_parquet_file_paths(self) -> list[str]:
-        return [
-            str(Path(self.final_dataset_folder_name) / parquet_file_name)
-            for (stage, _, parquet_file_name) in sorted(self._frames)
-            if stage == BatchStage.FINAL_RESULT.value
-        ]
-
-    def get_processor_file_paths(self) -> dict[str, list[str]]:
-        processor_files: dict[str, list[str]] = {}
-        for stage, subfolder, parquet_file_name in sorted(self._frames):
-            if stage != BatchStage.PROCESSORS_OUTPUTS.value:
-                continue
-            processor_name = subfolder or Path(parquet_file_name).stem
-            path_parts = [self.processors_outputs_folder_name]
-            if subfolder:
-                path_parts.append(subfolder)
-            path_parts.append(parquet_file_name)
-            processor_files.setdefault(processor_name, []).append(str(Path(*path_parts)))
-        return processor_files
-
-    def get_file_paths(self) -> dict[str, list[str] | dict[str, list[str]]]:
-        file_paths: dict[str, list[str] | dict[str, list[str]]] = {
-            "parquet-files": self.get_parquet_file_paths(),
-        }
-        processor_file_paths = self.get_processor_file_paths()
-        if processor_file_paths:
-            file_paths["processor-files"] = processor_file_paths
-        return file_paths
-
-    def read_metadata(self) -> dict[str, Any]:
-        return dict(self._metadata)
-
-    def write_metadata(self, metadata: dict[str, Any]) -> Path:
-        self._metadata = dict(metadata)
-        return self.metadata_file_path
-
-    def update_metadata(self, updates: dict[str, Any]) -> Path:
-        self._metadata.update(updates)
-        return self.metadata_file_path
-
-    def _iter_stage_frames(self, batch_stage: BatchStage) -> list[tuple[tuple[str, str, str], Any]]:
-        stage = self._stage_value(batch_stage)
-        return sorted((key, frame) for key, frame in self._frames.items() if key[0] == stage)
-
-    def _stage_value(self, batch_stage: BatchStage) -> str:
-        return BatchStage(batch_stage).value
-
-    def _copy_dataframe(self, dataframe: Any) -> Any:
-        copy_method = getattr(dataframe, "copy", None)
-        if not callable(copy_method):
-            return dataframe
-        try:
-            return copy_method(deep=True)
-        except TypeError:
-            return copy_method()
-
-
 class _RayBatchWorker:
     def __init__(
         self,
@@ -1170,42 +1030,26 @@ class _RayBatchWorker:
         self._metrics_collector: Any | None = metrics_collector
         self._observability_options: _RayObservabilityOptions = observability_options or _RayObservabilityOptions()
         self._base_config: DataDesignerConfig = DataDesignerConfig.model_validate_json(execution_payload.config_json)
-        self._artifact_storage: _InMemoryPreviewArtifactStorage = _InMemoryPreviewArtifactStorage()
         worker_options = execution_payload.worker_options
         run_config = copy.deepcopy(worker_options.run_config)
         if self._observability_options.trace_enabled:
             run_config.async_trace = True
-        self._seed_reader_registry: SeedReaderRegistry = SeedReaderRegistry(
-            readers=copy.deepcopy(worker_options.seed_readers)
-        )
+        seed_readers = copy.deepcopy(worker_options.seed_readers)
         dataframe_seed_reader = DataFrameSeedReader()
-        if (
-            execution_payload.use_input_dataset
-            and dataframe_seed_reader.get_seed_type() not in self._seed_reader_registry._readers
-        ):
-            self._seed_reader_registry.add_reader(dataframe_seed_reader)
-        self._resource_provider: Any = create_resource_provider(
-            artifact_storage=self._artifact_storage,
-            model_configs=self._base_config.model_configs or [],
-            secret_resolver=worker_options.secret_resolver,
-            model_provider_registry=resolve_model_provider_registry(
-                worker_options.model_providers,
-                worker_options.default_provider_name,
-            ),
-            seed_reader_registry=self._seed_reader_registry,
-            person_reader=worker_options.person_reader or create_person_reader(worker_options.managed_assets_path),
-            seed_dataset_source=None,
+        seed_types = {reader.get_seed_type() for reader in seed_readers}
+        if execution_payload.use_input_dataset and dataframe_seed_reader.get_seed_type() not in seed_types:
+            seed_readers.append(dataframe_seed_reader)
+        self._worker_options: _RayWorkerOptions = replace(
+            worker_options,
+            seed_readers=seed_readers,
             run_config=run_config,
-            mcp_providers=worker_options.mcp_providers,
-            tool_configs=self._base_config.tool_configs or [],
-            throttle_manager=worker_options.throttle_manager,
         )
 
     def __call__(self, batch: Any) -> Any:
         return _generate_batch(batch, worker=self, metrics_collector=self._metrics_collector)
 
     def close(self) -> None:
-        self._release_block_state()
+        return None
 
     def generate_batch(self, batch: Any) -> Any:
         start_time = time.perf_counter()
@@ -1246,7 +1090,15 @@ class _RayBatchWorker:
                 )
             _record_worker_metrics(
                 self._metrics_collector,
-                RayWorkerMetrics(total_rows=0, blocks=1, elapsed_seconds=elapsed_seconds, block_id=block_id),
+                RayWorkerMetrics(
+                    total_rows=0,
+                    input_rows=0,
+                    output_rows=0,
+                    empty_input=True,
+                    blocks=1,
+                    elapsed_seconds=elapsed_seconds,
+                    block_id=block_id,
+                ),
             )
             _record_worker_observability(
                 self._metrics_collector,
@@ -1256,19 +1108,14 @@ class _RayBatchWorker:
             )
             return dataframe
 
+        failure_metrics_recorded = False
         try:
             order_values = _get_hidden_order_values(
                 dataframe,
                 hidden_order_column=self._execution_payload.hidden_order_column,
             )
             block_config = self._create_block_config(dataframe)
-            self._attach_seed_reader(block_config)
-            model_usage_snapshot = self._resource_provider.model_registry.get_model_usage_snapshot()
-            builder = DatasetBuilder(
-                data_designer_config=block_config,
-                resource_provider=self._resource_provider,
-                use_async=True,
-            )
+            input_frame = _strip_internal_columns(dataframe) if self._execution_payload.use_input_dataset else None
             if observability_options.trace_enabled:
                 trace_events.append(
                     _create_trace_event(
@@ -1279,20 +1126,69 @@ class _RayBatchWorker:
                         worker_context=worker_context,
                     )
                 )
-            raw_dataset = builder.build_preview(num_records=num_records)
-            output = builder.process_preview(raw_dataset)
+            block_result = execute_dataset_block(
+                data_designer_config=block_config,
+                runtime_context=self._worker_options,
+                input_frame=input_frame,
+                num_records=num_records,
+                options=BlockExecutionOptions(use_async=True, dataset_name="ray-block"),
+            )
+            output = block_result.dataframe
+            elapsed_seconds = time.perf_counter() - start_time
+            model_usage = block_result.model_usage_stats or None
+            if block_result.all_rows_dropped:
+                if observability_options.trace_enabled:
+                    trace_events.append(
+                        _create_trace_event(
+                            block_id,
+                            "block_failed",
+                            start_time,
+                            row_count=num_records,
+                            worker_context=worker_context,
+                            details={
+                                "error_type": "AllRowsDropped",
+                                "error": "all input rows were dropped",
+                                "input_rows": block_result.input_rows,
+                                "output_rows": block_result.output_rows,
+                                "dropped_rows": block_result.dropped_rows,
+                            },
+                        )
+                    )
+                _record_worker_metrics(
+                    self._metrics_collector,
+                    _metrics_from_block_result(
+                        block_result,
+                        elapsed_seconds=elapsed_seconds,
+                        block_id=block_id,
+                        failed_blocks=1,
+                    ),
+                )
+                _record_worker_observability(
+                    self._metrics_collector,
+                    worker_profile=None,
+                    trace_events=trace_events,
+                    throttle_snapshots=[],
+                )
+                failure_metrics_recorded = True
+                raise RayDatasetGenerationError(
+                    _format_worker_failure_message(
+                        dataframe=dataframe,
+                        exc=RuntimeError(
+                            "all input rows were dropped during block execution "
+                            f"(input_rows={block_result.input_rows}, output_rows=0)"
+                        ),
+                    )
+                )
             if self._execution_payload.hidden_order_column is not None:
                 output = _append_hidden_order_column(
                     output,
                     order_values=order_values,
                     hidden_order_column=self._execution_payload.hidden_order_column,
                 )
-            elapsed_seconds = time.perf_counter() - start_time
-            model_usage = self._get_model_usage_delta(model_usage_snapshot, elapsed_seconds)
             if observability_options.trace_enabled:
                 trace_events.extend(
                     _task_traces_to_events(
-                        builder.task_traces,
+                        block_result.task_traces,
                         block_id=block_id,
                         worker_context=worker_context,
                     )
@@ -1304,17 +1200,20 @@ class _RayBatchWorker:
                         start_time,
                         row_count=len(output),
                         worker_context=worker_context,
-                        details={"output_columns": [str(column) for column in output.columns]},
+                        details={
+                            "output_columns": [str(column) for column in output.columns],
+                            "input_rows": block_result.input_rows,
+                            "output_rows": block_result.output_rows,
+                            "dropped_rows": block_result.dropped_rows,
+                        },
                     )
                 )
-            throttle_snapshots = _snapshot_worker_throttle(self._resource_provider.model_registry.throttle_manager)
+            throttle_snapshots = _snapshot_worker_throttle(self._worker_options.throttle_manager)
             _record_worker_metrics(
                 self._metrics_collector,
-                RayWorkerMetrics(
-                    total_rows=len(output),
-                    blocks=1,
+                _metrics_from_block_result(
+                    block_result,
                     elapsed_seconds=elapsed_seconds,
-                    model_usage=model_usage,
                     block_id=block_id,
                 ),
             )
@@ -1341,79 +1240,45 @@ class _RayBatchWorker:
                         details={"error_type": type(exc).__name__, "error": str(exc)},
                     )
                 )
-            _record_worker_metrics(
-                self._metrics_collector,
-                RayWorkerMetrics(
-                    total_rows=0,
-                    blocks=1,
-                    failed_blocks=1,
-                    elapsed_seconds=time.perf_counter() - start_time,
-                    block_id=block_id,
-                ),
-            )
-            _record_worker_observability(
-                self._metrics_collector,
-                worker_profile=None,
-                trace_events=trace_events,
-                throttle_snapshots=[],
-            )
+            if not failure_metrics_recorded:
+                _record_worker_metrics(
+                    self._metrics_collector,
+                    RayWorkerMetrics(
+                        total_rows=0,
+                        input_rows=num_records,
+                        output_rows=0,
+                        blocks=1,
+                        failed_blocks=1,
+                        elapsed_seconds=time.perf_counter() - start_time,
+                        block_id=block_id,
+                    ),
+                )
+                _record_worker_observability(
+                    self._metrics_collector,
+                    worker_profile=None,
+                    trace_events=trace_events,
+                    throttle_snapshots=[],
+                )
+            if isinstance(exc, RayDatasetGenerationError):
+                raise
             raise RayDatasetGenerationError(_format_worker_failure_message(dataframe=dataframe, exc=exc)) from exc
-        finally:
-            self._release_block_state()
 
     def _create_block_config(self, dataframe: Any) -> DataDesignerConfig:
         block_config = DataDesignerConfig.model_validate_json(self._execution_payload.config_json)
-        if self._execution_payload.use_input_dataset:
-            block_config.seed_config = SeedConfig(source=DataFrameSeedSource(df=_strip_internal_columns(dataframe)))
-        elif self._execution_payload.seed_window is not None:
+        if self._execution_payload.seed_window is not None:
             if self._execution_payload.seed_config is None:
                 raise RayDatasetGenerationError("RayBackend seed window was provided without a seed config.")
             block_config.seed_config = SeedConfig(
                 source=DataFrameSeedSource(
                     df=_read_seed_window_dataframe(
                         seed_config=self._execution_payload.seed_config,
-                        worker_options=self._execution_payload.worker_options,
+                        worker_options=self._worker_options,
                         dataframe=dataframe,
                         seed_window=self._execution_payload.seed_window,
                     )
                 )
             )
         return block_config
-
-    def _attach_seed_reader(self, block_config: DataDesignerConfig) -> None:
-        if block_config.seed_config is None:
-            self._resource_provider.seed_reader = None
-            return
-        self._resource_provider.seed_reader = self._seed_reader_registry.get_reader(
-            block_config.seed_config.source,
-            self._execution_payload.worker_options.secret_resolver,
-        )
-
-    def _get_model_usage_delta(
-        self,
-        model_usage_snapshot: Any,
-        elapsed_seconds: float,
-    ) -> dict[str, dict[str, Any]] | None:
-        usage_deltas = self._resource_provider.model_registry.get_usage_deltas(model_usage_snapshot)
-        if not usage_deltas:
-            return None
-        return {
-            model_name: usage_stats.get_usage_stats(total_time_elapsed=elapsed_seconds)
-            for model_name, usage_stats in usage_deltas.items()
-        }
-
-    def _release_block_state(self) -> None:
-        self._resource_provider.seed_reader = None
-        self._artifact_storage.clear()
-        _detach_seed_readers(self._seed_reader_registry._readers.values())
-
-
-def _detach_seed_readers(readers: Iterable[SeedReader]) -> None:
-    for reader in readers:
-        reader._reset_attachment_state()
-        for attr in ("source", "secret_resolver"):
-            if hasattr(reader, attr):
-                delattr(reader, attr)
 
 
 def _generate_batch(
@@ -1481,6 +1346,28 @@ def _append_hidden_order_column(
     output = output.copy()
     output[hidden_order_column] = order_values
     return output
+
+
+def _metrics_from_block_result(
+    block_result: Any,
+    *,
+    elapsed_seconds: float,
+    block_id: str,
+    failed_blocks: int = 0,
+) -> RayWorkerMetrics:
+    return RayWorkerMetrics(
+        total_rows=block_result.output_rows,
+        input_rows=block_result.input_rows,
+        output_rows=block_result.output_rows,
+        dropped_rows=block_result.dropped_rows,
+        all_rows_dropped=block_result.all_rows_dropped,
+        partial_rows_dropped=block_result.partial_rows_dropped,
+        blocks=1,
+        failed_blocks=failed_blocks,
+        elapsed_seconds=elapsed_seconds,
+        model_usage=block_result.model_usage_stats or None,
+        block_id=block_id,
+    )
 
 
 def _read_seed_window_dataframe(

--- a/packages/data-designer/src/data_designer/integrations/ray/metrics.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/metrics.py
@@ -18,6 +18,12 @@ class RayWorkerMetrics:
     """Serializable metrics emitted by one Ray worker or processed Ray block."""
 
     total_rows: int = 0
+    input_rows: int = 0
+    output_rows: int = 0
+    dropped_rows: int = 0
+    all_rows_dropped: bool = False
+    partial_rows_dropped: bool = False
+    empty_input: bool = False
     blocks: int = 1
     failed_blocks: int = 0
     elapsed_seconds: float = 0.0
@@ -25,7 +31,15 @@ class RayWorkerMetrics:
     block_id: str | None = None
 
     def __post_init__(self) -> None:
+        if self.output_rows == 0 and self.total_rows > 0:
+            object.__setattr__(self, "output_rows", self.total_rows)
         _validate_non_negative_int("total_rows", self.total_rows)
+        _validate_non_negative_int("input_rows", self.input_rows)
+        _validate_non_negative_int("output_rows", self.output_rows)
+        _validate_non_negative_int("dropped_rows", self.dropped_rows)
+        _validate_bool("all_rows_dropped", self.all_rows_dropped)
+        _validate_bool("partial_rows_dropped", self.partial_rows_dropped)
+        _validate_bool("empty_input", self.empty_input)
         _validate_non_negative_int("blocks", self.blocks)
         _validate_non_negative_int("failed_blocks", self.failed_blocks)
         _validate_non_negative_float("elapsed_seconds", self.elapsed_seconds)
@@ -46,6 +60,12 @@ class RayDatasetMetrics:
     """
 
     total_rows: int = 0
+    input_rows: int = 0
+    output_rows: int = 0
+    dropped_rows: int = 0
+    all_rows_dropped_blocks: int = 0
+    partial_rows_dropped_blocks: int = 0
+    empty_input_blocks: int = 0
     blocks: int = 0
     failed_blocks: int = 0
     elapsed_seconds: float = 0.0
@@ -53,7 +73,15 @@ class RayDatasetMetrics:
     throttle: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
+        if self.output_rows == 0 and self.total_rows > 0:
+            object.__setattr__(self, "output_rows", self.total_rows)
         _validate_non_negative_int("total_rows", self.total_rows)
+        _validate_non_negative_int("input_rows", self.input_rows)
+        _validate_non_negative_int("output_rows", self.output_rows)
+        _validate_non_negative_int("dropped_rows", self.dropped_rows)
+        _validate_non_negative_int("all_rows_dropped_blocks", self.all_rows_dropped_blocks)
+        _validate_non_negative_int("partial_rows_dropped_blocks", self.partial_rows_dropped_blocks)
+        _validate_non_negative_int("empty_input_blocks", self.empty_input_blocks)
         _validate_non_negative_int("blocks", self.blocks)
         _validate_non_negative_int("failed_blocks", self.failed_blocks)
         _validate_non_negative_float("elapsed_seconds", self.elapsed_seconds)
@@ -71,6 +99,12 @@ class RayDatasetMetrics:
 @dataclass(slots=True)
 class _MetricsAccumulator:
     total_rows: int = 0
+    input_rows: int = 0
+    output_rows: int = 0
+    dropped_rows: int = 0
+    all_rows_dropped_blocks: int = 0
+    partial_rows_dropped_blocks: int = 0
+    empty_input_blocks: int = 0
     blocks: int = 0
     failed_blocks: int = 0
     elapsed_seconds: float = 0.0
@@ -89,6 +123,12 @@ def aggregate_ray_metrics(worker_metrics: Iterable[RayMetricsPayload]) -> RayDat
     for payload in worker_metrics:
         metrics = normalize_ray_worker_metrics(payload)
         accumulator.total_rows += metrics.total_rows
+        accumulator.input_rows += metrics.input_rows
+        accumulator.output_rows += metrics.output_rows
+        accumulator.dropped_rows += metrics.dropped_rows
+        accumulator.all_rows_dropped_blocks += int(metrics.all_rows_dropped)
+        accumulator.partial_rows_dropped_blocks += int(metrics.partial_rows_dropped)
+        accumulator.empty_input_blocks += int(metrics.empty_input)
         accumulator.blocks += metrics.blocks
         accumulator.failed_blocks += metrics.failed_blocks
         accumulator.elapsed_seconds += metrics.elapsed_seconds
@@ -101,6 +141,12 @@ def aggregate_ray_metrics(worker_metrics: Iterable[RayMetricsPayload]) -> RayDat
 
     return RayDatasetMetrics(
         total_rows=accumulator.total_rows,
+        input_rows=accumulator.input_rows,
+        output_rows=accumulator.output_rows,
+        dropped_rows=accumulator.dropped_rows,
+        all_rows_dropped_blocks=accumulator.all_rows_dropped_blocks,
+        partial_rows_dropped_blocks=accumulator.partial_rows_dropped_blocks,
+        empty_input_blocks=accumulator.empty_input_blocks,
         blocks=accumulator.blocks,
         failed_blocks=accumulator.failed_blocks,
         elapsed_seconds=accumulator.elapsed_seconds,
@@ -113,6 +159,12 @@ def normalize_ray_worker_metrics(payload: RayMetricsPayload) -> RayWorkerMetrics
     if isinstance(payload, RayDatasetMetrics):
         return RayWorkerMetrics(
             total_rows=payload.total_rows,
+            input_rows=payload.input_rows,
+            output_rows=payload.output_rows,
+            dropped_rows=payload.dropped_rows,
+            all_rows_dropped=payload.all_rows_dropped_blocks > 0,
+            partial_rows_dropped=payload.partial_rows_dropped_blocks > 0,
+            empty_input=payload.empty_input_blocks > 0,
             blocks=payload.blocks,
             failed_blocks=payload.failed_blocks,
             elapsed_seconds=payload.elapsed_seconds,
@@ -126,6 +178,12 @@ def normalize_ray_worker_metrics(payload: RayMetricsPayload) -> RayWorkerMetrics
 
     return RayWorkerMetrics(
         total_rows=_coerce_int(payload, "total_rows", default=0),
+        input_rows=_coerce_int(payload, "input_rows", default=0),
+        output_rows=_coerce_int(payload, "output_rows", default=_coerce_int(payload, "total_rows", default=0)),
+        dropped_rows=_coerce_int(payload, "dropped_rows", default=0),
+        all_rows_dropped=_coerce_bool(payload, "all_rows_dropped", default=False),
+        partial_rows_dropped=_coerce_bool(payload, "partial_rows_dropped", default=False),
+        empty_input=_coerce_bool(payload, "empty_input", default=False),
         blocks=_coerce_int(payload, "blocks", default=1),
         failed_blocks=_coerce_int(payload, "failed_blocks", default=0),
         elapsed_seconds=_coerce_float(payload, "elapsed_seconds", default=0.0),
@@ -146,6 +204,13 @@ def _coerce_float(payload: Mapping[str, Any], field_name: str, *, default: float
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise RayMetricsError(f"Ray metrics field {field_name!r} must be numeric.")
     return float(value)
+
+
+def _coerce_bool(payload: Mapping[str, Any], field_name: str, *, default: bool) -> bool:
+    value = payload.get(field_name, default)
+    if not isinstance(value, bool):
+        raise RayMetricsError(f"Ray metrics field {field_name!r} must be a boolean.")
+    return value
 
 
 def _coerce_model_usage(value: Any) -> ModelUsageSummary | None:
@@ -184,6 +249,11 @@ def _validate_non_negative_float(field_name: str, value: float) -> None:
         raise RayMetricsError(f"Ray metrics field {field_name!r} must be numeric.")
     if value < 0:
         raise RayMetricsError(f"Ray metrics field {field_name!r} must be non-negative.")
+
+
+def _validate_bool(field_name: str, value: bool) -> None:
+    if not isinstance(value, bool):
+        raise RayMetricsError(f"Ray metrics field {field_name!r} must be a boolean.")
 
 
 def _merge_model_usage(target: ModelUsageSummary, source: ModelUsageSummary) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_metrics.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics.py
@@ -77,7 +77,32 @@ def test_aggregate_ray_metrics_sums_worker_metrics_and_model_usage() -> None:
 def test_normalize_ray_worker_metrics_uses_serializable_mapping_defaults() -> None:
     metrics = normalize_ray_worker_metrics({"total_rows": 3})
 
-    assert metrics == RayWorkerMetrics(total_rows=3, blocks=1)
+    assert metrics == RayWorkerMetrics(total_rows=3, output_rows=3, blocks=1)
+
+
+def test_aggregate_ray_metrics_sums_row_outcomes() -> None:
+    metrics = aggregate_ray_metrics(
+        [
+            RayWorkerMetrics(total_rows=2, input_rows=3, output_rows=2, dropped_rows=1, partial_rows_dropped=True),
+            {
+                "total_rows": 0,
+                "input_rows": 2,
+                "output_rows": 0,
+                "dropped_rows": 2,
+                "all_rows_dropped": True,
+                "failed_blocks": 1,
+            },
+            {"total_rows": 0, "empty_input": True},
+        ]
+    )
+
+    assert metrics.input_rows == 5
+    assert metrics.output_rows == 2
+    assert metrics.dropped_rows == 3
+    assert metrics.partial_rows_dropped_blocks == 1
+    assert metrics.all_rows_dropped_blocks == 1
+    assert metrics.empty_input_blocks == 1
+    assert metrics.failed_blocks == 1
 
 
 def test_normalize_ray_worker_metrics_rejects_invalid_payload() -> None:

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -18,9 +18,9 @@ from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import SamplingStrategy
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
+from data_designer.engine.dataset_builders.block_execution import BlockExecutionResult
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
-from data_designer.engine.storage.artifact_storage import BatchStage
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
@@ -169,30 +169,25 @@ def test_worker_options_and_map_payload_are_cloudpickle_serializable_when_availa
     assert DataDesignerConfig.model_validate_json(round_tripped.config_json).seed_config is None
 
 
-def test_in_memory_preview_artifact_storage_keeps_processor_outputs_off_disk() -> None:
-    storage = ray_backend_module._InMemoryPreviewArtifactStorage()
-    dataframe = lazy.pd.DataFrame({"value": [1, 2]})
-
-    path = storage.write_parquet_file(
-        "schema-transform.parquet",
-        dataframe,
-        BatchStage.PROCESSORS_OUTPUTS,
+def _block_result(*, dataframe: Any, input_rows: int, model_usage: dict[str, dict[str, Any]] | None = None) -> Any:
+    output_rows = len(dataframe)
+    dropped_rows = max(input_rows - output_rows, 0)
+    return BlockExecutionResult(
+        dataframe=dataframe,
+        raw_dataframe=dataframe.copy(),
+        task_traces=[],
+        model_usage_stats=model_usage or {},
+        model_usage_deltas={},
+        processor_artifacts={},
+        input_rows=input_rows,
+        output_rows=output_rows,
+        dropped_rows=dropped_rows,
+        all_rows_dropped=input_rows > 0 and output_rows == 0,
+        partial_rows_dropped=0 < output_rows < input_rows,
     )
 
-    assert not path.exists()
-    assert storage.list_processor_names() == ["schema-transform"]
-    assert storage.load_processor_dataset("schema-transform").to_dict(orient="records") == [
-        {"value": 1},
-        {"value": 2},
-    ]
 
-    storage.clear()
-
-    assert storage.list_processor_names() == []
-    assert storage.load_processor_dataset("schema-transform").empty
-
-
-def test_ray_batch_worker_reuses_setup_and_clears_block_state(
+def test_ray_batch_worker_delegates_to_engine_block_api(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     stub_model_configs: Any,
@@ -209,41 +204,14 @@ def test_ray_batch_worker_reuses_setup_and_clears_block_state(
         worker_options=_worker_options_from_designer(designer),
         use_input_dataset=True,
     )
-    resource_provider_ids: list[int] = []
-    model_registry_ids: list[int] = []
-    artifact_storage_ids: list[int] = []
-    seed_records: list[list[dict[str, Any]]] = []
-    processor_names_seen: list[list[str]] = []
+    calls: list[dict[str, Any]] = []
 
-    class RecordingBuilder:
-        def __init__(
-            self,
-            *,
-            data_designer_config: DataDesignerConfig,
-            resource_provider: Any,
-            use_async: bool | None = None,
-        ) -> None:
-            assert use_async is True
-            assert data_designer_config.seed_config is not None
-            self._resource_provider: Any = resource_provider
-            resource_provider_ids.append(id(resource_provider))
-            model_registry_ids.append(id(resource_provider.model_registry))
-            artifact_storage_ids.append(id(resource_provider.artifact_storage))
-            seed_records.append(data_designer_config.seed_config.source.df.to_dict(orient="records"))
+    def execute_dataset_block(**kwargs: Any) -> BlockExecutionResult:
+        calls.append(kwargs)
+        num_records = kwargs["num_records"]
+        return _block_result(dataframe=lazy.pd.DataFrame({"row": list(range(num_records))}), input_rows=num_records)
 
-        def build_preview(self, *, num_records: int) -> Any:
-            return lazy.pd.DataFrame({"row": list(range(num_records))})
-
-        def process_preview(self, dataset: Any) -> Any:
-            self._resource_provider.artifact_storage.write_parquet_file(
-                "processor.parquet",
-                dataset,
-                BatchStage.PROCESSORS_OUTPUTS,
-            )
-            processor_names_seen.append(self._resource_provider.artifact_storage.list_processor_names())
-            return dataset
-
-    monkeypatch.setattr(ray_backend_module, "DatasetBuilder", RecordingBuilder)
+    monkeypatch.setattr(ray_backend_module, "execute_dataset_block", execute_dataset_block)
     worker = ray_backend_module._RayBatchWorker(execution_payload=payload)
 
     first = worker(lazy.pd.DataFrame({"x": [1], "label": ["a"]}))
@@ -251,19 +219,93 @@ def test_ray_batch_worker_reuses_setup_and_clears_block_state(
 
     assert first.to_dict(orient="records") == [{"row": 0}]
     assert second.to_dict(orient="records") == [{"row": 0}, {"row": 1}]
-    assert len(set(resource_provider_ids)) == 1
-    assert len(set(model_registry_ids)) == 1
-    assert len(set(artifact_storage_ids)) == 1
-    assert seed_records == [
+    assert [call["input_frame"].to_dict(orient="records") for call in calls] == [
         [{"x": 1, "label": "a"}],
         [{"x": 2, "label": "b"}, {"x": 3, "label": "c"}],
     ]
-    assert processor_names_seen == [["processor"], ["processor"]]
-    assert worker._artifact_storage.list_processor_names() == []
-    assert worker._resource_provider.seed_reader is None
-    for reader in worker._seed_reader_registry._readers.values():
-        assert not hasattr(reader, "source")
-        assert not hasattr(reader, "secret_resolver")
+    assert all(call["runtime_context"] is worker._worker_options for call in calls)
+    assert all(call["options"].use_async is True for call in calls)
+    assert all(call["data_designer_config"].seed_config is None for call in calls)
+
+
+def test_ray_batch_worker_records_partial_row_drop_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ray_installer: Any,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = fake_ray_installer(with_remote=True)
+    collector = ray_backend_module._create_metrics_collector(fake_ray)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    payload = ray_backend_module._compile_ray_execution_payload(
+        config_builder=_input_expression_config_builder(stub_model_configs),
+        worker_options=_worker_options_from_designer(designer),
+        use_input_dataset=True,
+    )
+
+    def execute_dataset_block(**_: Any) -> BlockExecutionResult:
+        return _block_result(dataframe=lazy.pd.DataFrame({"row": [0]}), input_rows=2)
+
+    monkeypatch.setattr(ray_backend_module, "execute_dataset_block", execute_dataset_block)
+
+    output = ray_backend_module._RayBatchWorker(execution_payload=payload, metrics_collector=collector)(
+        lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]})
+    )
+
+    metrics = fake_ray.get(collector.snapshot.remote())[0]
+    assert output.to_dict(orient="records") == [{"row": 0}]
+    assert metrics["input_rows"] == 2
+    assert metrics["output_rows"] == 1
+    assert metrics["dropped_rows"] == 1
+    assert metrics["partial_rows_dropped"] is True
+    assert metrics["all_rows_dropped"] is False
+    assert metrics["failed_blocks"] == 0
+
+
+def test_ray_batch_worker_fails_all_row_drop_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ray_installer: Any,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = fake_ray_installer(with_remote=True)
+    collector = ray_backend_module._create_metrics_collector(fake_ray)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    payload = ray_backend_module._compile_ray_execution_payload(
+        config_builder=_input_expression_config_builder(stub_model_configs),
+        worker_options=_worker_options_from_designer(designer),
+        use_input_dataset=True,
+    )
+
+    def execute_dataset_block(**_: Any) -> BlockExecutionResult:
+        return _block_result(dataframe=lazy.pd.DataFrame({"row": []}), input_rows=2)
+
+    monkeypatch.setattr(ray_backend_module, "execute_dataset_block", execute_dataset_block)
+
+    with pytest.raises(RayDatasetGenerationError, match="all input rows were dropped"):
+        ray_backend_module._RayBatchWorker(execution_payload=payload, metrics_collector=collector)(
+            lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]})
+        )
+
+    metrics = fake_ray.get(collector.snapshot.remote())[0]
+    assert metrics["input_rows"] == 2
+    assert metrics["output_rows"] == 0
+    assert metrics["dropped_rows"] == 2
+    assert metrics["all_rows_dropped"] is True
+    assert metrics["partial_rows_dropped"] is False
+    assert metrics["failed_blocks"] == 1
 
 
 def test_ray_execution_payload_is_driver_config_snapshot(
@@ -400,21 +442,17 @@ def test_worker_failure_includes_block_context(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    class FailingDatasetBuilder:
-        def __init__(self, **_: Any) -> None:
-            pass
-
-        def build_preview(self, *, num_records: int) -> lazy.pd.DataFrame:
-            del num_records
-            raise RuntimeError("worker boom")
-
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
         secret_resolver=PlaintextResolver(),
         managed_assets_path=_managed_assets_path(tmp_path),
     )
-    monkeypatch.setattr(ray_backend_module, "DatasetBuilder", FailingDatasetBuilder)
+
+    def fail_block(**_: Any) -> BlockExecutionResult:
+        raise RuntimeError("worker boom")
+
+    monkeypatch.setattr(ray_backend_module, "execute_dataset_block", fail_block)
 
     with pytest.raises(RayDatasetGenerationError, match="range rows 5-6") as exc_info:
         ray_backend_module._generate_batch(


### PR DESCRIPTION
## 📋 Summary
Adds an engine-owned dataset block execution API for distributed backends and moves Ray worker generation onto that API instead of using preview methods as the worker contract.
The block result now carries row outcome metadata so Ray can distinguish empty input, partial row drops, and all-row-drop failures.

## 🔗 Related Issue
Fixes #63
Closes #92
Part of #82

## 🔄 Changes
- Added `execute_dataset_block(...)`, `BlockExecutionOptions`, and `BlockExecutionResult` in the engine package.
- Added `DatasetBuilder.build_block()` / `process_block()` helpers for in-memory block execution.
- Updated Ray workers to delegate block generation to the engine API while keeping Ray ordering, observability, and failure wrapping in the integration layer.
- Removed Ray worker preview-storage emulation and added row outcome fields to Ray worker/dataset metrics.
- Added engine block execution tests and Ray worker/metrics tests for delegation, partial row drops, all-row drops, and empty inputs.

## 🧪 Testing
- [ ] `make test` passes
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (if applicable)

Targeted checks run:
- `uv run ruff check packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/metrics.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_metrics.py`
- `uv run ruff format --check packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/metrics.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_metrics.py`
- `uv run pytest packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_metrics.py`

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
