### PR TITLE
refactor(ray): compact RayBackend options

### DIFF
--- a/docs/concepts/deployment-options.md
+++ b/docs/concepts/deployment-options.md
@@ -151,6 +151,25 @@ The optional Ray backend is a library scaling mode for trusted Ray clusters. It 
 model provider definitions, secret resolver state, seed-reader state, MCP provider definitions, and runtime settings
 to Ray workers so each worker can construct its local generation engine.
 
+Use option objects for Ray-specific planning and execution controls, while keeping common constructor arguments direct:
+
+```python
+from data_designer.integrations.ray import RayBackend, RayBlockPlanning, RayExecutionOptions
+
+backend = RayBackend(
+    batch_size=128,
+    output="dataset",
+    auto_init=False,
+    block_planning=RayBlockPlanning(target_block_size=10_000, min_blocks=4),
+    execution_options=RayExecutionOptions(num_cpus=1, concurrency=8),
+)
+```
+
+`batch_size`, `output`, and `auto_init` remain the direct constructor controls for common use. Older individual
+Ray planning and execution kwargs such as `override_num_blocks`, `read_concurrency`, `num_cpus`, and
+`map_concurrency` are still accepted as compatibility shims, but do not combine them with `block_planning` or
+`execution_options`; effective mixed values raise a configuration error. Prefer the option objects for new code.
+
 Use Ray only when the driver and workers are inside the same trusted operational boundary, such as a single-tenant
 cluster or a managed cluster with equivalent isolation. A Ray worker may receive provider endpoint configuration and
 may be able to resolve API keys through the configured `SecretResolver` or worker environment. Treat every Ray worker

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -45,7 +45,7 @@ from data_designer.integrations.ray.observability import (
     normalize_ray_trace_event,
     normalize_ray_worker_profile,
 )
-from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, RayMapConcurrency
+from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, resolve_ray_backend_options
 from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 from data_designer.integrations.ray.throttling import create_ray_throttle_manager
 from data_designer.interface.backends import BackendRuntimeContext
@@ -310,6 +310,11 @@ class RayBackend:
     Ray-resident outputs. Ray is imported lazily so base Data Designer installs
     do not require the optional dependency. input_dataset may be a Ray Dataset
     or a sequence of ObjectRefs containing Arrow tables or pandas DataFrames.
