### PR TITLE
refactor(ray): isolate seed planning

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -14,26 +14,21 @@ import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import CustomColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.run_config import RunConfig
-from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy, SeedConfig
-from data_designer.config.seed_source_dataframe import DataFrameSeedSource
+from data_designer.config.seed import SeedConfig
 from data_designer.engine.column_generators.utils.generator_classification import column_type_is_model_generated
 from data_designer.engine.dataset_builders.block_execution import BlockExecutionOptions, execute_dataset_block
 from data_designer.engine.resources.person_reader import PersonReader
-from data_designer.engine.resources.seed_reader import (
-    DataFrameSeedReader,
-    FileSystemSeedReader,
-    SeedReader,
-    SeedReaderRegistry,
-)
+from data_designer.engine.resources.seed_reader import SeedReader
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
+from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import (
     RayDatasetMetrics,
@@ -62,7 +57,6 @@ if TYPE_CHECKING:
 
 RayOutputMode = Literal["dataset", "arrow_refs"]
 RayObjectRefInputFormat = Literal["arrow", "pandas"]
-_RAY_RANGE_ID_COLUMN = "id"
 _RAY_INTERNAL_ROW_ID_COLUMN = "__data_designer_ray_row_id"
 
 
@@ -80,17 +74,11 @@ class _RayWorkerOptions:
 
 
 @dataclass(frozen=True)
-class _RaySeedWindow:
-    start: int
-    size: int
-
-
-@dataclass(frozen=True)
 class _RayExecutionPayload:
     config_json: str
     worker_options: _RayWorkerOptions
     use_input_dataset: bool
-    seed_window: _RaySeedWindow | None = None
+    seed_window: ray_seed_planning.RaySeedWindow | None = None
     seed_config: SeedConfig | None = None
     hidden_order_column: str | None = None
 
@@ -384,23 +372,18 @@ class RayBackend:
                 "range dataset. Remove override_num_blocks, target_block_size, min_blocks, max_blocks, "
                 "and read_concurrency when passing input_dataset."
             )
-        seed_window: _RaySeedWindow | None = None
+        seed_window: ray_seed_planning.RaySeedWindow | None = None
         if not use_input_dataset and seed_config is not None:
-            if _should_materialize_seed_on_driver(runtime_context=runtime_context, seed_config=seed_config):
-                input_dataset = ray.data.from_pandas(
-                    _materialize_seed_dataframe(
-                        runtime_context=runtime_context,
-                        seed_config=seed_config,
-                        num_records=num_records,
-                    )
-                )
+            seed_plan = ray_seed_planning.plan_seed_execution(
+                runtime_context=runtime_context,
+                seed_config=seed_config,
+                num_records=num_records,
+            )
+            if seed_plan.input_dataframe is not None:
+                input_dataset = ray.data.from_pandas(seed_plan.input_dataframe)
                 use_input_dataset = True
             else:
-                seed_window = _preflight_seed_window(
-                    runtime_context=runtime_context,
-                    seed_config=seed_config,
-                    num_records=num_records,
-                )
+                seed_window = seed_plan.seed_window
         if not self.allow_unsafe_processors:
             validate_ray_safe_processors(config_builder)
 
