### PR TITLE
fix: make Ray throttle async paths nonblocking

### DIFF
--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py
@@ -72,12 +72,31 @@ class ThrottleManagerLike(Protocol):
         timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
     ) -> None: ...
 
+    async def release_success_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None: ...
+
     def release_success(
         self,
         *,
         provider_name: str,
         model_id: str,
         domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None: ...
+
+    async def release_rate_limited_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
         now: float | None = None,
     ) -> None: ...
 
@@ -88,6 +107,15 @@ class ThrottleManagerLike(Protocol):
         model_id: str,
         domain: ThrottleDomain,
         retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None: ...
+
+    async def release_failure_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
         now: float | None = None,
     ) -> None: ...
 
@@ -311,6 +339,16 @@ class ThrottleManager:
                         )
                 state.success_streak = 0
 
+    async def release_success_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        self.release_success(provider_name=provider_name, model_id=model_id, domain=domain, now=now)
+
     def release_rate_limited(
         self,
         *,
@@ -368,6 +406,23 @@ class ThrottleManager:
                     state.current_limit,
                 )
 
+    async def release_rate_limited_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None:
+        self.release_rate_limited(
+            provider_name=provider_name,
+            model_id=model_id,
+            domain=domain,
+            retry_after=retry_after,
+            now=now,
+        )
+
     def release_failure(
         self,
         *,
@@ -379,6 +434,16 @@ class ThrottleManager:
         with self._lock:
             state = self._get_or_create_domain(provider_name, model_id, domain)
             state.in_flight = max(0, state.in_flight - 1)
+
+    async def release_failure_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        self.release_failure(provider_name=provider_name, model_id=model_id, domain=domain, now=now)
 
     # -------------------------------------------------------------------
     # Sync / async wrappers

--- a/packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py
+++ b/packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import contextlib
+import inspect
 import logging
 from typing import TYPE_CHECKING
 
@@ -175,26 +176,18 @@ class ThrottledModelClient(ModelClient):
         except ProviderError as exc:
             exc_to_reraise = exc
             try:
-                self._release_on_provider_error(domain, exc)
+                await self._arelease_on_provider_error(domain, exc)
             except Exception:
                 logger.exception("ThrottleManager release failed; permit may leak")
         except BaseException as exc:
             exc_to_reraise = exc
             try:
-                self._tm.release_failure(
-                    provider_name=self._provider_name,
-                    model_id=self._model_id,
-                    domain=domain,
-                )
+                await self._release_failure_async(domain)
             except Exception:
                 logger.exception("ThrottleManager release failed; permit may leak")
         else:
             try:
-                self._tm.release_success(
-                    provider_name=self._provider_name,
-                    model_id=self._model_id,
-                    domain=domain,
-                )
+                await self._release_success_async(domain)
             except Exception:
                 logger.exception("ThrottleManager release_success failed")
         if exc_to_reraise is not None:
@@ -216,6 +209,50 @@ class ThrottledModelClient(ModelClient):
                 model_id=self._model_id,
                 domain=domain,
             )
+
+    async def _arelease_on_provider_error(self, domain: ThrottleDomain, exc: ProviderError) -> None:
+        if exc.kind == ProviderErrorKind.RATE_LIMIT:
+            await self._release_rate_limited_async(domain, retry_after=exc.retry_after)
+        else:
+            await self._release_failure_async(domain)
+
+    async def _release_success_async(self, domain: ThrottleDomain) -> None:
+        await self._call_async_release(
+            "release_success_async",
+            "release_success",
+            provider_name=self._provider_name,
+            model_id=self._model_id,
+            domain=domain,
+        )
+
+    async def _release_rate_limited_async(self, domain: ThrottleDomain, *, retry_after: float | None) -> None:
+        await self._call_async_release(
+            "release_rate_limited_async",
+            "release_rate_limited",
+            provider_name=self._provider_name,
+            model_id=self._model_id,
+            domain=domain,
+            retry_after=retry_after,
+        )
+
+    async def _release_failure_async(self, domain: ThrottleDomain) -> None:
+        await self._call_async_release(
+            "release_failure_async",
+            "release_failure",
+            provider_name=self._provider_name,
+            model_id=self._model_id,
+            domain=domain,
+        )
+
+    async def _call_async_release(self, async_method_name: str, sync_method_name: str, **kwargs: object) -> None:
+        async_method = getattr(self._tm, async_method_name, None)
+        if callable(async_method):
+            result = async_method(**kwargs)
+            if inspect.isawaitable(result):
+                await result
+            return
+        sync_method = getattr(self._tm, sync_method_name)
+        sync_method(**kwargs)
 
     @staticmethod
     def _image_domain(request: ImageGenerationRequest) -> ThrottleDomain:

