### PR TITLE
fix(ray): validate backend execution options

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -305,13 +305,14 @@ class RayBackend:
         max_trace_events: int = 1000,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
-            raise ValueError("RayBackend output must be 'dataset' or 'arrow_refs'.")
+            raise RayBackendConfigurationError("RayBackend output must be 'dataset' or 'arrow_refs'.")
         if object_ref_format not in ("arrow", "pandas"):
-            raise ValueError("RayBackend object_ref_format must be 'arrow' or 'pandas'.")
+            raise RayBackendConfigurationError("RayBackend object_ref_format must be 'arrow' or 'pandas'.")
+        _validate_ray_backend_batch_size(batch_size)
         if order_column is not None and order_column == "":
-            raise ValueError("RayBackend order_column must be a non-empty string when provided.")
+            raise RayBackendConfigurationError("RayBackend order_column must be a non-empty string when provided.")
         if max_trace_events < 0:
-            raise ValueError("RayBackend max_trace_events must be non-negative.")
+            raise RayBackendConfigurationError("RayBackend max_trace_events must be non-negative.")
         self.block_planning = _resolve_block_planning(
             block_planning,
             override_num_blocks=override_num_blocks,
@@ -423,7 +424,7 @@ class RayBackend:
             dataset = _attach_hidden_row_id_column(ray, dataset, hidden_order_column=hidden_order_column)
         input_blocks = _get_num_blocks(dataset)
         metrics_collector = _create_metrics_collector(ray, max_trace_events=self.max_trace_events)
-        batch_size = self.batch_size or runtime_context.run_config.buffer_size
+        batch_size = self.batch_size if self.batch_size is not None else runtime_context.run_config.buffer_size
         observability_options = _RayObservabilityOptions(
             profile_workers=self.profile_workers,
             trace_enabled=self.trace_enabled,
@@ -568,7 +569,9 @@ def _resolve_block_planning(
         value is not None
         for value in (override_num_blocks, target_block_size, min_blocks, max_blocks, read_concurrency)
     ):
-        raise ValueError("RayBackend block_planning cannot be combined with individual block planning arguments.")
+        raise RayBackendConfigurationError(
+            "RayBackend block_planning cannot be combined with individual block planning arguments."
+        )
     if block_planning is not None:
         return block_planning
     return RayBlockPlanning(
@@ -578,6 +581,13 @@ def _resolve_block_planning(
         max_blocks=max_blocks,
         read_concurrency=read_concurrency,
     )
+
+
+def _validate_ray_backend_batch_size(batch_size: int | None) -> None:
+    if batch_size is None:
+        return
+    if isinstance(batch_size, bool) or not isinstance(batch_size, int) or batch_size <= 0:
+        raise RayBackendConfigurationError("RayBackend batch_size must be a positive integer or None.")
 
 
 def _resolve_execution_options(
@@ -612,7 +622,9 @@ def _resolve_execution_options(
         actor_pool_initial_size,
     )
     if execution_options is not None and (use_actor_pool or any(value is not None for value in explicit_values)):
-        raise ValueError("RayBackend execution_options cannot be combined with individual Ray execution arguments.")
+        raise RayBackendConfigurationError(
+            "RayBackend execution_options cannot be combined with individual Ray execution arguments."
+        )
     if execution_options is not None:
         return execution_options
     return RayExecutionOptions(

--- a/packages/data-designer/src/data_designer/integrations/ray/options.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/options.py
@@ -8,7 +8,21 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from data_designer.integrations.ray.errors import RayBackendConfigurationError
+
 RayMapConcurrency = int | tuple[int, int] | tuple[int, int, int]
+_DATA_DESIGNER_OWNED_MAP_BATCHES_KEYS = frozenset(
+    {
+        "batch_format",
+        "batch_size",
+        "fn",
+        "fn_args",
+        "fn_constructor_args",
+        "fn_constructor_kwargs",
+        "fn_kwargs",
+        "zero_copy_batch",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,14 +62,14 @@ class RayBlockPlanning:
         if self.override_num_blocks is not None and any(
             value is not None for value in (self.target_block_size, self.min_blocks, self.max_blocks)
         ):
-            raise ValueError(
+            raise RayBackendConfigurationError(
                 "RayBlockPlanning override_num_blocks cannot be combined with target_block_size, "
                 "min_blocks, or max_blocks."
             )
         if self.min_blocks is not None and self.max_blocks is not None and self.min_blocks > self.max_blocks:
-            raise ValueError("RayBlockPlanning min_blocks must be less than or equal to max_blocks.")
+            raise RayBackendConfigurationError("RayBlockPlanning min_blocks must be less than or equal to max_blocks.")
         if self.target_block_size is None and (self.min_blocks is not None or self.max_blocks is not None):
-            raise ValueError("RayBlockPlanning min_blocks and max_blocks require target_block_size.")
+            raise RayBackendConfigurationError("RayBlockPlanning min_blocks and max_blocks require target_block_size.")
 
     @property
     def has_explicit_controls(self) -> bool:
@@ -74,7 +88,7 @@ class RayBlockPlanning:
     def resolve(self, *, num_records: int) -> RayResolvedBlockPlan:
         """Resolve configured planning controls for a concrete record count."""
         if num_records < 0:
-            raise ValueError("RayBlockPlanning num_records must be non-negative.")
+            raise RayBackendConfigurationError("RayBlockPlanning num_records must be non-negative.")
         if self.override_num_blocks is not None:
             return RayResolvedBlockPlan(
                 override_num_blocks=self.override_num_blocks,
@@ -122,32 +136,48 @@ class RayExecutionOptions:
         _validate_optional_positive_number("memory", self.memory)
         _validate_resources(self.resources)
         if isinstance(self.scheduling_strategy, str) and not self.scheduling_strategy:
-            raise ValueError("RayExecutionOptions scheduling_strategy must be non-empty when provided.")
+            raise RayBackendConfigurationError(
+                "RayExecutionOptions scheduling_strategy must be non-empty when provided."
+            )
         if self.compute is not None and self.use_actor_pool:
-            raise ValueError("RayExecutionOptions compute cannot be combined with use_actor_pool=True.")
+            raise RayBackendConfigurationError(
+                "RayExecutionOptions compute cannot be combined with use_actor_pool=True."
+            )
         if self.compute is not None and self.concurrency is not None:
-            raise ValueError("RayExecutionOptions compute cannot be combined with concurrency.")
+            raise RayBackendConfigurationError("RayExecutionOptions compute cannot be combined with concurrency.")
+        if self.use_actor_pool and self.concurrency is not None:
+            raise RayBackendConfigurationError(
+                "RayExecutionOptions use_actor_pool=True cannot be combined with concurrency."
+            )
         _validate_map_concurrency(self.concurrency)
         _validate_optional_positive_int("actor_pool_min_size", self.actor_pool_min_size)
         _validate_optional_positive_int("actor_pool_max_size", self.actor_pool_max_size)
         _validate_optional_positive_int("actor_pool_initial_size", self.actor_pool_initial_size)
         if self.actor_pool_min_size is not None and not self.use_actor_pool:
-            raise ValueError("RayExecutionOptions actor_pool_min_size requires use_actor_pool=True.")
+            raise RayBackendConfigurationError("RayExecutionOptions actor_pool_min_size requires use_actor_pool=True.")
         if self.actor_pool_max_size is not None and not self.use_actor_pool:
-            raise ValueError("RayExecutionOptions actor_pool_max_size requires use_actor_pool=True.")
+            raise RayBackendConfigurationError("RayExecutionOptions actor_pool_max_size requires use_actor_pool=True.")
         if self.actor_pool_initial_size is not None and not self.use_actor_pool:
-            raise ValueError("RayExecutionOptions actor_pool_initial_size requires use_actor_pool=True.")
+            raise RayBackendConfigurationError(
+                "RayExecutionOptions actor_pool_initial_size requires use_actor_pool=True."
+            )
         if (
             self.actor_pool_min_size is not None
             and self.actor_pool_max_size is not None
             and self.actor_pool_min_size > self.actor_pool_max_size
         ):
-            raise ValueError("RayExecutionOptions actor_pool_min_size must be less than or equal to max_size.")
+            raise RayBackendConfigurationError(
+                "RayExecutionOptions actor_pool_min_size must be less than or equal to max_size."
+            )
         if self.actor_pool_initial_size is not None:
             if self.actor_pool_min_size is not None and self.actor_pool_initial_size < self.actor_pool_min_size:
-                raise ValueError("RayExecutionOptions actor_pool_initial_size must be at least actor_pool_min_size.")
+                raise RayBackendConfigurationError(
+                    "RayExecutionOptions actor_pool_initial_size must be at least actor_pool_min_size."
+                )
             if self.actor_pool_max_size is not None and self.actor_pool_initial_size > self.actor_pool_max_size:
-                raise ValueError("RayExecutionOptions actor_pool_initial_size must be at most actor_pool_max_size.")
+                raise RayBackendConfigurationError(
+                    "RayExecutionOptions actor_pool_initial_size must be at most actor_pool_max_size."
+                )
         _validate_remote_arg_conflicts(self)
 
     def to_map_batches_kwargs(self, ray: Any | None = None) -> dict[str, Any]:
@@ -166,7 +196,9 @@ class RayExecutionOptions:
             kwargs.update(dict(self.ray_remote_args))
         if self.use_actor_pool:
             if ray is None:
-                raise ValueError("RayExecutionOptions use_actor_pool=True requires an imported ray module.")
+                raise RayBackendConfigurationError(
+                    "RayExecutionOptions use_actor_pool=True requires an imported ray module."
+                )
             kwargs["compute"] = _create_actor_pool_strategy(ray, self)
         return kwargs
 
@@ -175,21 +207,21 @@ def _validate_optional_positive_int(field_name: str, value: int | None) -> None:
     if value is None:
         return
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        raise ValueError(f"Ray option {field_name} must be a positive integer.")
+        raise RayBackendConfigurationError(f"Ray option {field_name} must be a positive integer.")
 
 
 def _validate_optional_non_negative_number(field_name: str, value: float | None) -> None:
     if value is None:
         return
     if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
-        raise ValueError(f"Ray option {field_name} must be a non-negative number.")
+        raise RayBackendConfigurationError(f"Ray option {field_name} must be a non-negative number.")
 
 
 def _validate_optional_positive_number(field_name: str, value: float | None) -> None:
     if value is None:
         return
     if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
-        raise ValueError(f"Ray option {field_name} must be a positive number.")
+        raise RayBackendConfigurationError(f"Ray option {field_name} must be a positive number.")
 
 
 def _validate_resources(resources: Mapping[str, float] | None) -> None:
@@ -197,7 +229,7 @@ def _validate_resources(resources: Mapping[str, float] | None) -> None:
         return
     for name, value in resources.items():
         if not isinstance(name, str) or not name:
-            raise ValueError("RayExecutionOptions resource names must be non-empty strings.")
+            raise RayBackendConfigurationError("RayExecutionOptions resource names must be non-empty strings.")
         _validate_optional_positive_number(f"resources[{name!r}]", value)
 
 
@@ -208,13 +240,19 @@ def _validate_map_concurrency(value: RayMapConcurrency | None) -> None:
         _validate_optional_positive_int("concurrency", value)
         return
     if not isinstance(value, tuple) or len(value) not in (2, 3):
-        raise ValueError("RayExecutionOptions concurrency must be a positive integer or a 2/3-item tuple.")
+        raise RayBackendConfigurationError(
+            "RayExecutionOptions concurrency must be a positive integer or a 2/3-item tuple."
+        )
     for index, item in enumerate(value):
         _validate_optional_positive_int(f"concurrency[{index}]", item)
     if value[0] > value[1]:
-        raise ValueError("RayExecutionOptions concurrency minimum must be less than or equal to maximum.")
+        raise RayBackendConfigurationError(
+            "RayExecutionOptions concurrency minimum must be less than or equal to maximum."
+        )
     if len(value) == 3 and not value[0] <= value[2] <= value[1]:
-        raise ValueError("RayExecutionOptions concurrency initial size must be within the min/max range.")
+        raise RayBackendConfigurationError(
+            "RayExecutionOptions concurrency initial size must be within the min/max range."
+        )
 
 
 def _validate_remote_arg_conflicts(options: RayExecutionOptions) -> None:
@@ -235,15 +273,24 @@ def _validate_remote_arg_conflicts(options: RayExecutionOptions) -> None:
     )
     if conflicts:
         conflict_list = ", ".join(conflicts)
-        raise ValueError(
+        raise RayBackendConfigurationError(
             f"RayExecutionOptions received duplicate explicit and ray_remote_args values: {conflict_list}."
+        )
+    reserved_keys = sorted(_DATA_DESIGNER_OWNED_MAP_BATCHES_KEYS.intersection(options.ray_remote_args))
+    if reserved_keys:
+        reserved_list = ", ".join(reserved_keys)
+        raise RayBackendConfigurationError(
+            "RayExecutionOptions ray_remote_args cannot override DataDesigner-owned map_batches arguments: "
+            f"{reserved_list}."
         )
 
 
 def _create_actor_pool_strategy(ray: Any, options: RayExecutionOptions) -> Any:
     actor_pool_strategy = getattr(ray.data, "ActorPoolStrategy", None)
     if not callable(actor_pool_strategy):
-        raise ValueError("RayExecutionOptions use_actor_pool=True requires ray.data.ActorPoolStrategy.")
+        raise RayBackendConfigurationError(
+            "RayExecutionOptions use_actor_pool=True requires ray.data.ActorPoolStrategy."
+        )
     kwargs: dict[str, int] = {}
     _set_if_not_none(kwargs, "min_size", options.actor_pool_min_size or 1)
     _set_if_not_none(kwargs, "max_size", options.actor_pool_max_size)

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -22,9 +22,11 @@ from data_designer.engine.testing.seed_readers import LineFanoutDirectorySeedRea
 from data_designer.integrations.ray import (
     RayBackend,
     RayBackendConfigurationError,
+    RayBlockPlanning,
     RayDatasetCreationResults,
     RayDatasetGenerationError,
     RayDatasetMetrics,
+    RayExecutionOptions,
 )
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.interface.data_designer import DataDesigner
@@ -181,8 +183,61 @@ def test_ray_backend_rejects_block_planning_with_input_dataset(
     ],
 )
 def test_ray_backend_validates_invalid_block_planning_options(kwargs: dict[str, Any], match: str) -> None:
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(RayBackendConfigurationError, match=match):
         RayBackend(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"output": "table"}, "output"),
+        ({"object_ref_format": "json"}, "object_ref_format"),
+        ({"order_column": ""}, "order_column"),
+        ({"max_trace_events": -1}, "max_trace_events"),
+    ],
+)
+def test_ray_backend_constructor_uses_configuration_error(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(RayBackendConfigurationError, match=match):
+        RayBackend(**kwargs)
+
+
+@pytest.mark.parametrize("batch_size", [True, "10", 0, -1])
+def test_ray_backend_rejects_invalid_batch_size(batch_size: Any) -> None:
+    with pytest.raises(RayBackendConfigurationError, match="batch_size"):
+        RayBackend(batch_size=batch_size)
+
+
+def test_ray_backend_batch_size_none_uses_run_config_buffer_size(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=None),
+    )
+    designer.set_run_config(RunConfig(buffer_size=7))
+
+    designer.create(_input_expression_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_kwargs["batch_size"] == 7
+
+
+def test_ray_backend_rejects_grouped_block_planning_conflicts() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="block_planning"):
+        RayBackend(block_planning=RayBlockPlanning(), override_num_blocks=1)
+
+
+def test_ray_backend_rejects_grouped_execution_option_conflicts() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="execution_options"):
+        RayBackend(execution_options=RayExecutionOptions(), num_cpus=1)
 
 
 def test_ray_backend_propagates_execution_resource_options(
@@ -249,12 +304,18 @@ def test_ray_backend_actor_pool_uses_autoscaling_strategy_and_constructor_payloa
     assert input_dataset.map_batches_fn is ray_backend_module._RayBatchWorker
     assert "fn_kwargs" not in input_dataset.map_batches_kwargs
     assert "fn_constructor_kwargs" in input_dataset.map_batches_kwargs
+    assert "concurrency" not in input_dataset.map_batches_kwargs
     assert input_dataset.map_batches_kwargs["scheduling_strategy"] == "DEFAULT"
     assert input_dataset.map_batches_kwargs["compute"].kwargs == {
         "min_size": 1,
         "max_size": 4,
         "initial_size": 2,
     }
+
+
+def test_ray_backend_rejects_actor_pool_with_map_concurrency() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="use_actor_pool"):
+        RayBackend(use_actor_pool=True, map_concurrency=2)
 
 
 def test_ray_backend_driver_model_health_check_runs_once_and_workers_skip_by_default(

--- a/packages/data-designer/tests/integrations/ray/test_options.py
+++ b/packages/data-designer/tests/integrations/ray/test_options.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from data_designer.integrations.ray import RayBackendConfigurationError, RayBlockPlanning, RayExecutionOptions
+
+pytestmark = pytest.mark.ray_fake
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"override_num_blocks": 0}, "positive integer"),
+        ({"target_block_size": 10, "min_blocks": 4, "max_blocks": 2}, "min_blocks"),
+        ({"min_blocks": 2}, "require target_block_size"),
+    ],
+)
+def test_ray_block_planning_validation_uses_configuration_error(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(RayBackendConfigurationError, match=match):
+        RayBlockPlanning(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "reserved_key",
+    [
+        "batch_format",
+        "batch_size",
+        "fn",
+        "fn_args",
+        "fn_constructor_args",
+        "fn_constructor_kwargs",
+        "fn_kwargs",
+        "zero_copy_batch",
+    ],
+)
+def test_ray_execution_options_rejects_data_designer_owned_map_batches_keys(reserved_key: str) -> None:
+    with pytest.raises(RayBackendConfigurationError, match=reserved_key):
+        RayExecutionOptions(ray_remote_args={reserved_key: object()})
+
+
+def test_ray_execution_options_rejects_duplicate_explicit_remote_args() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="num_cpus"):
+        RayExecutionOptions(num_cpus=0.5, ray_remote_args={"num_cpus": 1})
+
+
+def test_ray_execution_options_rejects_actor_pool_with_concurrency() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="use_actor_pool"):
+        RayExecutionOptions(use_actor_pool=True, concurrency=2)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"num_cpus": True}, "num_cpus"),
+        ({"memory": 0}, "memory"),
+        ({"resources": {"": 1}}, "resource names"),
+        ({"concurrency": (3, 1)}, "minimum"),
+        ({"actor_pool_min_size": 1}, "use_actor_pool"),
+    ],
+)
+def test_ray_execution_options_validation_uses_configuration_error(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(RayBackendConfigurationError, match=match):
+        RayExecutionOptions(**kwargs)


### PR DESCRIPTION
## 📋 Summary

Normalize Ray backend option validation so invalid configuration fails at DataDesigner’s Ray boundary before `map_batches` execution. This covers invalid backend batch sizes, reserved worker-boundary kwargs in `ray_remote_args`, actor-pool/concurrency conflicts, and representative constructor/grouped-option errors.

## 🔗 Related Issue

Fixes #59
Fixes #66
Fixes #79
Fixes #86

## 🔄 Changes

- Validate `RayBackend(batch_size=...)` as `None` or a positive non-bool integer, and preserve `None` as the run-config buffer-size fallback.
- Reject `RayExecutionOptions.ray_remote_args` keys owned by DataDesigner’s `map_batches` worker boundary, including `fn_constructor_kwargs`, `fn_kwargs`, `batch_size`, `batch_format`, and `zero_copy_batch`.
- Reject `use_actor_pool=True` with `concurrency` / `map_concurrency` so Ray receives a single execution-control path.
- Normalize Ray backend constructor, grouped option conflict, `RayBlockPlanning`, and `RayExecutionOptions` validation failures to `RayBackendConfigurationError`.
- Add focused fake Ray and option tests for the fixed behaviors.

## 🧪 Testing

- [x] `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py`
- [x] `uv run --group dev pytest packages/data-designer/tests/integrations/ray -m ray_fake`
- [x] `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_options.py`
- [x] `uv run ruff check --output-format=full packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_options.py`
- [ ] `make test` passes (not run; targeted Ray fake/option coverage only)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A — option validation only)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — no architecture change)