@@ -437,9 +420,9 @@ class RayBackend:
             worker_model_health_checks=self.worker_model_health_checks,
         )
         worker_seed_readers = (
-            [DataFrameSeedReader()]
+            ray_seed_planning.input_dataset_seed_readers()
             if use_input_dataset
-            else _clone_seed_readers_for_worker(runtime_context.seed_readers)
+            else ray_seed_planning.clone_seed_readers_for_worker(runtime_context.seed_readers)
         )
         worker_options = _RayWorkerOptions(
             model_providers=list(runtime_context.model_providers),
@@ -689,123 +672,6 @@ def _clone_config_builder_for_worker(
     return worker_config_builder
 
 
-def _preflight_seed_window(
-    *,
-    runtime_context: BackendRuntimeContext,
-    seed_config: SeedConfig,
-    num_records: int,
-) -> _RaySeedWindow:
-    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
-        raise RayBackendConfigurationError(
-            "RayBackend seed configs without input_dataset currently support only ordered sampling. "
-            "Pass the seed data as input_dataset or use the local backend for shuffled seed sampling."
-        )
-
-    try:
-        seed_reader = runtime_context.create_seed_reader_registry(
-            seed_readers=_clone_seed_readers_for_worker(runtime_context.seed_readers)
-        ).get_reader(seed_config.source, runtime_context.secret_resolver)
-        seed_dataset_size = seed_reader.get_seed_dataset_size()
-        index_range = _resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
-    except RayBackendConfigurationError:
-        raise
-    except Exception as exc:
-        raise RayBackendConfigurationError(
-            "RayBackend failed to preflight the seed config for partition offsets."
-        ) from exc
-
-    if num_records > index_range.size:
-        raise RayBackendConfigurationError(
-            "RayBackend seed configs without input_dataset require num_records to fit inside the selected seed "
-            f"range. Requested {num_records} records from {index_range.size} selected seed rows."
-        )
-    return _RaySeedWindow(start=index_range.start, size=index_range.size)
-
-
-def _should_materialize_seed_on_driver(*, runtime_context: BackendRuntimeContext, seed_config: SeedConfig) -> bool:
-    """Return whether Ray should treat a seed source as a materialized input dataset."""
-    try:
-        seed_reader = runtime_context.create_seed_reader_registry(
-            seed_readers=_clone_seed_readers_for_worker(runtime_context.seed_readers)
-        ).get_reader(seed_config.source, runtime_context.secret_resolver)
-    except Exception as exc:
-        raise RayBackendConfigurationError("RayBackend failed to inspect the seed reader for Ray planning.") from exc
-    return isinstance(seed_reader, FileSystemSeedReader)
-
-
-def _materialize_seed_dataframe(
-    *,
-    runtime_context: BackendRuntimeContext,
-    seed_config: SeedConfig,
-    num_records: int,
-) -> Any:
-    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
-        raise RayBackendConfigurationError(
-            "RayBackend driver-materialized filesystem seed configs currently support only ordered sampling. "
-            "Pass the seed data as input_dataset or use the local backend for shuffled seed sampling."
-        )
-
-    try:
-        seed_reader = runtime_context.create_seed_reader_registry(
-            seed_readers=_clone_seed_readers_for_worker(runtime_context.seed_readers)
-        ).get_reader(seed_config.source, runtime_context.secret_resolver)
-        seed_dataset_size = seed_reader.get_seed_dataset_size()
-        index_range = _resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
-    except RayBackendConfigurationError:
-        raise
-    except Exception as exc:
-        raise RayBackendConfigurationError("RayBackend failed to materialize the seed config for Ray input.") from exc
-
-    batch_reader = seed_reader.create_batch_reader(batch_size=num_records, index_range=index_range, shuffle=False)
-    output = lazy.pd.DataFrame()
-    empty_batch_reads = 0
-    while len(output) < num_records:
-        try:
-            seed_batch = batch_reader.read_next_batch().to_pandas().reset_index(drop=True)
-        except StopIteration:
-            batch_reader = seed_reader.create_batch_reader(
-                batch_size=num_records,
-                index_range=index_range,
-                shuffle=False,
-            )
-            continue
-
-        if len(seed_batch) == 0:
-            empty_batch_reads += 1
-            if empty_batch_reads > max(num_records * 2, 1):
-                raise RayBackendConfigurationError(
-                    "RayBackend filesystem seed materialization did not produce any rows after repeated reads."
-                )
-            continue
-        output = lazy.pd.concat([output, seed_batch], ignore_index=True)
-
-    return output.iloc[:num_records].reset_index(drop=True)
-
-
-def _resolve_seed_config_index_range(*, seed_config: SeedConfig, seed_dataset_size: int) -> IndexRange:
-    if seed_dataset_size <= 0:
-        raise RayBackendConfigurationError("RayBackend seed config resolved to an empty seed dataset.")
-    if seed_config.selection_strategy is None:
-        return IndexRange(start=0, end=seed_dataset_size - 1)
-    if isinstance(seed_config.selection_strategy, IndexRange):
-        if seed_config.selection_strategy.end >= seed_dataset_size:
-            raise RayBackendConfigurationError(
-                "RayBackend seed config selection_strategy is out of bounds for the seed dataset. "
-                f"Selection end={seed_config.selection_strategy.end}, seed rows={seed_dataset_size}."
-            )
-        return seed_config.selection_strategy
-    if isinstance(seed_config.selection_strategy, PartitionBlock):
-        if seed_config.selection_strategy.num_partitions > seed_dataset_size:
-            raise RayBackendConfigurationError(
-                "RayBackend seed config selection_strategy is out of bounds for the seed dataset. "
-                f"Partition count={seed_config.selection_strategy.num_partitions}, seed rows={seed_dataset_size}."
-            )
-        return seed_config.selection_strategy.to_index_range(seed_dataset_size)
-    raise RayBackendConfigurationError(
-        "RayBackend seed config uses an unsupported selection_strategy for partitioned execution."
-    )
-
-
 def _get_num_blocks(dataset: Any) -> int | None:
     num_blocks = getattr(dataset, "num_blocks", None)
     if not callable(num_blocks):
@@ -851,11 +717,11 @@ def _attach_hidden_row_id_column(ray: Any, dataset: Any, *, hidden_order_column:
 
 def _rename_range_id_column(batch: Any, *, hidden_order_column: str) -> Any:
     dataframe = _coerce_pandas_dataframe(batch)
-    if _RAY_RANGE_ID_COLUMN not in dataframe.columns:
+    if ray_seed_planning.RAY_RANGE_ID_COLUMN not in dataframe.columns:
         raise RayDatasetGenerationError(
-            f"RayBackend expected ray.data.range() batches to include {_RAY_RANGE_ID_COLUMN!r}."
+            f"RayBackend expected ray.data.range() batches to include {ray_seed_planning.RAY_RANGE_ID_COLUMN!r}."
         )
-    return lazy.pd.DataFrame({hidden_order_column: dataframe[_RAY_RANGE_ID_COLUMN].tolist()})
+    return lazy.pd.DataFrame({hidden_order_column: dataframe[ray_seed_planning.RAY_RANGE_ID_COLUMN].tolist()})
 
 
 def _dataset_from_arrow_refs(ray: Any, refs: list[Any]) -> Any:
@@ -900,7 +766,7 @@ def _compile_ray_execution_payload(
     config_builder: DataDesignerConfigBuilder,
     worker_options: _RayWorkerOptions,
     use_input_dataset: bool,
-    seed_window: _RaySeedWindow | None = None,
+    seed_window: ray_seed_planning.RaySeedWindow | None = None,
     hidden_order_column: str | None = None,
 ) -> _RayExecutionPayload:
     data_designer_config = config_builder.build()
@@ -1012,24 +878,6 @@ def _merge_driver_and_worker_metrics(
     )
 
 
-def _clone_seed_readers_for_worker(readers: Iterable[SeedReader]) -> list[SeedReader]:
-    clones = [_clone_seed_reader_for_worker(reader) for reader in readers]
-    seed_types = {reader.get_seed_type() for reader in clones}
-    dataframe_reader = DataFrameSeedReader()
-    if dataframe_reader.get_seed_type() not in seed_types:
-        clones.append(dataframe_reader)
-    return clones
-
-
-def _clone_seed_reader_for_worker(reader: SeedReader) -> SeedReader:
-    clone = copy.copy(reader)
-    clone._reset_attachment_state()
-    for attr in ("source", "secret_resolver"):
-        if hasattr(clone, attr):
-            delattr(clone, attr)
-    return clone
-
-
 class _RayBatchWorker:
     def __init__(
         self,
@@ -1048,10 +896,8 @@ class _RayBatchWorker:
         if self._observability_options.trace_enabled:
             run_config.async_trace = True
         seed_readers = copy.deepcopy(worker_options.seed_readers)
-        dataframe_seed_reader = DataFrameSeedReader()
-        seed_types = {reader.get_seed_type() for reader in seed_readers}
-        if execution_payload.use_input_dataset and dataframe_seed_reader.get_seed_type() not in seed_types:
-            seed_readers.append(dataframe_seed_reader)
+        if execution_payload.use_input_dataset:
+            seed_readers = ray_seed_planning.ensure_dataframe_seed_reader(seed_readers)
         self._worker_options: _RayWorkerOptions = replace(
             worker_options,
             seed_readers=seed_readers,
@@ -1281,15 +1127,12 @@ class _RayBatchWorker:
         if self._execution_payload.seed_window is not None:
             if self._execution_payload.seed_config is None:
                 raise RayDatasetGenerationError("RayBackend seed window was provided without a seed config.")
-            block_config.seed_config = SeedConfig(
-                source=DataFrameSeedSource(
-                    df=_read_seed_window_dataframe(
-                        seed_config=self._execution_payload.seed_config,
-                        worker_options=self._worker_options,
-                        dataframe=dataframe,
-                        seed_window=self._execution_payload.seed_window,
-                    )
-                )
+            block_config.seed_config = ray_seed_planning.create_seed_config_for_window(
+                seed_config=self._execution_payload.seed_config,
+                seed_readers=self._worker_options.seed_readers,
+                secret_resolver=self._worker_options.secret_resolver,
+                dataframe=dataframe,
+                seed_window=self._execution_payload.seed_window,
             )
         return block_config
 
@@ -1301,7 +1144,7 @@ def _generate_batch(
     config_builder: DataDesignerConfigBuilder | None = None,
     worker_options: _RayWorkerOptions | None = None,
     use_input_dataset: bool | None = None,
-    seed_window: _RaySeedWindow | None = None,
+    seed_window: ray_seed_planning.RaySeedWindow | None = None,
     hidden_order_column: str | None = None,
     metrics_collector: Any | None = None,
     observability_options: _RayObservabilityOptions | None = None,
@@ -1336,8 +1179,8 @@ def _get_hidden_order_values(dataframe: Any, *, hidden_order_column: str | None)
         return []
     if hidden_order_column in dataframe.columns:
         values = dataframe[hidden_order_column].tolist()
-    elif _RAY_RANGE_ID_COLUMN in dataframe.columns:
-        values = dataframe[_RAY_RANGE_ID_COLUMN].tolist()
+    elif ray_seed_planning.RAY_RANGE_ID_COLUMN in dataframe.columns:
+        values = dataframe[ray_seed_planning.RAY_RANGE_ID_COLUMN].tolist()
     else:
         raise RayDatasetGenerationError(
             "RayBackend preserve_order=True could not find the hidden row-id source column in a Ray worker batch."
@@ -1383,67 +1226,14 @@ def _metrics_from_block_result(
     )
 
 
-def _read_seed_window_dataframe(
-    *,
-    seed_config: SeedConfig,
-    worker_options: _RayWorkerOptions,
-    dataframe: Any,
-    seed_window: _RaySeedWindow,
-) -> Any:
-    row_offsets = _get_contiguous_range_offsets(dataframe)
-    index_range = IndexRange(
-        start=seed_window.start + row_offsets[0],
-        end=seed_window.start + row_offsets[-1],
-    )
-    if row_offsets[-1] >= seed_window.size:
-        raise RayDatasetGenerationError(
-            "RayBackend seed partition offset exceeded the selected seed range. "
-            f"Offset={row_offsets[-1]}, selected seed rows={seed_window.size}."
-        )
-
-    seed_reader = SeedReaderRegistry(readers=copy.deepcopy(worker_options.seed_readers)).get_reader(
-        seed_config.source,
-        worker_options.secret_resolver,
-    )
-    batch_reader = seed_reader.create_batch_reader(
-        batch_size=len(row_offsets),
-        index_range=index_range,
-        shuffle=False,
-    )
-    seed_dataframe = batch_reader.read_next_batch().to_pandas().reset_index(drop=True)
-    if len(seed_dataframe) != len(row_offsets):
-        raise RayDatasetGenerationError(
-            "RayBackend seed reader returned an unexpected row count for a partition offset. "
-            f"Expected {len(row_offsets)} rows, got {len(seed_dataframe)}."
-        )
-    return seed_dataframe
-
-
-def _get_contiguous_range_offsets(dataframe: Any) -> list[int]:
-    if _RAY_RANGE_ID_COLUMN not in dataframe.columns:
-        raise RayDatasetGenerationError(
-            f"RayBackend seed partition offsets require {_RAY_RANGE_ID_COLUMN!r} from ray.data.range()."
-        )
-    row_offsets = [int(value) for value in dataframe[_RAY_RANGE_ID_COLUMN].tolist()]
-    if not row_offsets:
-        raise RayDatasetGenerationError("RayBackend seed partition offsets received an empty Ray worker batch.")
-    expected_offsets = list(range(row_offsets[0], row_offsets[0] + len(row_offsets)))
-    if row_offsets != expected_offsets:
-        raise RayDatasetGenerationError(
-            "RayBackend seed partition offsets require contiguous ray.data.range() batches. "
-            f"Received offsets {row_offsets!r}."
-        )
-    return row_offsets
-
-
 def _format_worker_failure_message(*, dataframe: Any, exc: Exception) -> str:
     context_parts = [f"{len(dataframe)} input row(s)"]
     if _RAY_INTERNAL_ROW_ID_COLUMN in dataframe.columns:
         row_ids = [int(value) for value in dataframe[_RAY_INTERNAL_ROW_ID_COLUMN].tolist()]
         if row_ids:
             context_parts.append(f"logical rows {min(row_ids)}-{max(row_ids)}")
-    elif _RAY_RANGE_ID_COLUMN in dataframe.columns:
-        row_ids = [int(value) for value in dataframe[_RAY_RANGE_ID_COLUMN].tolist()]
+    elif ray_seed_planning.RAY_RANGE_ID_COLUMN in dataframe.columns:
+        row_ids = [int(value) for value in dataframe[ray_seed_planning.RAY_RANGE_ID_COLUMN].tolist()]
         if row_ids:
             context_parts.append(f"range rows {min(row_ids)}-{max(row_ids)}")
     task_context = _get_ray_task_context()

--- a/packages/data-designer/src/data_designer/integrations/ray/seed_planning.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/seed_planning.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy, SeedConfig
+from data_designer.config.seed_source_dataframe import DataFrameSeedSource
+from data_designer.engine.resources.seed_reader import (
+    DataFrameSeedReader,
+    FileSystemSeedReader,
+    SeedReader,
+    SeedReaderRegistry,
+)
+from data_designer.engine.secret_resolver import SecretResolver
+from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
+from data_designer.interface.backends import BackendRuntimeContext
+
+RAY_RANGE_ID_COLUMN = "id"
+
+
+@dataclass(frozen=True)
+class RaySeedWindow:
+    start: int
+    size: int
+
+
+@dataclass(frozen=True)
+class RaySeedPlan:
+    input_dataframe: Any | None = None
+    seed_window: RaySeedWindow | None = None
+
+
+def plan_seed_execution(
+    *,
+    runtime_context: BackendRuntimeContext,
+    seed_config: SeedConfig,
+    num_records: int,
+) -> RaySeedPlan:
+    if should_materialize_seed_on_driver(runtime_context=runtime_context, seed_config=seed_config):
+        return RaySeedPlan(
+            input_dataframe=materialize_seed_dataframe(
+                runtime_context=runtime_context,
+                seed_config=seed_config,
+                num_records=num_records,
+            )
+        )
+    return RaySeedPlan(
+        seed_window=preflight_seed_window(
+            runtime_context=runtime_context,
+            seed_config=seed_config,
+            num_records=num_records,
+        )
+    )
+
+
+def preflight_seed_window(
+    *,
+    runtime_context: BackendRuntimeContext,
+    seed_config: SeedConfig,
+    num_records: int,
+) -> RaySeedWindow:
+    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
+        raise RayBackendConfigurationError(
+            "RayBackend seed configs without input_dataset currently support only ordered sampling. "
+            "Pass the seed data as input_dataset or use the local backend for shuffled seed sampling."
+        )
+
+    try:
+        seed_reader = _get_detached_seed_reader(runtime_context=runtime_context, seed_config=seed_config)
+        seed_dataset_size = seed_reader.get_seed_dataset_size()
+        index_range = resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayBackendConfigurationError(
+            "RayBackend failed to preflight the seed config for partition offsets."
+        ) from exc
+
+    if num_records > index_range.size:
+        raise RayBackendConfigurationError(
+            "RayBackend seed configs without input_dataset require num_records to fit inside the selected seed "
+            f"range. Requested {num_records} records from {index_range.size} selected seed rows."
+        )
+    return RaySeedWindow(start=index_range.start, size=index_range.size)
+
+
+def should_materialize_seed_on_driver(*, runtime_context: BackendRuntimeContext, seed_config: SeedConfig) -> bool:
+    """Return whether Ray should treat a seed source as a materialized input dataset."""
+    try:
+        seed_reader = _get_detached_seed_reader(runtime_context=runtime_context, seed_config=seed_config)
+    except Exception as exc:
+        raise RayBackendConfigurationError("RayBackend failed to inspect the seed reader for Ray planning.") from exc
+    return isinstance(seed_reader, FileSystemSeedReader)
+
+
+def materialize_seed_dataframe(
+    *,
+    runtime_context: BackendRuntimeContext,
+    seed_config: SeedConfig,
+    num_records: int,
+) -> Any:
+    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
+        raise RayBackendConfigurationError(
+            "RayBackend driver-materialized filesystem seed configs currently support only ordered sampling. "
+            "Pass the seed data as input_dataset or use the local backend for shuffled seed sampling."
+        )
+
+    try:
+        seed_reader = _get_detached_seed_reader(runtime_context=runtime_context, seed_config=seed_config)
+        seed_dataset_size = seed_reader.get_seed_dataset_size()
+        index_range = resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayBackendConfigurationError("RayBackend failed to materialize the seed config for Ray input.") from exc
+
+    batch_reader = seed_reader.create_batch_reader(batch_size=num_records, index_range=index_range, shuffle=False)
+    output = lazy.pd.DataFrame()
+    empty_batch_reads = 0
+    while len(output) < num_records:
+        try:
+            seed_batch = batch_reader.read_next_batch().to_pandas().reset_index(drop=True)
+        except StopIteration:
+            batch_reader = seed_reader.create_batch_reader(
+                batch_size=num_records,
+                index_range=index_range,
+                shuffle=False,
+            )
+            continue
+
+        if len(seed_batch) == 0:
+            empty_batch_reads += 1
+            if empty_batch_reads > max(num_records * 2, 1):
+                raise RayBackendConfigurationError(
+                    "RayBackend filesystem seed materialization did not produce any rows after repeated reads."
+                )
+            continue
+        output = lazy.pd.concat([output, seed_batch], ignore_index=True)
+
+    return output.iloc[:num_records].reset_index(drop=True)
+
+
+def resolve_seed_config_index_range(*, seed_config: SeedConfig, seed_dataset_size: int) -> IndexRange:
+    if seed_dataset_size <= 0:
+        raise RayBackendConfigurationError("RayBackend seed config resolved to an empty seed dataset.")
+    if seed_config.selection_strategy is None:
+        return IndexRange(start=0, end=seed_dataset_size - 1)
+    if isinstance(seed_config.selection_strategy, IndexRange):
+        if seed_config.selection_strategy.end >= seed_dataset_size:
+            raise RayBackendConfigurationError(
+                "RayBackend seed config selection_strategy is out of bounds for the seed dataset. "
+                f"Selection end={seed_config.selection_strategy.end}, seed rows={seed_dataset_size}."
+            )
+        return seed_config.selection_strategy
+    if isinstance(seed_config.selection_strategy, PartitionBlock):
+        if seed_config.selection_strategy.num_partitions > seed_dataset_size:
+            raise RayBackendConfigurationError(
+                "RayBackend seed config selection_strategy is out of bounds for the seed dataset. "
+                f"Partition count={seed_config.selection_strategy.num_partitions}, seed rows={seed_dataset_size}."
+            )
+        return seed_config.selection_strategy.to_index_range(seed_dataset_size)
+    raise RayBackendConfigurationError(
+        "RayBackend seed config uses an unsupported selection_strategy for partitioned execution."
+    )
+
+
+def input_dataset_seed_readers() -> list[SeedReader]:
+    return [DataFrameSeedReader()]
+
+
+def clone_seed_readers_for_worker(readers: Iterable[SeedReader]) -> list[SeedReader]:
+    clones = [_clone_seed_reader_for_worker(reader) for reader in readers]
+    return ensure_dataframe_seed_reader(clones)
+
+
+def ensure_dataframe_seed_reader(readers: Sequence[SeedReader]) -> list[SeedReader]:
+    seed_readers = list(readers)
+    seed_types = {reader.get_seed_type() for reader in seed_readers}
+    dataframe_reader = DataFrameSeedReader()
+    if dataframe_reader.get_seed_type() not in seed_types:
+        seed_readers.append(dataframe_reader)
+    return seed_readers
+
+
+def create_seed_config_for_window(
+    *,
+    seed_config: SeedConfig,
+    seed_readers: Sequence[SeedReader],
+    secret_resolver: SecretResolver,
+    dataframe: Any,
+    seed_window: RaySeedWindow,
+    range_id_column: str = RAY_RANGE_ID_COLUMN,
+) -> SeedConfig:
+    return SeedConfig(
+        source=DataFrameSeedSource(
+            df=read_seed_window_dataframe(
+                seed_config=seed_config,
+                seed_readers=seed_readers,
+                secret_resolver=secret_resolver,
+                dataframe=dataframe,
+                seed_window=seed_window,
+                range_id_column=range_id_column,
+            )
+        )
+    )
+
+
+def read_seed_window_dataframe(
+    *,
+    seed_config: SeedConfig,
+    seed_readers: Sequence[SeedReader],
+    secret_resolver: SecretResolver,
+    dataframe: Any,
+    seed_window: RaySeedWindow,
+    range_id_column: str = RAY_RANGE_ID_COLUMN,
+) -> Any:
+    row_offsets = get_contiguous_range_offsets(dataframe, range_id_column=range_id_column)
+    index_range = IndexRange(
+        start=seed_window.start + row_offsets[0],
+        end=seed_window.start + row_offsets[-1],
+    )
+    if row_offsets[-1] >= seed_window.size:
+        raise RayDatasetGenerationError(
+            "RayBackend seed partition offset exceeded the selected seed range. "
+            f"Offset={row_offsets[-1]}, selected seed rows={seed_window.size}."
+        )
+
+    seed_reader = _create_seed_reader(
+        seed_readers=copy.deepcopy(seed_readers),
+        seed_config=seed_config,
+        secret_resolver=secret_resolver,
+    )
+    batch_reader = seed_reader.create_batch_reader(
+        batch_size=len(row_offsets),
+        index_range=index_range,
+        shuffle=False,
+    )
+    seed_dataframe = batch_reader.read_next_batch().to_pandas().reset_index(drop=True)
+    if len(seed_dataframe) != len(row_offsets):
+        raise RayDatasetGenerationError(
+            "RayBackend seed reader returned an unexpected row count for a partition offset. "
+            f"Expected {len(row_offsets)} rows, got {len(seed_dataframe)}."
+        )
+    return seed_dataframe
+
+
+def get_contiguous_range_offsets(dataframe: Any, *, range_id_column: str = RAY_RANGE_ID_COLUMN) -> list[int]:
+    if range_id_column not in dataframe.columns:
+        raise RayDatasetGenerationError(
+            f"RayBackend seed partition offsets require {range_id_column!r} from ray.data.range()."
+        )
+    row_offsets = [int(value) for value in dataframe[range_id_column].tolist()]
+    if not row_offsets:
+        raise RayDatasetGenerationError("RayBackend seed partition offsets received an empty Ray worker batch.")
+    expected_offsets = list(range(row_offsets[0], row_offsets[0] + len(row_offsets)))
+    if row_offsets != expected_offsets:
+        raise RayDatasetGenerationError(
+            "RayBackend seed partition offsets require contiguous ray.data.range() batches. "
+            f"Received offsets {row_offsets!r}."
+        )
+    return row_offsets
+
+
+def _get_detached_seed_reader(*, runtime_context: BackendRuntimeContext, seed_config: SeedConfig) -> SeedReader:
+    return _create_seed_reader(
+        seed_readers=clone_seed_readers_for_worker(runtime_context.seed_readers),
+        seed_config=seed_config,
+        secret_resolver=runtime_context.secret_resolver,
+        runtime_context=runtime_context,
+    )
+
+
+def _create_seed_reader(
+    *,
+    seed_readers: Sequence[SeedReader],
+    seed_config: SeedConfig,
+    secret_resolver: SecretResolver,
+    runtime_context: BackendRuntimeContext | None = None,
+) -> SeedReader:
+    if runtime_context is not None:
+        registry = runtime_context.create_seed_reader_registry(seed_readers=seed_readers)
+    else:
+        registry = SeedReaderRegistry(readers=seed_readers)
+    return registry.get_reader(seed_config.source, secret_resolver)
+
+
+def _clone_seed_reader_for_worker(reader: SeedReader) -> SeedReader:
+    clone = copy.copy(reader)
+    # Compatibility shim: SeedReader currently has no public detached/snapshot
+    # API, but Ray workers must not inherit driver-local attachment state such as
+    # DuckDB connections or attached sources. Replace this with the public engine
+    # lifecycle API when one exists.
+    clone._reset_attachment_state()
+    for attr in ("source", "secret_resolver"):
+        if hasattr(clone, attr):
+            delattr(clone, attr)
+    return clone

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -29,6 +29,7 @@ from data_designer.integrations.ray import (
     RayExecutionOptions,
 )
 from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.interface.data_designer import DataDesigner
 
 pytestmark = pytest.mark.ray_fake
@@ -887,7 +888,7 @@ def test_seed_readers_are_cloned_without_attachment_state() -> None:
     assert reader.get_seed_dataset_size() == 1
     assert getattr(reader, "_duckdb_conn") is not None
 
-    clones = ray_backend_module._clone_seed_readers_for_worker([reader])
+    clones = ray_seed_planning.clone_seed_readers_for_worker([reader])
 
     assert len(clones) == 1
     assert clones[0] is not reader

--- a/packages/data-designer/tests/integrations/ray/test_seed_planning.py
+++ b/packages/data-designer/tests/integrations/ray/test_seed_planning.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy, SeedConfig
+from data_designer.config.seed_source import DirectorySeedSource
+from data_designer.config.seed_source_dataframe import DataFrameSeedSource
+from data_designer.engine.resources.seed_reader import DataFrameSeedReader
+from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.engine.testing.seed_readers import LineFanoutDirectorySeedReader
+from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
+from data_designer.integrations.ray.seed_planning import (
+    RaySeedWindow,
+    clone_seed_readers_for_worker,
+    get_contiguous_range_offsets,
+    plan_seed_execution,
+    read_seed_window_dataframe,
+    resolve_seed_config_index_range,
+)
+from data_designer.interface.data_designer import DataDesigner
+
+pytestmark = [pytest.mark.ray_fake, pytest.mark.ray_worker_boundary]
+
+
+def _managed_assets_path(tmp_path: Path) -> Path:
+    path = tmp_path / "managed-assets"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _runtime_context(
+    *,
+    tmp_path: Path,
+    stub_model_providers: Any,
+    seed_readers: list[Any] | None = None,
+) -> Any:
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        seed_readers=seed_readers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    return designer._create_backend_runtime_context()
+
+
+def test_clone_seed_readers_for_worker_detaches_driver_state() -> None:
+    reader = DataFrameSeedReader()
+    reader.attach(
+        DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [1]})),
+        PlaintextResolver(),
+    )
+    assert reader.get_seed_dataset_size() == 1
+    assert getattr(reader, "_duckdb_conn") is not None
+
+    clone = clone_seed_readers_for_worker([reader])[0]
+
+    assert clone is not reader
+    assert isinstance(clone, DataFrameSeedReader)
+    assert getattr(clone, "_duckdb_conn") is None
+    assert not hasattr(clone, "source")
+    assert not hasattr(clone, "secret_resolver")
+    assert getattr(reader, "_duckdb_conn") is not None
+    assert hasattr(reader, "source")
+    assert hasattr(reader, "secret_resolver")
+
+
+def test_plan_seed_execution_uses_partition_window_for_dataframe_seed(
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    runtime_context = _runtime_context(tmp_path=tmp_path, stub_model_providers=stub_model_providers)
+    seed_config = SeedConfig(
+        source=DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [0, 1, 2, 3, 4]})),
+        selection_strategy=PartitionBlock(index=1, num_partitions=2),
+    )
+
+    seed_plan = plan_seed_execution(runtime_context=runtime_context, seed_config=seed_config, num_records=2)
+
+    assert seed_plan.input_dataframe is None
+    assert seed_plan.seed_window == RaySeedWindow(start=2, size=3)
+
+
+def test_plan_seed_execution_materializes_filesystem_seed_on_driver(
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    seed_dir = tmp_path / "seeds"
+    seed_dir.mkdir()
+    (seed_dir / "a.txt").write_text("alpha\nbeta", encoding="utf-8")
+    (seed_dir / "b.txt").write_text("gamma\ndelta", encoding="utf-8")
+    runtime_context = _runtime_context(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        seed_readers=[LineFanoutDirectorySeedReader()],
+    )
+    seed_config = SeedConfig(source=DirectorySeedSource(path=str(seed_dir), file_pattern="*.txt"))
+
+    seed_plan = plan_seed_execution(runtime_context=runtime_context, seed_config=seed_config, num_records=3)
+
+    assert seed_plan.seed_window is None
+    assert seed_plan.input_dataframe is not None
+    assert seed_plan.input_dataframe.to_dict(orient="records") == [
+        {"relative_path": "a.txt", "line_index": 0, "line": "alpha"},
+        {"relative_path": "a.txt", "line_index": 1, "line": "beta"},
+        {"relative_path": "b.txt", "line_index": 0, "line": "gamma"},
+    ]
+
+
+def test_read_seed_window_dataframe_uses_contiguous_partition_offsets(
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    runtime_context = _runtime_context(tmp_path=tmp_path, stub_model_providers=stub_model_providers)
+    seed_config = SeedConfig(source=DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [10, 11, 12, 13, 14]})))
+
+    seed_df = read_seed_window_dataframe(
+        seed_config=seed_config,
+        seed_readers=clone_seed_readers_for_worker(runtime_context.seed_readers),
+        secret_resolver=runtime_context.secret_resolver,
+        dataframe=lazy.pd.DataFrame({"id": [2, 3]}),
+        seed_window=RaySeedWindow(start=0, size=5),
+    )
+
+    assert seed_df.to_dict(orient="records") == [{"x": 12}, {"x": 13}]
+
+
+def test_seed_window_offsets_reject_missing_or_noncontiguous_range_id() -> None:
+    with pytest.raises(RayDatasetGenerationError, match="'id'"):
+        get_contiguous_range_offsets(lazy.pd.DataFrame({"row": [0]}))
+
+    with pytest.raises(RayDatasetGenerationError, match="contiguous"):
+        get_contiguous_range_offsets(lazy.pd.DataFrame({"id": [0, 2]}))
+
+
+def test_seed_range_resolution_validates_bounds() -> None:
+    seed_config = SeedConfig(
+        source=DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [0]})),
+        selection_strategy=IndexRange(start=0, end=2),
+    )
+
+    with pytest.raises(RayBackendConfigurationError, match="out of bounds"):
+        resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=2)
+
+
+def test_seed_plan_rejects_shuffled_non_input_seed(
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    runtime_context = _runtime_context(tmp_path=tmp_path, stub_model_providers=stub_model_providers)
+    seed_config = SeedConfig(
+        source=DataFrameSeedSource(df=lazy.pd.DataFrame({"x": [0, 1]})),
+        sampling_strategy=SamplingStrategy.SHUFFLE,
+    )
+
+    with pytest.raises(RayBackendConfigurationError, match="ordered sampling"):
+        plan_seed_execution(runtime_context=runtime_context, seed_config=seed_config, num_records=1)

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -23,6 +23,7 @@ from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.interface.data_designer import DataDesigner
 
 pytestmark = [pytest.mark.ray_fake, pytest.mark.ray_worker_boundary]
@@ -87,7 +88,7 @@ def _worker_options_from_designer(data_designer: DataDesigner) -> ray_backend_mo
         model_providers=list(runtime_context.model_providers),
         default_provider_name=runtime_context.default_provider_name,
         secret_resolver=runtime_context.secret_resolver,
-        seed_readers=ray_backend_module._clone_seed_readers_for_worker(runtime_context.seed_readers),
+        seed_readers=ray_seed_planning.clone_seed_readers_for_worker(runtime_context.seed_readers),
         managed_assets_path=str(runtime_context.managed_assets_path),
         person_reader=runtime_context.person_reader,
         mcp_providers=list(runtime_context.mcp_providers),
@@ -104,7 +105,7 @@ def test_seed_reader_worker_clone_removes_attachment_state() -> None:
     assert reader.get_seed_dataset_size() == 1
     assert getattr(reader, "_duckdb_conn") is not None
 
-    clone = ray_backend_module._clone_seed_readers_for_worker([reader])[0]
+    clone = ray_seed_planning.clone_seed_readers_for_worker([reader])[0]
 
     assert clone is not reader
     assert isinstance(clone, DataFrameSeedReader)


### PR DESCRIPTION
## 📋 Summary
Ray seed planning now lives behind a dedicated `seed_planning.py` boundary instead of dense backend orchestration code. The backend delegates driver materialization, partition-window reads, and seed-reader worker snapshots while preserving the block execution, option validation, throttle snapshot, and finite-number validation paths already merged into `feat/ray-backend`.

## 🔗 Related Issue
Closes #61
Refs #81
Refs #82

## 🔄 Changes
- Added `data_designer.integrations.ray.seed_planning` for seed execution planning, driver materialization, partition-offset reads, and seed-reader worker cloning.
- Reduced `backend.py` seed responsibilities to delegation while keeping the PR #95 `execute_dataset_block` path and PR #97 throttle snapshot behavior intact.
- Isolated the remaining private seed-reader detach compatibility shim in one helper with focused tests and a follow-up comment.
- Added focused seed-planning coverage for DataFrame seed windows, filesystem driver materialization, contiguous range offsets, ordered sampling validation, and clone detachment.

## 🧪 Testing
- [ ] `make test` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated: N/A, Ray fake integration coverage only

Focused checks run:
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run --package data-designer pytest packages/data-designer/tests/integrations/ray/test_seed_planning.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_semantics.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_options.py`
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/seed_planning.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_seed_planning.py`
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/seed_planning.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_seed_planning.py`

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated: N/A, internal Ray module boundary only