--- a/packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py
+++ b/packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py
@@ -228,6 +228,158 @@ async def test_acompletion_rate_limit_calls_release_rate_limited(
     assert state.blocked_until > 0
 
 
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    ("outcome", "expected_release"),
+    [
+        ("success", "success"),
+        ("rate_limit", "rate_limited"),
+        ("failure", "failure"),
+    ],
+)
+async def test_async_throttled_client_uses_async_release_methods(
+    inner_client: MagicMock,
+    outcome: str,
+    expected_release: str,
+) -> None:
+    class AsyncReleaseThrottleManager:
+        def __init__(self) -> None:
+            self.release_events: list[str] = []
+
+        def register(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            alias: str,
+            max_parallel_requests: int,
+        ) -> None:
+            pass
+
+        def try_acquire(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            now: float | None = None,
+        ) -> float:
+            return 0.0
+
+        def acquire_sync(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            timeout: float = 300.0,
+        ) -> None:
+            pass
+
+        async def acquire_async(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            timeout: float = 300.0,
+        ) -> None:
+            pass
+
+        def release_success(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            now: float | None = None,
+        ) -> None:
+            raise AssertionError("sync release_success should not run")
+
+        async def release_success_async(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            now: float | None = None,
+        ) -> None:
+            self.release_events.append("success")
+
+        def release_rate_limited(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            retry_after: float | None = None,
+            now: float | None = None,
+        ) -> None:
+            raise AssertionError("sync release_rate_limited should not run")
+
+        async def release_rate_limited_async(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            retry_after: float | None = None,
+            now: float | None = None,
+        ) -> None:
+            self.release_events.append("rate_limited")
+
+        def release_failure(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            now: float | None = None,
+        ) -> None:
+            raise AssertionError("sync release_failure should not run")
+
+        async def release_failure_async(
+            self,
+            *,
+            provider_name: str,
+            model_id: str,
+            domain: ThrottleDomain,
+            now: float | None = None,
+        ) -> None:
+            self.release_events.append("failure")
+
+    throttle_manager = AsyncReleaseThrottleManager()
+    if outcome == "rate_limit":
+        inner_client.acompletion = AsyncMock(
+            side_effect=ProviderError(
+                kind=ProviderErrorKind.RATE_LIMIT,
+                message="429",
+                status_code=429,
+                retry_after=3.0,
+            )
+        )
+    elif outcome == "failure":
+        inner_client.acompletion = AsyncMock(side_effect=RuntimeError("boom"))
+
+    client = ThrottledModelClient(
+        inner=inner_client,
+        throttle_manager=throttle_manager,
+        provider_name=PROVIDER,
+        model_id=MODEL_ID,
+    )
+
+    if outcome == "success":
+        await client.acompletion(ChatCompletionRequest(model=MODEL_ID, messages=[]))
+    elif outcome == "rate_limit":
+        with pytest.raises(ProviderError, match="429"):
+            await client.acompletion(ChatCompletionRequest(model=MODEL_ID, messages=[]))
+    else:
+        with pytest.raises(RuntimeError, match="boom"):
+            await client.acompletion(ChatCompletionRequest(model=MODEL_ID, messages=[]))
+
+    assert throttle_manager.release_events == [expected_release]
+
+
 # --- Non-rate-limit ProviderError: release_failure ---
 
 

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -11,6 +11,7 @@ import socket
 import tempfile
 import time
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
@@ -1534,32 +1535,70 @@ def _profile_worker_output(
 def _snapshot_worker_throttle(throttle_manager: Any | None) -> list[RayThrottleSnapshot]:
     if throttle_manager is None:
         return []
-    domains = getattr(throttle_manager, "_domains", None)
-    if not isinstance(domains, dict):
+    snapshot = getattr(throttle_manager, "snapshot", None)
+    if not callable(snapshot):
         return []
-    get_effective_max = getattr(throttle_manager, "get_effective_max", None)
+    try:
+        payload = snapshot()
+    except Exception:
+        return []
+    if not isinstance(payload, Mapping):
+        return []
+    global_caps = _effective_max_by_throttle_key(payload.get("global_caps"))
+    domains = payload.get("domains")
+    if not isinstance(domains, list):
+        return []
     snapshots: list[RayThrottleSnapshot] = []
-    for key, state in domains.items():
-        if not isinstance(key, tuple) or len(key) != 3:
+    for domain_payload in domains:
+        if not isinstance(domain_payload, Mapping):
             continue
-        provider_name, model_id, domain = key
+        provider_name = domain_payload.get("provider_name")
+        model_id = domain_payload.get("model_id")
+        domain = domain_payload.get("domain")
         if not all(isinstance(value, str) for value in (provider_name, model_id, domain)):
             continue
-        effective_max = get_effective_max(provider_name, model_id) if callable(get_effective_max) else None
+        effective_max = _safe_optional_int_mapping(domain_payload, "effective_max")
+        if effective_max is None:
+            effective_max = global_caps.get((provider_name, model_id))
         snapshots.append(
             RayThrottleSnapshot(
                 provider_name=provider_name,
                 model_id=model_id,
                 domain=domain,
-                current_limit=_safe_int_attr(state, "current_limit"),
+                current_limit=_safe_int_mapping(domain_payload, "current_limit"),
                 effective_max=effective_max,
-                in_flight=_safe_int_attr(state, "in_flight"),
-                waiters=_safe_int_attr(state, "waiters"),
-                rate_limit_ceiling=_safe_int_attr(state, "rate_limit_ceiling"),
-                consecutive_rate_limits=_safe_int_attr(state, "consecutive_429s"),
+                in_flight=_safe_int_mapping(domain_payload, "in_flight"),
+                waiters=_safe_int_mapping(domain_payload, "waiters"),
+                rate_limit_ceiling=_safe_int_mapping(domain_payload, "rate_limit_ceiling"),
+                consecutive_rate_limits=_safe_int_mapping(
+                    domain_payload,
+                    "consecutive_rate_limits",
+                    fallback_field_name="consecutive_429s",
+                ),
             )
         )
     return snapshots
+
+
+def _effective_max_by_throttle_key(global_caps: Any) -> dict[tuple[str, str], int]:
+    if not isinstance(global_caps, list):
+        return {}
+    effective_by_key: dict[tuple[str, str], int] = {}
+    for cap_payload in global_caps:
+        if not isinstance(cap_payload, Mapping):
+            continue
+        provider_name = cap_payload.get("provider_name")
+        model_id = cap_payload.get("model_id")
+        effective_max = cap_payload.get("effective_max")
+        if (
+            isinstance(provider_name, str)
+            and isinstance(model_id, str)
+            and isinstance(effective_max, int)
+            and not isinstance(effective_max, bool)
+            and effective_max >= 0
+        ):
+            effective_by_key[(provider_name, model_id)] = effective_max
+    return effective_by_key
 
 
 def _task_traces_to_events(
@@ -1656,9 +1695,23 @@ def _runtime_context_value(runtime_context: Any, method_name: str) -> str | None
     return str(value) if value is not None else None
 
 
-def _safe_int_attr(value: Any, attr_name: str) -> int:
-    attr = getattr(value, attr_name, 0)
-    return attr if isinstance(attr, int) and not isinstance(attr, bool) and attr >= 0 else 0
+def _safe_int_mapping(
+    payload: Mapping[str, Any],
+    field_name: str,
+    *,
+    fallback_field_name: str | None = None,
+) -> int:
+    value = payload.get(field_name)
+    if value is None and fallback_field_name is not None:
+        value = payload.get(fallback_field_name)
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _safe_optional_int_mapping(payload: Mapping[str, Any], field_name: str) -> int | None:
+    value = payload.get(field_name)
+    if value is None:
+        return None
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
 
 
 def _safe_float_attr(value: Any, attr_name: str) -> float:

--- a/packages/data-designer/src/data_designer/integrations/ray/throttling.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/throttling.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import importlib
+import inspect
 import time
 from typing import Any
 
@@ -16,6 +18,8 @@ from data_designer.engine.models.clients.throttle_manager import (
     ThrottleManager,
 )
 from data_designer.integrations.ray.errors import RayDatasetGenerationError
+
+_RAY_GET_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_prefix="dd-ray-throttle")
 
 
 class RayThrottleCoordinator:
@@ -151,6 +155,25 @@ class RayThrottleManagerProxy:
             )
         )
 
