### PR TITLE
fix: clarify Ray metrics elapsed semantics

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -136,7 +136,10 @@ class RayDatasetCreationResults:
             raise RayDatasetGenerationError("RayBackend failed to load worker metrics.") from exc
         if not worker_metrics_payloads:
             return self._driver_metrics
-        worker_metrics = aggregate_ray_metrics(worker_metrics_payloads)
+        worker_metrics = aggregate_ray_metrics(
+            worker_metrics_payloads,
+            elapsed_seconds=self._driver_metrics.elapsed_seconds,
+        )
         self._metrics_cache = _merge_driver_and_worker_metrics(
             self._driver_metrics,
             worker_metrics,
@@ -872,7 +875,8 @@ def _merge_driver_and_worker_metrics(
         empty_input_blocks=worker_metrics.empty_input_blocks,
         blocks=worker_metrics.blocks,
         failed_blocks=worker_metrics.failed_blocks,
-        elapsed_seconds=worker_metrics.elapsed_seconds,
+        elapsed_seconds=driver_metrics.elapsed_seconds,
+        worker_elapsed_seconds=worker_metrics.worker_elapsed_seconds,
         model_usage=worker_metrics.model_usage or driver_metrics.model_usage,
         throttle=throttle_metrics or worker_metrics.throttle or driver_metrics.throttle,
     )

--- a/packages/data-designer/src/data_designer/integrations/ray/metrics.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/metrics.py
@@ -11,7 +11,16 @@ from data_designer.integrations.ray._validation import validate_finite_number
 from data_designer.integrations.ray.errors import RayMetricsError
 
 ModelUsageSummary = dict[str, dict[str, Any]]
-RayMetricsPayload: TypeAlias = "RayDatasetMetrics | RayWorkerMetrics | Mapping[str, Any]"
+RayWorkerMetricsPayload: TypeAlias = "RayWorkerMetrics | Mapping[str, Any]"
+_DATASET_METRICS_ONLY_FIELDS = frozenset(
+    {
+        "all_rows_dropped_blocks",
+        "partial_rows_dropped_blocks",
+        "empty_input_blocks",
+        "worker_elapsed_seconds",
+        "throttle",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +52,7 @@ class RayWorkerMetrics:
         _validate_bool("empty_input", self.empty_input)
         _validate_non_negative_int("blocks", self.blocks)
         _validate_non_negative_int("failed_blocks", self.failed_blocks)
+        _validate_failed_blocks_not_greater_than_blocks(blocks=self.blocks, failed_blocks=self.failed_blocks)
         _validate_non_negative_float("elapsed_seconds", self.elapsed_seconds)
         if self.block_id is not None and not isinstance(self.block_id, str):
             raise RayMetricsError("Ray metrics field 'block_id' must be a string when provided.")
@@ -58,6 +68,9 @@ class RayDatasetMetrics:
 
     total_rows is populated only when the backend knows the count without
     forcing Ray Dataset materialization on the driver.
+    elapsed_seconds is driver-observed wall-clock duration. worker_elapsed_seconds
+    is the cumulative elapsed duration reported by worker/block payloads.
+    Aggregated model usage rates use worker_elapsed_seconds when available.
     """
 
     total_rows: int = 0
@@ -70,6 +83,7 @@ class RayDatasetMetrics:
     blocks: int = 0
     failed_blocks: int = 0
     elapsed_seconds: float = 0.0
+    worker_elapsed_seconds: float = 0.0
     model_usage: ModelUsageSummary | None = None
     throttle: dict[str, Any] | None = None
 
@@ -85,12 +99,14 @@ class RayDatasetMetrics:
         _validate_non_negative_int("empty_input_blocks", self.empty_input_blocks)
         _validate_non_negative_int("blocks", self.blocks)
         _validate_non_negative_int("failed_blocks", self.failed_blocks)
+        _validate_failed_blocks_not_greater_than_blocks(blocks=self.blocks, failed_blocks=self.failed_blocks)
         _validate_non_negative_float("elapsed_seconds", self.elapsed_seconds)
+        _validate_non_negative_float("worker_elapsed_seconds", self.worker_elapsed_seconds)
 
     @property
     def successful_blocks(self) -> int:
         """Return completed block count after failed blocks are subtracted."""
-        return max(self.blocks - self.failed_blocks, 0)
+        return self.blocks - self.failed_blocks
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation."""
@@ -108,17 +124,22 @@ class _MetricsAccumulator:
     empty_input_blocks: int = 0
     blocks: int = 0
     failed_blocks: int = 0
-    elapsed_seconds: float = 0.0
+    worker_elapsed_seconds: float = 0.0
     model_usage: ModelUsageSummary = field(default_factory=dict)
 
 
-def aggregate_ray_metrics(worker_metrics: Iterable[RayMetricsPayload]) -> RayDatasetMetrics:
+def aggregate_ray_metrics(
+    worker_metrics: Iterable[RayWorkerMetricsPayload],
+    *,
+    elapsed_seconds: float = 0.0,
+) -> RayDatasetMetrics:
     """Aggregate worker or block metrics into a dataset-level summary.
 
     The helper accepts plain mappings so Ray workers can return JSON-like
     payloads without importing Data Designer integration classes on the driver.
     Model usage is expected to follow Data Designer's model usage summary shape;
-    token and request rates are recomputed from aggregate counters.
+    token and request rates are recomputed from aggregate counters using
+    cumulative worker elapsed time when worker timings are available.
     """
     accumulator = _MetricsAccumulator()
     for payload in worker_metrics:
@@ -132,13 +153,19 @@ def aggregate_ray_metrics(worker_metrics: Iterable[RayMetricsPayload]) -> RayDat
         accumulator.empty_input_blocks += int(metrics.empty_input)
         accumulator.blocks += metrics.blocks
         accumulator.failed_blocks += metrics.failed_blocks
-        accumulator.elapsed_seconds += metrics.elapsed_seconds
+        accumulator.worker_elapsed_seconds += metrics.elapsed_seconds
         if metrics.model_usage:
             _merge_model_usage(accumulator.model_usage, metrics.model_usage)
 
     model_usage = accumulator.model_usage or None
     if model_usage is not None:
-        _recompute_model_usage_rates(model_usage, accumulator.elapsed_seconds)
+        _recompute_model_usage_rates(
+            model_usage,
+            _model_usage_rate_elapsed_seconds(
+                elapsed_seconds=elapsed_seconds,
+                worker_elapsed_seconds=accumulator.worker_elapsed_seconds,
+            ),
+        )
 
     return RayDatasetMetrics(
         total_rows=accumulator.total_rows,
@@ -150,32 +177,25 @@ def aggregate_ray_metrics(worker_metrics: Iterable[RayMetricsPayload]) -> RayDat
         empty_input_blocks=accumulator.empty_input_blocks,
         blocks=accumulator.blocks,
         failed_blocks=accumulator.failed_blocks,
-        elapsed_seconds=accumulator.elapsed_seconds,
+        elapsed_seconds=elapsed_seconds,
+        worker_elapsed_seconds=accumulator.worker_elapsed_seconds,
         model_usage=model_usage,
     )
 
 
-def normalize_ray_worker_metrics(payload: RayMetricsPayload) -> RayWorkerMetrics:
+def normalize_ray_worker_metrics(payload: RayWorkerMetricsPayload) -> RayWorkerMetrics:
     """Normalize a dataclass or mapping payload into RayWorkerMetrics."""
     if isinstance(payload, RayDatasetMetrics):
-        return RayWorkerMetrics(
-            total_rows=payload.total_rows,
-            input_rows=payload.input_rows,
-            output_rows=payload.output_rows,
-            dropped_rows=payload.dropped_rows,
-            all_rows_dropped=payload.all_rows_dropped_blocks > 0,
-            partial_rows_dropped=payload.partial_rows_dropped_blocks > 0,
-            empty_input=payload.empty_input_blocks > 0,
-            blocks=payload.blocks,
-            failed_blocks=payload.failed_blocks,
-            elapsed_seconds=payload.elapsed_seconds,
-            model_usage=payload.model_usage,
-            block_id=None,
+        raise RayMetricsError(
+            "RayDatasetMetrics payloads are dataset-level summaries and cannot be normalized as worker metrics."
         )
     if isinstance(payload, RayWorkerMetrics):
         return payload
     if not isinstance(payload, Mapping):
-        raise RayMetricsError(f"Ray metrics payload must be a mapping or metrics dataclass, got {type(payload)!r}.")
+        raise RayMetricsError(
+            f"Ray metrics payload must be a mapping or RayWorkerMetrics dataclass, got {type(payload)!r}."
+        )
+    _reject_dataset_metrics_mapping(payload)
 
     return RayWorkerMetrics(
         total_rows=_coerce_int(payload, "total_rows", default=0),
@@ -269,6 +289,21 @@ def _validate_bool(field_name: str, value: bool) -> None:
         raise RayMetricsError(f"Ray metrics field {field_name!r} must be a boolean.")
 
 
+def _validate_failed_blocks_not_greater_than_blocks(*, blocks: int, failed_blocks: int) -> None:
+    if failed_blocks > blocks:
+        raise RayMetricsError("Ray metrics field 'failed_blocks' cannot be greater than 'blocks'.")
+
+
+def _reject_dataset_metrics_mapping(payload: Mapping[str, Any]) -> None:
+    dataset_fields = sorted(_DATASET_METRICS_ONLY_FIELDS.intersection(payload))
+    if dataset_fields:
+        field_list = ", ".join(repr(field) for field in dataset_fields)
+        raise RayMetricsError(
+            "Ray worker metrics payload contains dataset-level field(s) "
+            f"{field_list}; dataset metrics cannot be normalized as worker metrics."
+        )
+
+
 def _merge_model_usage(target: ModelUsageSummary, source: ModelUsageSummary) -> None:
     for model_name, stats in source.items():
         target_stats = target.setdefault(model_name, {})
@@ -311,6 +346,12 @@ def _recompute_model_usage_rates(model_usage: ModelUsageSummary, elapsed_seconds
             total_requests = successful_requests + failed_requests
             request_usage["total_requests"] = total_requests
             stats["requests_per_minute"] = int(total_requests / elapsed_seconds * 60) if elapsed_seconds > 0 else 0
+
+
+def _model_usage_rate_elapsed_seconds(*, elapsed_seconds: float, worker_elapsed_seconds: float) -> float:
+    if worker_elapsed_seconds > 0:
+        return worker_elapsed_seconds
+    return elapsed_seconds
 
 
 def _numeric_value(value: Any) -> int | float:

--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -137,12 +137,13 @@ class RayDatasetAnalysis:
         _validate_non_negative_int("total_rows", self.total_rows)
         _validate_non_negative_int("blocks", self.blocks)
         _validate_non_negative_int("failed_blocks", self.failed_blocks)
+        _validate_failed_blocks_not_greater_than_blocks(blocks=self.blocks, failed_blocks=self.failed_blocks)
         _validate_non_negative_int("trace_events_dropped", self.trace_events_dropped)
 
     @property
     def successful_blocks(self) -> int:
         """Return completed block count after failed blocks are subtracted."""
-        return max(self.blocks - self.failed_blocks, 0)
+        return self.blocks - self.failed_blocks
 
     @property
     def column_names(self) -> list[str]:
@@ -414,3 +415,8 @@ def _validate_non_negative_float(field_name: str, value: float) -> None:
     )
     if value < 0:
         raise RayMetricsError(f"Ray observability field {field_name!r} must be non-negative.")
+
+
+def _validate_failed_blocks_not_greater_than_blocks(*, blocks: int, failed_blocks: int) -> None:
+    if failed_blocks > blocks:
+        raise RayMetricsError("Ray observability field 'failed_blocks' cannot be greater than 'blocks'.")

--- a/packages/data-designer/tests/integrations/ray/test_metrics.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
 from data_designer.integrations.ray import RayDatasetMetrics, RayMetricsError, RayWorkerMetrics
@@ -56,7 +58,7 @@ def test_aggregate_ray_metrics_sums_worker_metrics_and_model_usage() -> None:
         total_rows=15,
         blocks=3,
         failed_blocks=1,
-        elapsed_seconds=5.0,
+        worker_elapsed_seconds=5.0,
         model_usage={
             "model-a": {
                 "token_usage": {"input_tokens": 5, "output_tokens": 15, "total_tokens": 20},
@@ -72,6 +74,28 @@ def test_aggregate_ray_metrics_sums_worker_metrics_and_model_usage() -> None:
     )
     assert metrics.successful_blocks == 2
     assert metrics.to_dict()["total_rows"] == 15
+    assert metrics.to_dict()["worker_elapsed_seconds"] == 5.0
+
+
+def test_aggregate_ray_metrics_preserves_driver_elapsed_seconds() -> None:
+    metrics = aggregate_ray_metrics(
+        [
+            RayWorkerMetrics(
+                total_rows=10,
+                blocks=1,
+                elapsed_seconds=2.0,
+            ),
+            RayWorkerMetrics(
+                total_rows=5,
+                blocks=1,
+                elapsed_seconds=3.0,
+            ),
+        ],
+        elapsed_seconds=1.25,
+    )
+
+    assert metrics.elapsed_seconds == 1.25
+    assert metrics.worker_elapsed_seconds == 5.0
 
 
 def test_normalize_ray_worker_metrics_uses_serializable_mapping_defaults() -> None:
@@ -114,3 +138,34 @@ def test_aggregate_ray_metrics_sums_row_outcomes() -> None:
 def test_normalize_ray_worker_metrics_rejects_invalid_payload() -> None:
     with pytest.raises(RayMetricsError, match="must be a mapping"):
         normalize_ray_worker_metrics(object())
+
+
+def test_normalize_ray_worker_metrics_rejects_dataset_metrics_dataclass() -> None:
+    with pytest.raises(RayMetricsError, match="dataset-level summaries"):
+        normalize_ray_worker_metrics(RayDatasetMetrics(total_rows=3, blocks=1, throttle={"domains": []}))
+
+
+def test_normalize_ray_worker_metrics_rejects_dataset_metrics_mapping() -> None:
+    payload = RayDatasetMetrics(
+        total_rows=3,
+        blocks=1,
+        elapsed_seconds=0.25,
+        worker_elapsed_seconds=1.0,
+        throttle={"domains": []},
+    ).to_dict()
+
+    with pytest.raises(RayMetricsError, match="dataset-level field"):
+        normalize_ray_worker_metrics(payload)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: RayWorkerMetrics(blocks=1, failed_blocks=2),
+        lambda: RayDatasetMetrics(blocks=1, failed_blocks=2),
+        lambda: normalize_ray_worker_metrics({"blocks": 1, "failed_blocks": 2}),
+    ],
+)
+def test_ray_metrics_reject_failed_blocks_greater_than_blocks(factory: Callable[[], object]) -> None:
+    with pytest.raises(RayMetricsError, match="failed_blocks.*greater than.*blocks"):
+        factory()

--- a/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
@@ -72,7 +72,7 @@ def test_ray_results_load_metrics_exposes_worker_aggregate(
     assert results.load_metrics() == RayDatasetMetrics(
         total_rows=5,
         blocks=2,
-        elapsed_seconds=3.0,
+        worker_elapsed_seconds=3.0,
         model_usage={
             "stub-model": {
                 "token_usage": {"input_tokens": 5, "output_tokens": 15, "total_tokens": 20},
@@ -108,7 +108,8 @@ def test_ray_results_load_metrics_preserves_zero_worker_total_rows(
 
     assert metrics.total_rows == 0
     assert metrics.blocks == 1
-    assert metrics.elapsed_seconds == 0.25
+    assert metrics.elapsed_seconds == 10.0
+    assert metrics.worker_elapsed_seconds == 0.25
 
 
 def test_ray_backend_load_metrics_aggregates_worker_emitted_payloads(
@@ -187,7 +188,8 @@ def test_ray_backend_load_metrics_aggregates_worker_emitted_payloads(
     assert results.load_dataset().to_pandas().to_dict(orient="records") == [{"id": 0}, {"id": 1}, {"id": 2}]
     assert metrics.total_rows == 3
     assert metrics.blocks == 2
-    assert metrics.elapsed_seconds == 1.5
+    assert metrics.elapsed_seconds > 0
+    assert metrics.worker_elapsed_seconds == 1.5
     assert metrics.model_usage == {
         "stub-model": {
             "token_usage": {"input_tokens": 6, "output_tokens": 8, "total_tokens": 14},

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -190,3 +190,8 @@ def test_normalize_ray_trace_event_rejects_non_finite_timestamp_seconds(value: f
                 "timestamp_seconds": value,
             }
         )
+
+
+def test_ray_dataset_analysis_rejects_failed_blocks_greater_than_blocks() -> None:
+    with pytest.raises(RayMetricsError, match="failed_blocks.*greater than.*blocks"):
+        RayDatasetAnalysis(blocks=1, failed_blocks=2)


### PR DESCRIPTION
## 📋 Summary
Clarifies Ray dataset metrics timing semantics so dataset elapsed time remains driver wall-clock while cumulative worker/block time is reported separately. The worker metrics boundary now rejects dataset summary payloads and telemetry with impossible failed block counts.

## 🔗 Related Issue
Fixes #69
Fixes #70
Fixes #80

## 🔄 Changes
- Added `worker_elapsed_seconds` to `RayDatasetMetrics` for cumulative worker/block duration while preserving `elapsed_seconds` as driver wall-clock.
- Recomputed aggregate model usage rates against cumulative worker elapsed time when worker timings are available.
- Rejected `failed_blocks > blocks` for worker metrics, dataset metrics, and Ray dataset analysis.
- Stopped normalizing `RayDatasetMetrics` dataclasses or dataset-summary mappings as worker metrics, preventing fields like `throttle` from being silently dropped.
- Updated focused Ray metrics, execution, and observability tests for the new semantics and the package-root normalizer export changes from #100.

## 🧪 Testing
- [ ] `make test` passes (not run; targeted Ray fake suite run)
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A — no E2E surface for this metrics-only change)

Additional targeted checks:
- [x] `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py packages/data-designer/tests/integrations/ray/test_backend.py -m ray_fake`
- [x] `uv run --group dev pytest packages/data-designer/tests/integrations/ray -m ray_fake`
- [x] `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/metrics.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_observability.py`
- [x] `uv run ruff check --output-format=full packages/data-designer/src/data_designer/integrations/ray/metrics.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_observability.py`

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — metrics semantics tested in code)