+
+    Prefer ``block_planning=RayBlockPlanning(...)`` and
+    ``execution_options=RayExecutionOptions(...)`` for Ray-specific controls.
+    Individual Ray planning and execution kwargs are still accepted as
+    backwards-compatible shims.
     """
 
     def __init__(
@@ -320,26 +325,8 @@ class RayBackend:
         object_ref_format: RayObjectRefInputFormat = "arrow",
         auto_init: bool = False,
         zero_copy_batch: bool = True,
-        ray_remote_args: dict[str, Any] | None = None,
         block_planning: RayBlockPlanning | None = None,
-        override_num_blocks: int | None = None,
-        target_block_size: int | None = None,
-        min_blocks: int | None = None,
-        max_blocks: int | None = None,
-        read_concurrency: int | None = None,
         execution_options: RayExecutionOptions | None = None,
-        num_cpus: float | None = None,
-        num_gpus: float | None = None,
-        memory: float | None = None,
-        resources: dict[str, float] | None = None,
-        scheduling_strategy: Any | None = None,
-        compute: Any | None = None,
-        map_concurrency: RayMapConcurrency | None = None,
-        ray_remote_args_fn: Any | None = None,
-        use_actor_pool: bool = False,
-        actor_pool_min_size: int | None = None,
-        actor_pool_max_size: int | None = None,
-        actor_pool_initial_size: int | None = None,
         preflight_model_health_check: bool = True,
         worker_model_health_checks: bool = False,
         order_column: str | None = None,
@@ -351,6 +338,7 @@ class RayBackend:
         profile_workers: bool = True,
         trace_enabled: bool = False,
         max_trace_events: int = 1000,
+        **legacy_options: Any,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
             raise RayBackendConfigurationError("RayBackend output must be 'dataset' or 'arrow_refs'.")
@@ -361,36 +349,19 @@ class RayBackend:
             raise RayBackendConfigurationError("RayBackend order_column must be a non-empty string when provided.")
         if max_trace_events < 0:
             raise RayBackendConfigurationError("RayBackend max_trace_events must be non-negative.")
-        self.block_planning = _resolve_block_planning(
-            block_planning,
-            override_num_blocks=override_num_blocks,
-            target_block_size=target_block_size,
-            min_blocks=min_blocks,
-            max_blocks=max_blocks,
-            read_concurrency=read_concurrency,
+        resolved_options = resolve_ray_backend_options(
+            block_planning=block_planning,
+            execution_options=execution_options,
+            legacy_options=legacy_options,
         )
-        self.execution_options = _resolve_execution_options(
-            execution_options,
-            ray_remote_args=ray_remote_args,
-            num_cpus=num_cpus,
-            num_gpus=num_gpus,
-            memory=memory,
-            resources=resources,
-            scheduling_strategy=scheduling_strategy,
-            compute=compute,
-            map_concurrency=map_concurrency,
-            ray_remote_args_fn=ray_remote_args_fn,
-            use_actor_pool=use_actor_pool,
-            actor_pool_min_size=actor_pool_min_size,
-            actor_pool_max_size=actor_pool_max_size,
-            actor_pool_initial_size=actor_pool_initial_size,
-        )
+        self.block_planning = resolved_options.block_planning
+        self.execution_options = resolved_options.execution_options
         self.batch_size = batch_size
         self.output = output
         self.object_ref_format = object_ref_format
         self.auto_init = auto_init
         self.zero_copy_batch = zero_copy_batch
-        self.ray_remote_args = ray_remote_args
+        self.ray_remote_args = self.execution_options.ray_remote_args
         self.preflight_model_health_check = preflight_model_health_check
         self.worker_model_health_checks = worker_model_health_checks
         self.order_column = order_column
@@ -680,92 +651,11 @@ def _create_driver_metrics(
     )
 
 
-def _resolve_block_planning(
-    block_planning: RayBlockPlanning | None,
-    *,
-    override_num_blocks: int | None,
-    target_block_size: int | None,
-    min_blocks: int | None,
-    max_blocks: int | None,
-    read_concurrency: int | None,
-) -> RayBlockPlanning:
-    if block_planning is not None and any(
-        value is not None
-        for value in (override_num_blocks, target_block_size, min_blocks, max_blocks, read_concurrency)
-    ):
-        raise RayBackendConfigurationError(
-            "RayBackend block_planning cannot be combined with individual block planning arguments."
-        )
-    if block_planning is not None:
-        return block_planning
-    return RayBlockPlanning(
-        override_num_blocks=override_num_blocks,
-        target_block_size=target_block_size,
-        min_blocks=min_blocks,
-        max_blocks=max_blocks,
-        read_concurrency=read_concurrency,
-    )
-
-
 def _validate_ray_backend_batch_size(batch_size: int | None) -> None:
     if batch_size is None:
         return
     if isinstance(batch_size, bool) or not isinstance(batch_size, int) or batch_size <= 0:
         raise RayBackendConfigurationError("RayBackend batch_size must be a positive integer or None.")
-
-
-def _resolve_execution_options(
-    execution_options: RayExecutionOptions | None,
-    *,
-    ray_remote_args: dict[str, Any] | None,
-    num_cpus: float | None,
-    num_gpus: float | None,
-    memory: float | None,
-    resources: dict[str, float] | None,
-    scheduling_strategy: Any | None,
-    compute: Any | None,
-    map_concurrency: RayMapConcurrency | None,
-    ray_remote_args_fn: Any | None,
-    use_actor_pool: bool,
-    actor_pool_min_size: int | None,
-    actor_pool_max_size: int | None,
-    actor_pool_initial_size: int | None,
-) -> RayExecutionOptions:
-    explicit_values = (
-        ray_remote_args,
-        num_cpus,
-        num_gpus,
-        memory,
-        resources,
-        scheduling_strategy,
-        compute,
-        map_concurrency,
-        ray_remote_args_fn,
-        actor_pool_min_size,
-        actor_pool_max_size,
-        actor_pool_initial_size,
-    )
-    if execution_options is not None and (use_actor_pool or any(value is not None for value in explicit_values)):
-        raise RayBackendConfigurationError(
-            "RayBackend execution_options cannot be combined with individual Ray execution arguments."
-        )
-    if execution_options is not None:
-        return execution_options
-    return RayExecutionOptions(
-        num_cpus=num_cpus,
-        num_gpus=num_gpus,
-        memory=memory,
-        resources=resources,
-        scheduling_strategy=scheduling_strategy,
-        compute=compute,
-        concurrency=map_concurrency,
-        ray_remote_args_fn=ray_remote_args_fn,
-        ray_remote_args=ray_remote_args,
-        use_actor_pool=use_actor_pool,
-        actor_pool_min_size=actor_pool_min_size,
-        actor_pool_max_size=actor_pool_max_size,
-        actor_pool_initial_size=actor_pool_initial_size,
-    )
 
 
 def _model_health_check_aliases(config_builder: DataDesignerConfigBuilder) -> list[str]:

--- a/packages/data-designer/src/data_designer/integrations/ray/options.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/options.py
@@ -24,6 +24,32 @@ _DATA_DESIGNER_OWNED_MAP_BATCHES_KEYS = frozenset(
         "zero_copy_batch",
     }
 )
+_RAY_BACKEND_BLOCK_PLANNING_LEGACY_KWARGS = frozenset(
+    {
+        "override_num_blocks",
+        "target_block_size",
+        "min_blocks",
+        "max_blocks",
+        "read_concurrency",
+    }
+)
+_RAY_BACKEND_EXECUTION_OPTIONS_LEGACY_KWARGS = frozenset(
+    {
+        "ray_remote_args",
+        "num_cpus",
+        "num_gpus",
+        "memory",
+        "resources",
+        "scheduling_strategy",
+        "compute",
+        "map_concurrency",
+        "ray_remote_args_fn",
+        "use_actor_pool",
+        "actor_pool_min_size",
+        "actor_pool_max_size",
+        "actor_pool_initial_size",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -202,6 +228,123 @@ class RayExecutionOptions:
                 )
             kwargs["compute"] = _create_actor_pool_strategy(ray, self)
         return kwargs
+
+
+@dataclass(frozen=True, slots=True)
+class RayBackendOptionResolution:
+    """Resolved RayBackend option objects after applying compatibility shims."""
+
+    block_planning: RayBlockPlanning
+    execution_options: RayExecutionOptions
+
+
+def resolve_ray_backend_options(
+    *,
+    block_planning: RayBlockPlanning | None = None,
+    execution_options: RayExecutionOptions | None = None,
+    legacy_options: Mapping[str, Any] | None = None,
+) -> RayBackendOptionResolution:
+    """Resolve RayBackend planning and execution option objects.
+
+    Args:
+        block_planning: Primary block-planning option object.
+        execution_options: Primary Ray execution option object.
+        legacy_options: Backwards-compatible constructor kwargs for individual
+            block-planning or execution settings.
+
+    Returns:
+        The resolved option objects used by RayBackend.
+
+    Raises:
+        RayBackendConfigurationError: If option objects are combined with
+            effective individual kwargs, or if unsupported legacy kwargs are
+            present.
+    """
+    remaining_options = dict(legacy_options or {})
+    block_planning_kwargs = _pop_legacy_options(
+        remaining_options,
+        _RAY_BACKEND_BLOCK_PLANNING_LEGACY_KWARGS,
+    )
+    execution_options_kwargs = _pop_legacy_options(
+        remaining_options,
+        _RAY_BACKEND_EXECUTION_OPTIONS_LEGACY_KWARGS,
+    )
+    if remaining_options:
+        unsupported_options = ", ".join(sorted(remaining_options))
+        raise RayBackendConfigurationError(
+            "RayBackend received unsupported Ray option arguments: "
+            f"{unsupported_options}. Use block_planning=RayBlockPlanning(...) or "
+            "execution_options=RayExecutionOptions(...) for Ray planning and execution controls."
+        )
+    return RayBackendOptionResolution(
+        block_planning=_resolve_ray_block_planning(block_planning, block_planning_kwargs),
+        execution_options=_resolve_ray_execution_options(execution_options, execution_options_kwargs),
+    )
+
+
+def _pop_legacy_options(source: dict[str, Any], option_names: frozenset[str]) -> dict[str, Any]:
+    options: dict[str, Any] = {}
+    for option_name in option_names:
+        if option_name in source:
+            options[option_name] = source.pop(option_name)
+    return options
+
+
+def _resolve_ray_block_planning(
+    block_planning: RayBlockPlanning | None,
+    legacy_options: Mapping[str, Any],
+) -> RayBlockPlanning:
+    if block_planning is not None and any(value is not None for value in legacy_options.values()):
+        raise RayBackendConfigurationError(
+            "RayBackend block_planning cannot be combined with individual block planning arguments."
+        )
+    if block_planning is not None:
+        return block_planning
+    return RayBlockPlanning(
+        override_num_blocks=legacy_options.get("override_num_blocks"),
+        target_block_size=legacy_options.get("target_block_size"),
+        min_blocks=legacy_options.get("min_blocks"),
+        max_blocks=legacy_options.get("max_blocks"),
+        read_concurrency=legacy_options.get("read_concurrency"),
+    )
+
+
+def _resolve_ray_execution_options(
+    execution_options: RayExecutionOptions | None,
+    legacy_options: Mapping[str, Any],
+) -> RayExecutionOptions:
+    if execution_options is not None and _has_effective_execution_legacy_options(legacy_options):
+        raise RayBackendConfigurationError(
+            "RayBackend execution_options cannot be combined with individual Ray execution arguments."
+        )
+    if execution_options is not None:
+        return execution_options
+    return RayExecutionOptions(
+        num_cpus=legacy_options.get("num_cpus"),
+        num_gpus=legacy_options.get("num_gpus"),
+        memory=legacy_options.get("memory"),
+        resources=legacy_options.get("resources"),
+        scheduling_strategy=legacy_options.get("scheduling_strategy"),
+        compute=legacy_options.get("compute"),
+        concurrency=legacy_options.get("map_concurrency"),
+        ray_remote_args_fn=legacy_options.get("ray_remote_args_fn"),
+        ray_remote_args=legacy_options.get("ray_remote_args"),
+        use_actor_pool=legacy_options.get("use_actor_pool", False),
+        actor_pool_min_size=legacy_options.get("actor_pool_min_size"),
+        actor_pool_max_size=legacy_options.get("actor_pool_max_size"),
+        actor_pool_initial_size=legacy_options.get("actor_pool_initial_size"),
+    )
+
+
+def _has_effective_execution_legacy_options(legacy_options: Mapping[str, Any]) -> bool:
+    for name, value in legacy_options.items():
+        if name == "use_actor_pool":
+            if value:
+                return True
+            continue
+        if value is not None:
+            return True
+    return False
 
 
 def _validate_optional_positive_int(field_name: str, value: int | None) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from typing import Any
 
@@ -348,6 +349,41 @@ def test_ray_backend_rejects_grouped_block_planning_conflicts() -> None:
 def test_ray_backend_rejects_grouped_execution_option_conflicts() -> None:
     with pytest.raises(RayBackendConfigurationError, match="execution_options"):
         RayBackend(execution_options=RayExecutionOptions(), num_cpus=1)
+
+
+def test_ray_backend_constructor_signature_keeps_option_objects_primary() -> None:
+    parameters = inspect.signature(RayBackend).parameters
+
+    assert "block_planning" in parameters
+    assert "execution_options" in parameters
+    assert "batch_size" in parameters
+    assert "output" in parameters
+    assert "auto_init" in parameters
+    assert "override_num_blocks" not in parameters
+    assert "num_cpus" not in parameters
+
+
+def test_ray_backend_accepts_legacy_option_kwargs_as_compatibility_shims() -> None:
+    backend = RayBackend(
+        override_num_blocks=3,
+        read_concurrency=2,
+        num_cpus=0.5,
+        map_concurrency=4,
+        ray_remote_args={"resources": {"token_bucket": 1}},
+    )
+
+    assert backend.block_planning == RayBlockPlanning(override_num_blocks=3, read_concurrency=2)
+    assert backend.execution_options == RayExecutionOptions(
+        num_cpus=0.5,
+        concurrency=4,
+        ray_remote_args={"resources": {"token_bucket": 1}},
+    )
+    assert backend.ray_remote_args == {"resources": {"token_bucket": 1}}
+
+
+def test_ray_backend_rejects_unknown_legacy_option_kwargs() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="unsupported Ray option arguments: unknown"):
+        RayBackend(unknown=1)
 
 
 def test_ray_backend_propagates_execution_resource_options(

--- a/packages/data-designer/tests/integrations/ray/test_options.py
+++ b/packages/data-designer/tests/integrations/ray/test_options.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from data_designer.integrations.ray import RayBackendConfigurationError, RayBlockPlanning, RayExecutionOptions
+from data_designer.integrations.ray.options import resolve_ray_backend_options
 
 pytestmark = pytest.mark.ray_fake
 
@@ -23,6 +24,14 @@ pytestmark = pytest.mark.ray_fake
 def test_ray_block_planning_validation_uses_configuration_error(kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(RayBackendConfigurationError, match=match):
         RayBlockPlanning(**kwargs)
+
+
+def test_ray_backend_option_resolution_rejects_block_planning_conflicts() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="block_planning"):
+        resolve_ray_backend_options(
+            block_planning=RayBlockPlanning(),
+            legacy_options={"override_num_blocks": 1},
+        )
 
 
 @pytest.mark.parametrize(
@@ -78,3 +87,34 @@ def test_ray_execution_options_rejects_actor_pool_with_concurrency() -> None:
 def test_ray_execution_options_validation_uses_configuration_error(kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(RayBackendConfigurationError, match=match):
         RayExecutionOptions(**kwargs)
+
+
+def test_ray_backend_option_resolution_rejects_execution_option_conflicts() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="execution_options"):
+        resolve_ray_backend_options(
+            execution_options=RayExecutionOptions(),
+            legacy_options={"num_cpus": 1},
+        )
+
+
+def test_ray_backend_option_resolution_allows_noop_legacy_values_with_option_objects() -> None:
+    block_planning = RayBlockPlanning(override_num_blocks=2)
+    execution_options = RayExecutionOptions(num_cpus=0.5)
+
+    resolved = resolve_ray_backend_options(
+        block_planning=block_planning,
+        execution_options=execution_options,
+        legacy_options={
+            "override_num_blocks": None,
+            "num_cpus": None,
+            "use_actor_pool": False,
+        },
+    )
+
+    assert resolved.block_planning is block_planning
+    assert resolved.execution_options is execution_options
+
+
+def test_ray_backend_option_resolution_rejects_unknown_legacy_options() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="unsupported Ray option arguments: unknown"):
+        resolve_ray_backend_options(legacy_options={"unknown": 1})


### PR DESCRIPTION
## 📋 Summary

Make Ray option objects the primary RayBackend constructor path while preserving existing individual Ray planning and execution kwargs as compatibility shims. The conflict resolution for those shims now lives with the Ray option abstractions instead of backend orchestration.

## 🔗 Related Issue

Closes #56

## 🔄 Changes

- Move RayBackend block planning and execution option resolution into `data_designer.integrations.ray.options`.
- Compact the public `RayBackend` signature around `block_planning`, `execution_options`, and common direct controls like `batch_size`, `output`, and `auto_init`.
- Preserve legacy Ray planning/execution kwargs through `**legacy_options`, with explicit conflict and unknown-option validation.
- Document the option-object constructor shape and compatibility behavior in the Ray backend deployment docs.
- Add tests for option-owned conflict validation, compact constructor shape, and backward-compatible kwargs.

## 🧪 Testing

- [ ] `make test` passes (not run; focused Ray/backend coverage run below)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A for constructor option resolution)
- [x] `uv run --package data-designer pytest packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py` — 77 passed
- [x] `uv run --package data-designer ruff check packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [x] `uv run --package data-designer ruff format --check packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [x] `uv run --group docs mkdocs build --strict`

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (Ray backend deployment docs updated)