+    async def try_acquire_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> float:
+        return float(
+            await _ray_get_async(
+                self._coordinator.try_acquire.remote(
+                    provider_name=provider_name,
+                    model_id=model_id,
+                    domain=domain,
+                    now=now,
+                )
+            )
+        )
+
     def acquire_sync(
         self,
         *,
@@ -180,7 +203,7 @@ class RayThrottleManagerProxy:
         timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
     ) -> None:
         deadline = time.monotonic() + timeout
-        wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+        wait = await self.try_acquire_async(provider_name=provider_name, model_id=model_id, domain=domain)
         while wait != 0.0:
             remaining = deadline - time.monotonic()
             if remaining <= 0 or wait > remaining:
@@ -189,7 +212,7 @@ class RayThrottleManagerProxy:
                     f"for {provider_name}/{model_id} [{domain.value}]"
                 )
             await asyncio.sleep(min(wait, remaining, CAPACITY_POLL_INTERVAL))
-            wait = self.try_acquire(provider_name=provider_name, model_id=model_id, domain=domain)
+            wait = await self.try_acquire_async(provider_name=provider_name, model_id=model_id, domain=domain)
 
     def release_success(
         self,
@@ -200,6 +223,23 @@ class RayThrottleManagerProxy:
         now: float | None = None,
     ) -> None:
         _ray_get(
+            self._coordinator.release_success.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                now=now,
+            )
+        )
+
+    async def release_success_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        await _ray_get_async(
             self._coordinator.release_success.remote(
                 provider_name=provider_name,
                 model_id=model_id,
@@ -227,6 +267,25 @@ class RayThrottleManagerProxy:
             )
         )
 
