### PR TITLE
fix(ray): clarify observability report API

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -1,6 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Stable public imports for the experimental Ray integration.
+
+Low-level telemetry normalizers, metric aggregators, and resolved planning
+internals remain available from their defining modules for tests and advanced
+debugging, but they are intentionally excluded from the package root surface.
+"""
+
 from __future__ import annotations
 
 from data_designer.integrations.ray.backend import RayBackend, RayDatasetCreationResults
@@ -13,22 +20,16 @@ from data_designer.integrations.ray.errors import (
 from data_designer.integrations.ray.metrics import (
     RayDatasetMetrics,
     RayWorkerMetrics,
-    aggregate_ray_metrics,
-    normalize_ray_worker_metrics,
 )
 from data_designer.integrations.ray.observability import (
     RayDatasetAnalysis,
     RayThrottleSnapshot,
     RayTraceEvent,
     RayWorkerProfile,
-    normalize_ray_throttle_snapshot,
-    normalize_ray_trace_event,
-    normalize_ray_worker_profile,
 )
 from data_designer.integrations.ray.options import (
     RayBlockPlanning,
     RayExecutionOptions,
-    RayResolvedBlockPlan,
 )
 
 __all__ = [
@@ -42,14 +43,8 @@ __all__ = [
     "RayExecutionOptions",
     "RayIntegrationError",
     "RayMetricsError",
-    "RayResolvedBlockPlan",
     "RayThrottleSnapshot",
     "RayTraceEvent",
     "RayWorkerMetrics",
     "RayWorkerProfile",
-    "aggregate_ray_metrics",
-    "normalize_ray_throttle_snapshot",
-    "normalize_ray_trace_event",
-    "normalize_ray_worker_metrics",
-    "normalize_ray_worker_profile",
 ]

--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -17,6 +17,17 @@ ModelUsageSummary = dict[str, dict[str, Any]]
 RayTraceEventPayload: TypeAlias = "RayTraceEvent | Mapping[str, Any]"
 RayWorkerProfilePayload: TypeAlias = "RayWorkerProfile | Mapping[str, Any]"
 RayThrottleSnapshotPayload: TypeAlias = "RayThrottleSnapshot | Mapping[str, Any]"
+_RAY_REPORT_SECTION_ALIASES = {
+    "overview": "summary",
+    "summary": "summary",
+    "worker_profiles": "worker_profiles",
+    "profiles": "worker_profiles",
+    "trace_events": "trace_events",
+    "traces": "trace_events",
+    "throttle_snapshots": "throttle_snapshots",
+    "throttles": "throttle_snapshots",
+}
+_RAY_REPORT_SECTIONS = frozenset(_RAY_REPORT_SECTION_ALIASES.values())
 
 
 @dataclass(frozen=True, slots=True)
@@ -143,17 +154,45 @@ class RayDatasetAnalysis:
         return asdict(self)
 
     def to_report(self, save_path: str | Path | None = None, include_sections: list[Any] | None = None) -> None:
-        """Write a compact JSON or HTML report for Ray-native analysis."""
-        del include_sections
+        """Write a compact JSON or HTML report for Ray-native analysis.
+
+        Ray-native reports are bounded worker summaries, not the standard local
+        dataset profiler report. include_sections filters top-level Ray report
+        sections and accepts ``summary``/``overview``, ``worker_profiles``,
+        ``trace_events``, and ``throttle_snapshots``.
+        """
+        sections = _normalize_include_sections(include_sections)
         if save_path is None:
             return
         path = Path(save_path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        payload = json.dumps(self.to_dict(), indent=2, sort_keys=True)
+        payload = json.dumps(self._report_payload(sections), indent=2, sort_keys=True)
         if path.suffix.lower() in {".html", ".htm"}:
             path.write_text(_analysis_payload_to_html(payload), encoding="utf-8")
             return
         path.write_text(f"{payload}\n", encoding="utf-8")
+
+    def _report_payload(self, sections: frozenset[str] | None) -> dict[str, Any]:
+        if sections is None:
+            return self.to_dict()
+        payload: dict[str, Any] = {}
+        if "summary" in sections:
+            payload["summary"] = {
+                "total_rows": self.total_rows,
+                "blocks": self.blocks,
+                "failed_blocks": self.failed_blocks,
+                "successful_blocks": self.successful_blocks,
+                "column_names": self.column_names,
+                "trace_events_dropped": self.trace_events_dropped,
+            }
+        if "worker_profiles" in sections:
+            payload["worker_profiles"] = [profile.to_dict() for profile in self.worker_profiles]
+        if "trace_events" in sections:
+            payload["trace_events"] = [event.to_dict() for event in self.trace_events]
+            payload["trace_events_dropped"] = self.trace_events_dropped
+        if "throttle_snapshots" in sections:
+            payload["throttle_snapshots"] = [snapshot.to_dict() for snapshot in self.throttle_snapshots]
+        return payload
 
 
 def normalize_ray_trace_event(payload: RayTraceEventPayload) -> RayTraceEvent:
@@ -223,6 +262,31 @@ def _analysis_payload_to_html(payload: str) -> str:
         f"{escaped}"
         "</pre></body></html>\n"
     )
+
+
+def _normalize_include_sections(include_sections: list[Any] | None) -> frozenset[str] | None:
+    if include_sections is None:
+        return None
+    sections: set[str] = set()
+    for section in include_sections:
+        section_name = _section_name(section)
+        normalized = _RAY_REPORT_SECTION_ALIASES.get(section_name)
+        if normalized is None:
+            supported = ", ".join(sorted(_RAY_REPORT_SECTIONS))
+            raise RayMetricsError(
+                f"RayDatasetAnalysis.to_report include_sections supports only Ray-native sections: {supported}."
+            )
+        sections.add(normalized)
+    return frozenset(sections)
+
+
+def _section_name(section: Any) -> str:
+    value = getattr(section, "value", section)
+    if not isinstance(value, str):
+        value = getattr(section, "name", section)
+    if not isinstance(value, str):
+        raise RayMetricsError("RayDatasetAnalysis.to_report include_sections values must be strings or enums.")
+    return value.lower()
 
 
 def _coerce_str(payload: Mapping[str, Any], field_name: str) -> str:

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -13,15 +13,16 @@ from fake_ray_harness import FakeActorHandle
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.integrations.ray import (
+    RayDatasetAnalysis,
     RayDatasetCreationResults,
     RayDatasetMetrics,
     RayMetricsError,
     RayThrottleSnapshot,
     RayTraceEvent,
     RayWorkerProfile,
-    normalize_ray_trace_event,
 )
 from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray.observability import normalize_ray_trace_event
 
 pytestmark = pytest.mark.ray_fake
 
@@ -111,6 +112,72 @@ def test_ray_results_load_analysis_returns_none_without_observability_payload(
     )
 
     assert results.load_analysis() is None
+
+
+def test_ray_dataset_analysis_to_report_filters_json_sections(tmp_path: Path) -> None:
+    analysis = RayDatasetAnalysis(
+        total_rows=2,
+        blocks=1,
+        worker_profiles=[RayWorkerProfile(block_id="block-a", total_rows=2, columns=["label"])],
+        trace_events=[RayTraceEvent(block_id="block-a", event_type="block_started", timestamp_seconds=1.0)],
+        trace_events_dropped=3,
+        throttle_snapshots=[
+            RayThrottleSnapshot(provider_name="provider", model_id="model", domain="chat", current_limit=1)
+        ],
+    )
+    report_path = tmp_path / "ray-analysis.json"
+
+    analysis.to_report(report_path, include_sections=["summary", "trace_events"])
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report == {
+        "summary": {
+            "blocks": 1,
+            "column_names": ["label"],
+            "failed_blocks": 0,
+            "successful_blocks": 1,
+            "total_rows": 2,
+            "trace_events_dropped": 3,
+        },
+        "trace_events": [
+            {
+                "block_id": "block-a",
+                "details": None,
+                "elapsed_seconds": 0.0,
+                "event_type": "block_started",
+                "ray_node_id": None,
+                "ray_task_id": None,
+                "row_count": 0,
+                "timestamp_seconds": 1.0,
+                "worker_hostname": None,
+                "worker_pid": None,
+            }
+        ],
+        "trace_events_dropped": 3,
+    }
+
+
+def test_ray_dataset_analysis_to_report_filters_html_sections(tmp_path: Path) -> None:
+    analysis = RayDatasetAnalysis(
+        total_rows=1,
+        blocks=1,
+        worker_profiles=[RayWorkerProfile(block_id="block-a", total_rows=1, columns=["label"])],
+    )
+    report_path = tmp_path / "ray-analysis.html"
+
+    analysis.to_report(report_path, include_sections=["worker_profiles"])
+
+    report = report_path.read_text(encoding="utf-8")
+    assert "&quot;worker_profiles&quot;" in report
+    assert "&quot;summary&quot;" not in report
+    assert "&quot;trace_events&quot;" not in report
+
+
+def test_ray_dataset_analysis_to_report_rejects_unknown_include_section(tmp_path: Path) -> None:
+    analysis = RayDatasetAnalysis()
+
+    with pytest.raises(RayMetricsError, match="Ray-native sections"):
+        analysis.to_report(tmp_path / "ray-analysis.json", include_sections=["column_profilers"])
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+import data_designer.integrations.ray as ray
+
+pytestmark = pytest.mark.ray_fake
+
+
+def test_ray_package_root_exports_stable_public_api() -> None:
+    expected_public_api = {
+        "RayBackend",
+        "RayBackendConfigurationError",
+        "RayBlockPlanning",
+        "RayDatasetAnalysis",
+        "RayDatasetCreationResults",
+        "RayDatasetGenerationError",
+        "RayDatasetMetrics",
+        "RayExecutionOptions",
+        "RayIntegrationError",
+        "RayMetricsError",
+        "RayThrottleSnapshot",
+        "RayTraceEvent",
+        "RayWorkerMetrics",
+        "RayWorkerProfile",
+    }
+
+    assert set(ray.__all__) == expected_public_api
+    for name in expected_public_api:
+        assert getattr(ray, name).__name__ == name
+
+
+def test_ray_package_root_does_not_export_internal_helpers() -> None:
+    internal_helpers = {
+        "RayResolvedBlockPlan",
+        "aggregate_ray_metrics",
+        "normalize_ray_throttle_snapshot",
+        "normalize_ray_trace_event",
+        "normalize_ray_worker_metrics",
+        "normalize_ray_worker_profile",
+    }
+
+    assert internal_helpers.isdisjoint(ray.__all__)
+    for name in internal_helpers:
+        assert not hasattr(ray, name)


### PR DESCRIPTION
## 📋 Summary
Clarifies the experimental Ray integration public observability surface. Ray analysis reports now honor explicit section filters for JSON/HTML output, and the package root only exposes stable user-facing Ray API objects.

## 🔗 Related Issue
Closes #75
Closes #76

## 🔄 Changes
- Implemented `RayDatasetAnalysis.to_report(include_sections=...)` filtering for `summary`/`overview`, `worker_profiles`, `trace_events`, and `throttle_snapshots`.
- Added clear `RayMetricsError` handling for unsupported Ray report sections.
- Reduced `data_designer.integrations.ray.__all__` to stable backend, result, metrics, analysis, option, and error imports.
- Moved normalizer usage in tests to defining modules and added package-root public API regression tests.

## 🧪 Testing
- [ ] `make test` passes
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A — no E2E surface changed)

Focused checks run:
- [x] `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_public_api.py`
- [x] `uv run --group dev ruff format --check packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_public_api.py`
- [x] `uv run --group dev ruff check --output-format=full packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_public_api.py`

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A — public behavior documented in docstrings and import tests)