### PR TITLE
fix(ray): reject non-finite option and telemetry values

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/_validation.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/_validation.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+
+
+def validate_finite_number(
+    field_name: str,
+    value: int | float,
+    *,
+    error_type: type[Exception],
+    error_label: str,
+) -> None:
+    """Raise the module-specific Ray error when a numeric value is not finite."""
+    if not math.isfinite(value):
+        raise error_type(f"{error_label} {field_name} must be finite.")

--- a/packages/data-designer/src/data_designer/integrations/ray/metrics.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/metrics.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass, field
 from typing import Any, TypeAlias
 
+from data_designer.integrations.ray._validation import validate_finite_number
 from data_designer.integrations.ray.errors import RayMetricsError
 
 ModelUsageSummary = dict[str, dict[str, Any]]
@@ -203,6 +204,12 @@ def _coerce_float(payload: Mapping[str, Any], field_name: str, *, default: float
     value = payload.get(field_name, default)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise RayMetricsError(f"Ray metrics field {field_name!r} must be numeric.")
+    validate_finite_number(
+        repr(field_name),
+        value,
+        error_type=RayMetricsError,
+        error_label="Ray metrics field",
+    )
     return float(value)
 
 
@@ -247,6 +254,12 @@ def _validate_non_negative_int(field_name: str, value: int) -> None:
 def _validate_non_negative_float(field_name: str, value: float) -> None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise RayMetricsError(f"Ray metrics field {field_name!r} must be numeric.")
+    validate_finite_number(
+        repr(field_name),
+        value,
+        error_type=RayMetricsError,
+        error_label="Ray metrics field",
+    )
     if value < 0:
         raise RayMetricsError(f"Ray metrics field {field_name!r} must be non-negative.")
 

--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, TypeAlias
 
+from data_designer.integrations.ray._validation import validate_finite_number
 from data_designer.integrations.ray.errors import RayMetricsError
 
 ModelUsageSummary = dict[str, dict[str, Any]]
@@ -258,6 +259,12 @@ def _coerce_float(payload: Mapping[str, Any], field_name: str, *, default: float
     value = payload.get(field_name, default)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise RayMetricsError(f"Ray observability field {field_name!r} must be numeric.")
+    validate_finite_number(
+        repr(field_name),
+        value,
+        error_type=RayMetricsError,
+        error_label="Ray observability field",
+    )
     return float(value)
 
 
@@ -335,5 +342,11 @@ def _validate_non_negative_int(field_name: str, value: int) -> None:
 def _validate_non_negative_float(field_name: str, value: float) -> None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise RayMetricsError(f"Ray observability field {field_name!r} must be numeric.")
+    validate_finite_number(
+        repr(field_name),
+        value,
+        error_type=RayMetricsError,
+        error_label="Ray observability field",
+    )
     if value < 0:
         raise RayMetricsError(f"Ray observability field {field_name!r} must be non-negative.")

--- a/packages/data-designer/src/data_designer/integrations/ray/options.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/options.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from data_designer.integrations.ray._validation import validate_finite_number
 from data_designer.integrations.ray.errors import RayBackendConfigurationError
 
 RayMapConcurrency = int | tuple[int, int] | tuple[int, int, int]
@@ -213,14 +214,20 @@ def _validate_optional_positive_int(field_name: str, value: int | None) -> None:
 def _validate_optional_non_negative_number(field_name: str, value: float | None) -> None:
     if value is None:
         return
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RayBackendConfigurationError(f"Ray option {field_name} must be a non-negative number.")
+    validate_finite_number(field_name, value, error_type=RayBackendConfigurationError, error_label="Ray option")
+    if value < 0:
         raise RayBackendConfigurationError(f"Ray option {field_name} must be a non-negative number.")
 
 
 def _validate_optional_positive_number(field_name: str, value: float | None) -> None:
     if value is None:
         return
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RayBackendConfigurationError(f"Ray option {field_name} must be a positive number.")
+    validate_finite_number(field_name, value, error_type=RayBackendConfigurationError, error_label="Ray option")
+    if value <= 0:
         raise RayBackendConfigurationError(f"Ray option {field_name} must be a positive number.")
 
 

--- a/packages/data-designer/tests/integrations/ray/test_metrics.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics.py
@@ -80,6 +80,12 @@ def test_normalize_ray_worker_metrics_uses_serializable_mapping_defaults() -> No
     assert metrics == RayWorkerMetrics(total_rows=3, output_rows=3, blocks=1)
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_normalize_ray_worker_metrics_rejects_non_finite_elapsed_seconds(value: float) -> None:
+    with pytest.raises(RayMetricsError, match="elapsed_seconds.*finite"):
+        normalize_ray_worker_metrics({"total_rows": 3, "elapsed_seconds": value})
+
+
 def test_aggregate_ray_metrics_sums_row_outcomes() -> None:
     metrics = aggregate_ray_metrics(
         [

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -15,9 +15,11 @@ from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.integrations.ray import (
     RayDatasetCreationResults,
     RayDatasetMetrics,
+    RayMetricsError,
     RayThrottleSnapshot,
     RayTraceEvent,
     RayWorkerProfile,
+    normalize_ray_trace_event,
 )
 from data_designer.integrations.ray import backend as ray_backend_module
 
@@ -109,3 +111,15 @@ def test_ray_results_load_analysis_returns_none_without_observability_payload(
     )
 
     assert results.load_analysis() is None
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_normalize_ray_trace_event_rejects_non_finite_timestamp_seconds(value: float) -> None:
+    with pytest.raises(RayMetricsError, match="timestamp_seconds.*finite"):
+        normalize_ray_trace_event(
+            {
+                "block_id": "block-a",
+                "event_type": "block_started",
+                "timestamp_seconds": value,
+            }
+        )

--- a/packages/data-designer/tests/integrations/ray/test_options.py
+++ b/packages/data-designer/tests/integrations/ray/test_options.py
@@ -48,6 +48,18 @@ def test_ray_execution_options_rejects_duplicate_explicit_remote_args() -> None:
         RayExecutionOptions(num_cpus=0.5, ray_remote_args={"num_cpus": 1})
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_ray_execution_options_rejects_non_finite_numeric_options(value: float) -> None:
+    with pytest.raises(RayBackendConfigurationError, match="num_cpus.*finite"):
+        RayExecutionOptions(num_cpus=value)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_ray_execution_options_rejects_non_finite_resources(value: float) -> None:
+    with pytest.raises(RayBackendConfigurationError, match=r"resources\['gpu_slice'\].*finite"):
+        RayExecutionOptions(resources={"gpu_slice": value})
+
+
 def test_ray_execution_options_rejects_actor_pool_with_concurrency() -> None:
     with pytest.raises(RayBackendConfigurationError, match="use_actor_pool"):
         RayExecutionOptions(use_actor_pool=True, concurrency=2)


### PR DESCRIPTION
## 📋 Summary
Reject `NaN`, positive infinity, and negative infinity in Ray execution option/resource validation and Ray metrics/observability float normalization. This keeps invalid non-finite numeric payloads from reaching Ray backend configuration, metrics aggregation, or trace analysis paths.

## 🔗 Related Issue
Fixes #78

## 🔄 Changes
- Added a shared Ray integration finite-number validator used by options, metrics, and observability modules.
- Updated `RayExecutionOptions` numeric option/resource validation to raise `RayBackendConfigurationError` for non-finite values.
- Updated Ray metrics and trace float coercion/validation to raise `RayMetricsError` for non-finite telemetry values.
- Added regression coverage for non-finite execution options, metrics payloads, and trace payloads.

## 🧪 Testing
- [ ] `make test` passes (not run; targeted tests run instead)
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A — no E2E surface changed)

Targeted checks:
- [x] `uv run --all-packages --group dev pytest packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_observability.py`
- [x] `uv run ruff check --output-format=full packages/data-designer/src/data_designer/integrations/ray/_validation.py packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/metrics.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_observability.py`
- [x] `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/_validation.py packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/metrics.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_observability.py`

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A — validation-only Ray integration fix)