+    async def release_rate_limited_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        retry_after: float | None = None,
+        now: float | None = None,
+    ) -> None:
+        await _ray_get_async(
+            self._coordinator.release_rate_limited.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                retry_after=retry_after,
+                now=now,
+            )
+        )
+
     def release_failure(
         self,
         *,
@@ -236,6 +295,23 @@ class RayThrottleManagerProxy:
         now: float | None = None,
     ) -> None:
         _ray_get(
+            self._coordinator.release_failure.remote(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                now=now,
+            )
+        )
+
+    async def release_failure_async(
+        self,
+        *,
+        provider_name: str,
+        model_id: str,
+        domain: ThrottleDomain,
+        now: float | None = None,
+    ) -> None:
+        await _ray_get_async(
             self._coordinator.release_failure.remote(
                 provider_name=provider_name,
                 model_id=model_id,
@@ -260,5 +336,17 @@ def create_ray_throttle_manager(ray: Any, run_config: RunConfig) -> RayThrottleM
 def _ray_get(ref: Any) -> Any:
     try:
         return importlib.import_module("ray").get(ref)
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend global provider throttle coordination failed.") from exc
+
+
+async def _ray_get_async(ref: Any) -> Any:
+    try:
+        if inspect.isawaitable(ref):
+            return await ref
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(_RAY_GET_EXECUTOR, _ray_get, ref)
+    except RayDatasetGenerationError:
+        raise
     except Exception as exc:
         raise RayDatasetGenerationError("RayBackend global provider throttle coordination failed.") from exc

--- a/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
@@ -208,6 +208,12 @@ class FakeObjectRef:
     def __init__(self, value: Any) -> None:
         self.value = value
 
+    def __await__(self) -> Any:
+        async def _value() -> Any:
+            return self.value
+
+        return _value().__await__()
+
 
 class FakeRemoteMethod:
     def __init__(self, method: Any) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
+++ b/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
@@ -3,16 +3,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
 import pytest
-from fake_ray_harness import install_fake_ray
+from fake_ray_harness import fake_ray_get, install_fake_ray
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.run_config import RunConfig
-from data_designer.engine.models.clients.throttle_manager import CAPACITY_POLL_INTERVAL, ThrottleDomain
+from data_designer.engine.models.clients.throttle_manager import CAPACITY_POLL_INTERVAL, ThrottleDomain, ThrottleManager
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend
 from data_designer.integrations.ray import backend as ray_backend_module
@@ -59,6 +60,82 @@ def test_ray_throttle_proxy_coordinates_shared_provider_cap(monkeypatch: pytest.
             "limits_by_alias": {"writer": 1},
         }
     ]
+    worker_snapshots = ray_backend_module._snapshot_worker_throttle(second_worker)
+    assert len(worker_snapshots) == 1
+    assert worker_snapshots[0].provider_name == "openai"
+    assert worker_snapshots[0].model_id == "gpt-4.1"
+    assert worker_snapshots[0].domain == ThrottleDomain.CHAT.value
+    assert worker_snapshots[0].effective_max == 1
+
+
+def test_snapshot_worker_throttle_uses_local_manager_public_snapshot() -> None:
+    throttle_manager = ThrottleManager()
+    throttle_manager.register(
+        provider_name="openai",
+        model_id="gpt-4.1",
+        alias="writer",
+        max_parallel_requests=3,
+    )
+
+    assert throttle_manager.try_acquire(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT) == 0.0
+    throttle_manager.release_rate_limited(
+        provider_name="openai",
+        model_id="gpt-4.1",
+        domain=ThrottleDomain.CHAT,
+        retry_after=0.01,
+    )
+
+    snapshots = ray_backend_module._snapshot_worker_throttle(throttle_manager)
+
+    assert len(snapshots) == 1
+    assert snapshots[0].provider_name == "openai"
+    assert snapshots[0].model_id == "gpt-4.1"
+    assert snapshots[0].domain == ThrottleDomain.CHAT.value
+    assert snapshots[0].current_limit == 2
+    assert snapshots[0].effective_max == 3
+    assert snapshots[0].rate_limit_ceiling == 3
+    assert snapshots[0].consecutive_rate_limits == 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_ray_throttle_proxy_async_paths_do_not_call_ray_get_on_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch, with_remote=True)
+    proxy = create_ray_throttle_manager(fake_ray, RunConfig())
+    proxy.register(
+        provider_name="openai",
+        model_id="gpt-4.1",
+        alias="writer",
+        max_parallel_requests=1,
+    )
+    event_loop_get_calls = 0
+
+    def guarded_get(ref: Any) -> Any:
+        nonlocal event_loop_get_calls
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return fake_ray_get(ref)
+        event_loop_get_calls += 1
+        return fake_ray_get(ref)
+
+    fake_ray.get = guarded_get
+
+    await proxy.acquire_async(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+    await proxy.release_success_async(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+    await proxy.acquire_async(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+    await proxy.release_rate_limited_async(
+        provider_name="openai",
+        model_id="gpt-4.1",
+        domain=ThrottleDomain.CHAT,
+        retry_after=0.01,
+    )
+    await asyncio.sleep(0.02)
+    await proxy.acquire_async(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+    await proxy.release_failure_async(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
+
+    assert event_loop_get_calls == 0
 
 
 def test_ray_backend_exposes_global_throttle_snapshot_in_metrics(


### PR DESCRIPTION
## 📋 Summary

This PR makes Ray-backed provider throttling safe for async model clients by keeping blocking Ray actor waits off the worker event loop. It also routes worker throttle observability through the public throttle snapshot contract so local and proxy-backed throttle state are represented consistently.

## 🔗 Related Issue

Closes #74
Closes #87
Closes #73

## 🔄 Changes

- Add async release methods to the throttle-manager contract and use them from async `ThrottledModelClient` release paths after success, provider rate limits, and failures.
- Update `RayThrottleManagerProxy.acquire_async()` and async release methods to await Ray refs when available, with a bounded executor fallback for non-awaitable refs while preserving sync `ray.get` behavior.
- Convert Ray worker throttle observability to consume public `snapshot()` payloads, including proxy-backed snapshots, instead of reading `ThrottleManager._domains`.
- Extend the fake Ray harness and tests to prove async acquire/release do not call blocking `ray.get` on the event loop and that local/proxy snapshots normalize correctly.

## 🧪 Testing

- [ ] `make test` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A — fake Ray/backend integration coverage only)
- [x] `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/throttling.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py`
- [x] `uv run ruff check --output-format=full packages/data-designer/src/data_designer/integrations/ray/throttling.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py packages/data-designer-engine/src/data_designer/engine/models/clients/throttled.py packages/data-designer-engine/src/data_designer/engine/models/clients/throttle_manager.py packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py`
- [x] `uv run --all-packages --group dev pytest packages/data-designer-engine/tests/engine/models/clients/test_throttled_model_client.py packages/data-designer-engine/tests/engine/models/clients/test_throttle_manager.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py` (138 passed, 1 skipped; existing unknown marker warnings)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A — behavior covered by code/tests)