### PR TITLE
refactor(ray): extract worker generation pipeline

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -5,28 +5,18 @@ from __future__ import annotations
 
 import copy
 import importlib
-import os
-import pickle
-import socket
 import tempfile
 import time
-import uuid
-from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import CustomColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.data_designer_config import DataDesignerConfig
-from data_designer.config.run_config import RunConfig
-from data_designer.config.seed import SeedConfig
 from data_designer.engine.column_generators.utils.generator_classification import column_type_is_model_generated
-from data_designer.engine.dataset_builders.block_execution import BlockExecutionOptions, execute_dataset_block
-from data_designer.engine.resources.person_reader import PersonReader
-from data_designer.engine.resources.seed_reader import SeedReader
-from data_designer.engine.secret_resolver import SecretResolver
+from data_designer.engine.dataset_builders.block_execution import execute_dataset_block
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
@@ -38,9 +28,6 @@ from data_designer.integrations.ray.metrics import (
 )
 from data_designer.integrations.ray.observability import (
     RayDatasetAnalysis,
-    RayThrottleSnapshot,
-    RayTraceEvent,
-    RayWorkerProfile,
     normalize_ray_throttle_snapshot,
     normalize_ray_trace_event,
     normalize_ray_worker_profile,
@@ -48,46 +35,26 @@ from data_designer.integrations.ray.observability import (
 from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, resolve_ray_backend_options
 from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
 from data_designer.integrations.ray.throttling import create_ray_throttle_manager
+from data_designer.integrations.ray.worker_pipeline import (
+    _RAY_INTERNAL_ROW_ID_COLUMN,
+    _coerce_pandas_dataframe,
+    _compile_ray_execution_payload,
+    _RayExecutionPayload,
+    _RayObservabilityOptions,
+    _RayWorkerGenerationPipeline,
+    _RayWorkerOptions,
+)
+from data_designer.integrations.ray.worker_pipeline import (
+    _record_worker_metrics as _record_worker_metrics,
+)
+from data_designer.integrations.ray.worker_pipeline import (
+    _snapshot_worker_throttle as _snapshot_worker_throttle,
+)
 from data_designer.interface.backends import BackendRuntimeContext
-
-if TYPE_CHECKING:
-    from data_designer.config.mcp import MCPProviderT
-    from data_designer.config.models import ModelProvider
-
 
 RayOutputMode = Literal["dataset", "arrow_refs"]
 RayObjectRefInputFormat = Literal["arrow", "pandas"]
 RayDatasetSourceKind = Literal["range", "input_dataset", "object_refs", "driver_materialized_seed", "seed_window"]
-_RAY_INTERNAL_ROW_ID_COLUMN = "__data_designer_ray_row_id"
-
-
-@dataclass(frozen=True)
-class _RayWorkerOptions:
-    model_providers: list[ModelProvider]
-    default_provider_name: str
-    secret_resolver: SecretResolver
-    seed_readers: list[SeedReader]
-    managed_assets_path: str
-    person_reader: PersonReader | None
-    mcp_providers: list[MCPProviderT]
-    run_config: RunConfig
-    throttle_manager: Any | None = None
-
-
-@dataclass(frozen=True)
-class _RayExecutionPayload:
-    config_json: str
-    worker_options: _RayWorkerOptions
-    use_input_dataset: bool
-    seed_window: ray_seed_planning.RaySeedWindow | None = None
-    seed_config: SeedConfig | None = None
-    hidden_order_column: str | None = None
-
-
-@dataclass(frozen=True)
-class _RayObservabilityOptions:
-    profile_workers: bool = False
-    trace_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -796,56 +763,6 @@ def _dataset_from_arrow_refs_via_items(ray: Any, refs: list[Any]) -> Any:
     return from_items(records, **kwargs)
 
 
-def _compile_ray_execution_payload(
-    *,
-    config_builder: DataDesignerConfigBuilder,
-    worker_options: _RayWorkerOptions,
-    use_input_dataset: bool,
-    seed_window: ray_seed_planning.RaySeedWindow | None = None,
-    hidden_order_column: str | None = None,
-) -> _RayExecutionPayload:
-    data_designer_config = config_builder.build()
-    payload_seed_config = data_designer_config.seed_config if seed_window is not None else None
-    if seed_window is not None:
-        data_designer_config.seed_config = None
-    config_json = data_designer_config.to_json(indent=None)
-    if config_json is None:
-        raise RayBackendConfigurationError("RayBackend failed to serialize the Data Designer configuration.")
-    payload = _RayExecutionPayload(
-        config_json=config_json,
-        worker_options=worker_options,
-        use_input_dataset=use_input_dataset,
-        seed_window=seed_window,
-        seed_config=payload_seed_config,
-        hidden_order_column=hidden_order_column,
-    )
-    _validate_worker_payload_serializable(payload)
-    return payload
-
-
-def _validate_worker_payload_serializable(payload: _RayExecutionPayload) -> None:
-    try:
-        serializer = importlib.import_module("cloudpickle")
-    except ImportError:
-        serializer = pickle
-    try:
-        serializer.dumps(payload)
-    except Exception as exc:
-        if payload.worker_options.throttle_manager is not None:
-            worker_options = replace(payload.worker_options, throttle_manager=None)
-            payload_without_throttle = replace(payload, worker_options=worker_options)
-            try:
-                serializer.dumps(payload_without_throttle)
-            except Exception:
-                pass
-            else:
-                return
-        raise RayBackendConfigurationError(
-            "RayBackend worker payload is not serializable. Check model providers, seed readers, "
-            "secret resolvers, and MCP providers for process-safe state before launching Ray workers."
-        ) from exc
-
-
 class _RayMetricsCollector:
     def __init__(self, max_trace_events: int = 1000) -> None:
         self._payloads: list[dict[str, Any]] = []
@@ -922,23 +839,17 @@ class _RayBatchWorker:
         metrics_collector: Any | None = None,
         observability_options: _RayObservabilityOptions | None = None,
     ) -> None:
-        os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1"
         self._execution_payload: _RayExecutionPayload = execution_payload
         self._metrics_collector: Any | None = metrics_collector
         self._observability_options: _RayObservabilityOptions = observability_options or _RayObservabilityOptions()
         self._base_config: DataDesignerConfig = DataDesignerConfig.model_validate_json(execution_payload.config_json)
-        worker_options = execution_payload.worker_options
-        run_config = copy.deepcopy(worker_options.run_config)
-        if self._observability_options.trace_enabled:
-            run_config.async_trace = True
-        seed_readers = copy.deepcopy(worker_options.seed_readers)
-        if execution_payload.use_input_dataset:
-            seed_readers = ray_seed_planning.ensure_dataframe_seed_reader(seed_readers)
-        self._worker_options: _RayWorkerOptions = replace(
-            worker_options,
-            seed_readers=seed_readers,
-            run_config=run_config,
+        self._pipeline = _RayWorkerGenerationPipeline(
+            execution_payload=execution_payload,
+            metrics_collector=metrics_collector,
+            observability_options=self._observability_options,
+            execute_block=execute_dataset_block,
         )
+        self._worker_options: _RayWorkerOptions = self._pipeline.worker_options
 
     def __call__(self, batch: Any) -> Any:
         return _generate_batch(batch, worker=self, metrics_collector=self._metrics_collector)
@@ -947,230 +858,11 @@ class _RayBatchWorker:
         return None
 
     def generate_batch(self, batch: Any) -> Any:
-        start_time = time.perf_counter()
-        block_id = uuid.uuid4().hex
-        observability_options = self._observability_options
-        worker_context = _get_ray_worker_context()
-        trace_events: list[RayTraceEvent] = []
-        dataframe = _coerce_pandas_dataframe(batch)
-        num_records = len(dataframe)
-        if observability_options.trace_enabled:
-            trace_events.append(
-                _create_trace_event(
-                    block_id,
-                    "block_started",
-                    start_time,
-                    row_count=num_records,
-                    worker_context=worker_context,
-                    details={"input_columns": [str(column) for column in dataframe.columns]},
-                )
-            )
-        if num_records == 0:
-            elapsed_seconds = time.perf_counter() - start_time
-            profile = (
-                _profile_worker_output(dataframe, block_id=block_id, model_usage=None)
-                if observability_options.profile_workers
-                else None
-            )
-            if observability_options.trace_enabled:
-                trace_events.append(
-                    _create_trace_event(
-                        block_id,
-                        "block_completed",
-                        start_time,
-                        row_count=0,
-                        worker_context=worker_context,
-                        details={"empty_batch": True},
-                    )
-                )
-            _record_worker_metrics(
-                self._metrics_collector,
-                RayWorkerMetrics(
-                    total_rows=0,
-                    input_rows=0,
-                    output_rows=0,
-                    empty_input=True,
-                    blocks=1,
-                    elapsed_seconds=elapsed_seconds,
-                    block_id=block_id,
-                ),
-            )
-            _record_worker_observability(
-                self._metrics_collector,
-                worker_profile=profile,
-                trace_events=trace_events,
-                throttle_snapshots=[],
-            )
-            return dataframe
-
-        failure_metrics_recorded = False
-        try:
-            order_values = _get_hidden_order_values(
-                dataframe,
-                hidden_order_column=self._execution_payload.hidden_order_column,
-            )
-            block_config = self._create_block_config(dataframe)
-            input_frame = _strip_internal_columns(dataframe) if self._execution_payload.use_input_dataset else None
-            if observability_options.trace_enabled:
-                trace_events.append(
-                    _create_trace_event(
-                        block_id,
-                        "generation_started",
-                        start_time,
-                        row_count=num_records,
-                        worker_context=worker_context,
-                    )
-                )
-            block_result = execute_dataset_block(
-                data_designer_config=block_config,
-                runtime_context=self._worker_options,
-                input_frame=input_frame,
-                num_records=num_records,
-                options=BlockExecutionOptions(use_async=True, dataset_name="ray-block"),
-            )
-            output = block_result.dataframe
-            elapsed_seconds = time.perf_counter() - start_time
-            model_usage = block_result.model_usage_stats or None
-            if block_result.all_rows_dropped:
-                if observability_options.trace_enabled:
-                    trace_events.append(
-                        _create_trace_event(
-                            block_id,
-                            "block_failed",
-                            start_time,
-                            row_count=num_records,
-                            worker_context=worker_context,
-                            details={
-                                "error_type": "AllRowsDropped",
-                                "error": "all input rows were dropped",
-                                "input_rows": block_result.input_rows,
-                                "output_rows": block_result.output_rows,
-                                "dropped_rows": block_result.dropped_rows,
-                            },
-                        )
-                    )
-                _record_worker_metrics(
-                    self._metrics_collector,
-                    _metrics_from_block_result(
-                        block_result,
-                        elapsed_seconds=elapsed_seconds,
-                        block_id=block_id,
-                        failed_blocks=1,
-                    ),
-                )
-                _record_worker_observability(
-                    self._metrics_collector,
-                    worker_profile=None,
-                    trace_events=trace_events,
-                    throttle_snapshots=[],
-                )
-                failure_metrics_recorded = True
-                raise RayDatasetGenerationError(
-                    _format_worker_failure_message(
-                        dataframe=dataframe,
-                        exc=RuntimeError(
-                            "all input rows were dropped during block execution "
-                            f"(input_rows={block_result.input_rows}, output_rows=0)"
-                        ),
-                    )
-                )
-            if self._execution_payload.hidden_order_column is not None:
-                output = _append_hidden_order_column(
-                    output,
-                    order_values=order_values,
-                    hidden_order_column=self._execution_payload.hidden_order_column,
-                )
-            if observability_options.trace_enabled:
-                trace_events.extend(
-                    _task_traces_to_events(
-                        block_result.task_traces,
-                        block_id=block_id,
-                        worker_context=worker_context,
-                    )
-                )
-                trace_events.append(
-                    _create_trace_event(
-                        block_id,
-                        "block_completed",
-                        start_time,
-                        row_count=len(output),
-                        worker_context=worker_context,
-                        details={
-                            "output_columns": [str(column) for column in output.columns],
-                            "input_rows": block_result.input_rows,
-                            "output_rows": block_result.output_rows,
-                            "dropped_rows": block_result.dropped_rows,
-                        },
-                    )
-                )
-            throttle_snapshots = _snapshot_worker_throttle(self._worker_options.throttle_manager)
-            _record_worker_metrics(
-                self._metrics_collector,
-                _metrics_from_block_result(
-                    block_result,
-                    elapsed_seconds=elapsed_seconds,
-                    block_id=block_id,
-                ),
-            )
-            _record_worker_observability(
-                self._metrics_collector,
-                worker_profile=(
-                    _profile_worker_output(output, block_id=block_id, model_usage=model_usage)
-                    if observability_options.profile_workers
-                    else None
-                ),
-                trace_events=trace_events,
-                throttle_snapshots=throttle_snapshots,
-            )
-            return output
-        except Exception as exc:
-            if observability_options.trace_enabled:
-                trace_events.append(
-                    _create_trace_event(
-                        block_id,
-                        "block_failed",
-                        start_time,
-                        row_count=num_records,
-                        worker_context=worker_context,
-                        details={"error_type": type(exc).__name__, "error": str(exc)},
-                    )
-                )
-            if not failure_metrics_recorded:
-                _record_worker_metrics(
-                    self._metrics_collector,
-                    RayWorkerMetrics(
-                        total_rows=0,
-                        input_rows=num_records,
-                        output_rows=0,
-                        blocks=1,
-                        failed_blocks=1,
-                        elapsed_seconds=time.perf_counter() - start_time,
-                        block_id=block_id,
-                    ),
-                )
-                _record_worker_observability(
-                    self._metrics_collector,
-                    worker_profile=None,
-                    trace_events=trace_events,
-                    throttle_snapshots=[],
-                )
-            if isinstance(exc, RayDatasetGenerationError):
-                raise
-            raise RayDatasetGenerationError(_format_worker_failure_message(dataframe=dataframe, exc=exc)) from exc
-
-    def _create_block_config(self, dataframe: Any) -> DataDesignerConfig:
-        block_config = DataDesignerConfig.model_validate_json(self._execution_payload.config_json)
-        if self._execution_payload.seed_window is not None:
-            if self._execution_payload.seed_config is None:
-                raise RayDatasetGenerationError("RayBackend seed window was provided without a seed config.")
-            block_config.seed_config = ray_seed_planning.create_seed_config_for_window(
-                seed_config=self._execution_payload.seed_config,
-                seed_readers=self._worker_options.seed_readers,
-                secret_resolver=self._worker_options.secret_resolver,
-                dataframe=dataframe,
-                seed_window=self._execution_payload.seed_window,
-            )
-        return block_config
+        worker_batch = self._pipeline.prepare_batch(batch)
+        batch_observer = self._pipeline.begin_observability(worker_batch)
+        if worker_batch.num_records == 0:
+            return self._pipeline.complete_empty_batch(worker_batch, batch_observer)
+        return self._pipeline.generate_non_empty_batch(worker_batch, batch_observer)
 
 
 def _generate_batch(
@@ -1203,348 +895,6 @@ def _generate_batch(
     )(batch)
 
 
-def _strip_internal_columns(dataframe: Any) -> Any:
-    columns_to_drop = [column for column in (_RAY_INTERNAL_ROW_ID_COLUMN,) if column in dataframe.columns]
-    if not columns_to_drop:
-        return dataframe.copy()
-    return dataframe.drop(columns=columns_to_drop).copy()
-
-
-def _get_hidden_order_values(dataframe: Any, *, hidden_order_column: str | None) -> list[int]:
-    if hidden_order_column is None:
-        return []
-    if hidden_order_column in dataframe.columns:
-        values = dataframe[hidden_order_column].tolist()
-    elif ray_seed_planning.RAY_RANGE_ID_COLUMN in dataframe.columns:
-        values = dataframe[ray_seed_planning.RAY_RANGE_ID_COLUMN].tolist()
-    else:
-        raise RayDatasetGenerationError(
-            "RayBackend preserve_order=True could not find the hidden row-id source column in a Ray worker batch."
-        )
-    return [int(value) for value in values]
-
-
-def _append_hidden_order_column(
-    output: Any,
-    *,
-    order_values: list[int],
-    hidden_order_column: str,
-) -> Any:
-    if len(output) != len(order_values):
-        raise RayDatasetGenerationError(
-            "RayBackend preserve_order=True requires each Ray worker batch to emit one output row for each "
-            f"input row. Input rows={len(order_values)}, output rows={len(output)}."
-        )
-    output = output.copy()
-    output[hidden_order_column] = order_values
-    return output
-
-
-def _metrics_from_block_result(
-    block_result: Any,
-    *,
-    elapsed_seconds: float,
-    block_id: str,
-    failed_blocks: int = 0,
-) -> RayWorkerMetrics:
-    return RayWorkerMetrics(
-        total_rows=block_result.output_rows,
-        input_rows=block_result.input_rows,
-        output_rows=block_result.output_rows,
-        dropped_rows=block_result.dropped_rows,
-        all_rows_dropped=block_result.all_rows_dropped,
-        partial_rows_dropped=block_result.partial_rows_dropped,
-        blocks=1,
-        failed_blocks=failed_blocks,
-        elapsed_seconds=elapsed_seconds,
-        model_usage=block_result.model_usage_stats or None,
-        block_id=block_id,
-    )
-
-
-def _format_worker_failure_message(*, dataframe: Any, exc: Exception) -> str:
-    context_parts = [f"{len(dataframe)} input row(s)"]
-    if _RAY_INTERNAL_ROW_ID_COLUMN in dataframe.columns:
-        row_ids = [int(value) for value in dataframe[_RAY_INTERNAL_ROW_ID_COLUMN].tolist()]
-        if row_ids:
-            context_parts.append(f"logical rows {min(row_ids)}-{max(row_ids)}")
-    elif ray_seed_planning.RAY_RANGE_ID_COLUMN in dataframe.columns:
-        row_ids = [int(value) for value in dataframe[ray_seed_planning.RAY_RANGE_ID_COLUMN].tolist()]
-        if row_ids:
-            context_parts.append(f"range rows {min(row_ids)}-{max(row_ids)}")
-    task_context = _get_ray_task_context()
-    if task_context:
-        context_parts.append(task_context)
-    return f"RayBackend worker failed while generating a Ray block ({', '.join(context_parts)}): {exc}"
-
-
-def _get_ray_task_context() -> str | None:
-    try:
-        ray = importlib.import_module("ray")
-        get_runtime_context = getattr(ray, "get_runtime_context", None)
-        if not callable(get_runtime_context):
-            return None
-        runtime_context = get_runtime_context()
-    except Exception:
-        return None
-
-    context_values: list[str] = []
-    for attr, method_name in (
-        ("task_id", "get_task_id"),
-        ("actor_id", "get_actor_id"),
-        ("worker_id", "get_worker_id"),
-    ):
-        try:
-            method = getattr(runtime_context, method_name, None)
-            value = method() if callable(method) else getattr(runtime_context, attr, None)
-        except Exception:
-            continue
-        if value is None:
-            continue
-        context_values.append(f"{attr}={value}")
-    return ", ".join(context_values) if context_values else None
-
-
-def _record_worker_observability(
-    metrics_collector: Any | None,
-    *,
-    worker_profile: RayWorkerProfile | None,
-    trace_events: list[RayTraceEvent],
-    throttle_snapshots: list[RayThrottleSnapshot],
-) -> None:
-    if metrics_collector is None:
-        return
-    payload = {
-        "worker_profile": worker_profile.to_dict() if worker_profile is not None else None,
-        "trace_events": [event.to_dict() for event in trace_events],
-        "throttle_snapshots": [snapshot.to_dict() for snapshot in throttle_snapshots],
-    }
-    importlib.import_module("ray").get(metrics_collector.record_observability.remote(payload))
-
-
-def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:
-    if metrics_collector is None:
-        return
-    importlib.import_module("ray").get(metrics_collector.record.remote(metrics.to_dict()))
-
-
-def _profile_worker_output(
-    output: Any, *, block_id: str, model_usage: dict[str, dict[str, Any]] | None
-) -> RayWorkerProfile:
-    warnings: list[str] = []
-    try:
-        columns = [str(column) for column in output.columns]
-        column_dtypes = {str(column): str(dtype) for column, dtype in output.dtypes.items()}
-        non_null_counts = {str(column): int(value) for column, value in output.notna().sum().to_dict().items()}
-        null_counts = {str(column): int(value) for column, value in output.isna().sum().to_dict().items()}
-        memory_usage_bytes = int(output.memory_usage(deep=True).sum())
-    except Exception as exc:
-        columns = []
-        column_dtypes = {}
-        non_null_counts = {}
-        null_counts = {}
-        memory_usage_bytes = None
-        warnings.append(f"Failed to profile Ray worker output: {type(exc).__name__}: {exc}")
-    return RayWorkerProfile(
-        block_id=block_id,
-        total_rows=len(output),
-        columns=columns,
-        column_dtypes=column_dtypes,
-        non_null_counts=non_null_counts,
-        null_counts=null_counts,
-        memory_usage_bytes=memory_usage_bytes,
-        model_usage=model_usage,
-        warnings=warnings,
-    )
-
-
-def _snapshot_worker_throttle(throttle_manager: Any | None) -> list[RayThrottleSnapshot]:
-    if throttle_manager is None:
-        return []
-    snapshot = getattr(throttle_manager, "snapshot", None)
-    if not callable(snapshot):
-        return []
-    try:
-        payload = snapshot()
-    except Exception:
-        return []
-    if not isinstance(payload, Mapping):
-        return []
-    global_caps = _effective_max_by_throttle_key(payload.get("global_caps"))
-    domains = payload.get("domains")
-    if not isinstance(domains, list):
-        return []
-    snapshots: list[RayThrottleSnapshot] = []
-    for domain_payload in domains:
-        if not isinstance(domain_payload, Mapping):
-            continue
-        provider_name = domain_payload.get("provider_name")
-        model_id = domain_payload.get("model_id")
-        domain = domain_payload.get("domain")
-        if not all(isinstance(value, str) for value in (provider_name, model_id, domain)):
-            continue
-        effective_max = _safe_optional_int_mapping(domain_payload, "effective_max")
-        if effective_max is None:
-            effective_max = global_caps.get((provider_name, model_id))
-        snapshots.append(
-            RayThrottleSnapshot(
-                provider_name=provider_name,
-                model_id=model_id,
-                domain=domain,
-                current_limit=_safe_int_mapping(domain_payload, "current_limit"),
-                effective_max=effective_max,
-                in_flight=_safe_int_mapping(domain_payload, "in_flight"),
-                waiters=_safe_int_mapping(domain_payload, "waiters"),
-                rate_limit_ceiling=_safe_int_mapping(domain_payload, "rate_limit_ceiling"),
-                consecutive_rate_limits=_safe_int_mapping(
-                    domain_payload,
-                    "consecutive_rate_limits",
-                    fallback_field_name="consecutive_429s",
-                ),
-            )
-        )
-    return snapshots
-
-
-def _effective_max_by_throttle_key(global_caps: Any) -> dict[tuple[str, str], int]:
-    if not isinstance(global_caps, list):
-        return {}
-    effective_by_key: dict[tuple[str, str], int] = {}
-    for cap_payload in global_caps:
-        if not isinstance(cap_payload, Mapping):
-            continue
-        provider_name = cap_payload.get("provider_name")
-        model_id = cap_payload.get("model_id")
-        effective_max = cap_payload.get("effective_max")
-        if (
-            isinstance(provider_name, str)
-            and isinstance(model_id, str)
-            and isinstance(effective_max, int)
-            and not isinstance(effective_max, bool)
-            and effective_max >= 0
-        ):
-            effective_by_key[(provider_name, model_id)] = effective_max
-    return effective_by_key
-
-
-def _task_traces_to_events(
-    task_traces: list[Any],
-    *,
-    block_id: str,
-    worker_context: dict[str, Any],
-) -> list[RayTraceEvent]:
-    events: list[RayTraceEvent] = []
-    for task_trace in task_traces:
-        dispatched_at = _safe_float_attr(task_trace, "dispatched_at")
-        slot_acquired_at = _safe_float_attr(task_trace, "slot_acquired_at")
-        completed_at = _safe_float_attr(task_trace, "completed_at")
-        elapsed_seconds = max(completed_at - dispatched_at, 0.0) if completed_at > 0 and dispatched_at > 0 else 0.0
-        wait_seconds = max(slot_acquired_at - dispatched_at, 0.0) if slot_acquired_at > 0 and dispatched_at > 0 else 0.0
-        run_seconds = max(completed_at - slot_acquired_at, 0.0) if completed_at > 0 and slot_acquired_at > 0 else 0.0
-        events.append(
-            RayTraceEvent(
-                block_id=block_id,
-                event_type="engine_task",
-                timestamp_seconds=time.time(),
-                elapsed_seconds=elapsed_seconds,
-                row_count=0,
-                worker_hostname=worker_context["worker_hostname"],
-                worker_pid=worker_context["worker_pid"],
-                ray_task_id=worker_context.get("ray_task_id"),
-                ray_node_id=worker_context.get("ray_node_id"),
-                details={
-                    "column": getattr(task_trace, "column", None),
-                    "row_group": getattr(task_trace, "row_group", None),
-                    "row_index": getattr(task_trace, "row_index", None),
-                    "task_type": getattr(task_trace, "task_type", None),
-                    "status": getattr(task_trace, "status", None),
-                    "error": getattr(task_trace, "error", None),
-                    "queue_wait_seconds": wait_seconds,
-                    "run_seconds": run_seconds,
-                },
-            )
-        )
-    return events
-
-
-def _create_trace_event(
-    block_id: str,
-    event_type: str,
-    start_time: float,
-    *,
-    row_count: int,
-    worker_context: dict[str, Any],
-    details: dict[str, Any] | None = None,
-) -> RayTraceEvent:
-    return RayTraceEvent(
-        block_id=block_id,
-        event_type=event_type,
-        timestamp_seconds=time.time(),
-        elapsed_seconds=time.perf_counter() - start_time,
-        row_count=row_count,
-        worker_hostname=worker_context["worker_hostname"],
-        worker_pid=worker_context["worker_pid"],
-        ray_task_id=worker_context.get("ray_task_id"),
-        ray_node_id=worker_context.get("ray_node_id"),
-        details=details,
-    )
-
-
-def _get_ray_worker_context() -> dict[str, Any]:
-    context: dict[str, Any] = {
-        "worker_hostname": socket.gethostname(),
-        "worker_pid": os.getpid(),
-        "ray_task_id": None,
-        "ray_node_id": None,
-    }
-    try:
-        ray = importlib.import_module("ray")
-        get_runtime_context = getattr(ray, "get_runtime_context", None)
-        runtime_context = get_runtime_context() if callable(get_runtime_context) else None
-    except Exception:
-        runtime_context = None
-    if runtime_context is None:
-        return context
-    context["ray_task_id"] = _runtime_context_value(runtime_context, "get_task_id")
-    context["ray_node_id"] = _runtime_context_value(runtime_context, "get_node_id")
-    return context
-
-
-def _runtime_context_value(runtime_context: Any, method_name: str) -> str | None:
-    method = getattr(runtime_context, method_name, None)
-    if not callable(method):
-        return None
-    try:
-        value = method()
-    except Exception:
-        return None
-    return str(value) if value is not None else None
-
-
-def _safe_int_mapping(
-    payload: Mapping[str, Any],
-    field_name: str,
-    *,
-    fallback_field_name: str | None = None,
-) -> int:
-    value = payload.get(field_name)
-    if value is None and fallback_field_name is not None:
-        value = payload.get(fallback_field_name)
-    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
-
-
-def _safe_optional_int_mapping(payload: Mapping[str, Any], field_name: str) -> int | None:
-    value = payload.get(field_name)
-    if value is None:
-        return None
-    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
-
-
-def _safe_float_attr(value: Any, attr_name: str) -> float:
-    attr = getattr(value, attr_name, 0.0)
-    return float(attr) if isinstance(attr, (int, float)) and not isinstance(attr, bool) and attr >= 0 else 0.0
-
-
 def _has_observability_payload(payload: dict[str, Any]) -> bool:
     return bool(
         payload.get("worker_profiles")
@@ -1552,14 +902,6 @@ def _has_observability_payload(payload: dict[str, Any]) -> bool:
         or payload.get("trace_events_dropped")
         or payload.get("throttle_snapshots")
     )
-
-
-def _coerce_pandas_dataframe(batch: Any) -> Any:
-    if isinstance(batch, lazy.pd.DataFrame):
-        return batch
-    if isinstance(batch, dict):
-        return lazy.pd.DataFrame(batch)
-    return lazy.pd.DataFrame(batch)
 
 
 def _import_ray() -> Any:

--- a/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
@@ -1,0 +1,862 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+import importlib
+import os
+import pickle
+import socket
+import time
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.data_designer_config import DataDesignerConfig
+from data_designer.config.run_config import RunConfig
+from data_designer.config.seed import SeedConfig
+from data_designer.engine.dataset_builders.block_execution import (
+    BlockExecutionOptions,
+    BlockExecutionResult,
+    execute_dataset_block,
+)
+from data_designer.engine.resources.person_reader import PersonReader
+from data_designer.engine.resources.seed_reader import SeedReader
+from data_designer.engine.secret_resolver import SecretResolver
+from data_designer.integrations.ray import seed_planning as ray_seed_planning
+from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
+from data_designer.integrations.ray.metrics import RayWorkerMetrics
+from data_designer.integrations.ray.observability import RayThrottleSnapshot, RayTraceEvent, RayWorkerProfile
+
+if TYPE_CHECKING:
+    from data_designer.config.mcp import MCPProviderT
+    from data_designer.config.models import ModelProvider
+
+
+_RAY_INTERNAL_ROW_ID_COLUMN = "__data_designer_ray_row_id"
+_ExecuteDatasetBlock = Callable[..., BlockExecutionResult]
+
+
+@dataclass(frozen=True)
+class _RayWorkerOptions:
+    model_providers: list[ModelProvider]
+    default_provider_name: str
+    secret_resolver: SecretResolver
+    seed_readers: list[SeedReader]
+    managed_assets_path: str
+    person_reader: PersonReader | None
+    mcp_providers: list[MCPProviderT]
+    run_config: RunConfig
+    throttle_manager: Any | None = None
+
+
+@dataclass(frozen=True)
+class _RayExecutionPayload:
+    config_json: str
+    worker_options: _RayWorkerOptions
+    use_input_dataset: bool
+    seed_window: ray_seed_planning.RaySeedWindow | None = None
+    seed_config: SeedConfig | None = None
+    hidden_order_column: str | None = None
+
+
+@dataclass(frozen=True)
+class _RayObservabilityOptions:
+    profile_workers: bool = False
+    trace_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class _RayWorkerBatch:
+    dataframe: Any
+    num_records: int
+    block_id: str
+    start_time: float
+    worker_context: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _RayWorkerGenerationResult:
+    dataframe: Any
+    block_result: BlockExecutionResult
+    model_usage: dict[str, dict[str, Any]] | None
+
+
+class _RayWorkerAllRowsDroppedError(Exception):
+    def __init__(self, block_result: BlockExecutionResult) -> None:
+        super().__init__(
+            f"all input rows were dropped during block execution (input_rows={block_result.input_rows}, output_rows=0)"
+        )
+        self.block_result = block_result
+
+
+class _RayWorkerGenerationPipeline:
+    """Execute one Ray worker batch through named generation phases."""
+
+    def __init__(
+        self,
+        *,
+        execution_payload: _RayExecutionPayload,
+        metrics_collector: Any | None = None,
+        observability_options: _RayObservabilityOptions | None = None,
+        execute_block: _ExecuteDatasetBlock | None = None,
+    ) -> None:
+        os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1"
+        self._execution_payload = execution_payload
+        self._observability_options = observability_options or _RayObservabilityOptions()
+        self._worker_options = _prepare_worker_options(
+            execution_payload,
+            observability_options=self._observability_options,
+        )
+        self._execute_block = execute_block or execute_dataset_block
+        self._observer = _RayWorkerObserver(
+            metrics_collector=metrics_collector,
+            observability_options=self._observability_options,
+        )
+
+    @property
+    def worker_options(self) -> _RayWorkerOptions:
+        return self._worker_options
+
+    def generate_batch(self, batch: Any) -> Any:
+        worker_batch = self.prepare_batch(batch)
+        batch_observer = self.begin_observability(worker_batch)
+        if worker_batch.num_records == 0:
+            return self.complete_empty_batch(worker_batch, batch_observer)
+        return self.generate_non_empty_batch(worker_batch, batch_observer)
+
+    def begin_observability(self, worker_batch: _RayWorkerBatch) -> _RayWorkerBatchObserver:
+        return self._observer.begin_batch(worker_batch)
+
+    def generate_non_empty_batch(
+        self,
+        worker_batch: _RayWorkerBatch,
+        batch_observer: _RayWorkerBatchObserver,
+    ) -> Any:
+        try:
+            batch_observer.record_generation_started(worker_batch)
+            generation_result = self.generate_rows(worker_batch)
+            return self.complete_successful_batch(worker_batch, generation_result, batch_observer)
+        except _RayWorkerAllRowsDroppedError as exc:
+            batch_observer.record_all_rows_dropped(worker_batch, exc.block_result)
+            raise RayDatasetGenerationError(
+                _format_worker_failure_message(dataframe=worker_batch.dataframe, exc=exc)
+            ) from None
+        except Exception as exc:
+            batch_observer.record_failure(worker_batch, exc)
+            if isinstance(exc, RayDatasetGenerationError):
+                raise
+            raise RayDatasetGenerationError(
+                _format_worker_failure_message(dataframe=worker_batch.dataframe, exc=exc)
+            ) from exc
+
+    def prepare_batch(self, batch: Any) -> _RayWorkerBatch:
+        dataframe = _coerce_pandas_dataframe(batch)
+        return _RayWorkerBatch(
+            dataframe=dataframe,
+            num_records=len(dataframe),
+            block_id=uuid.uuid4().hex,
+            start_time=time.perf_counter(),
+            worker_context=_get_ray_worker_context(),
+        )
+
+    def generate_rows(self, worker_batch: _RayWorkerBatch) -> _RayWorkerGenerationResult:
+        order_values = _get_hidden_order_values(
+            worker_batch.dataframe,
+            hidden_order_column=self._execution_payload.hidden_order_column,
+        )
+        block_config = self.create_block_config(worker_batch.dataframe)
+        input_frame = (
+            _strip_internal_columns(worker_batch.dataframe) if self._execution_payload.use_input_dataset else None
+        )
+        block_result = self._execute_block(
+            data_designer_config=block_config,
+            runtime_context=self._worker_options,
+            input_frame=input_frame,
+            num_records=worker_batch.num_records,
+            options=BlockExecutionOptions(use_async=True, dataset_name="ray-block"),
+        )
+        if block_result.all_rows_dropped:
+            raise _RayWorkerAllRowsDroppedError(block_result)
+
+        output = block_result.dataframe
+        if self._execution_payload.hidden_order_column is not None:
+            output = _append_hidden_order_column(
+                output,
+                order_values=order_values,
+                hidden_order_column=self._execution_payload.hidden_order_column,
+            )
+        return _RayWorkerGenerationResult(
+            dataframe=output,
+            block_result=block_result,
+            model_usage=block_result.model_usage_stats or None,
+        )
+
+    def complete_empty_batch(self, worker_batch: _RayWorkerBatch, batch_observer: _RayWorkerBatchObserver) -> Any:
+        batch_observer.record_empty(worker_batch)
+        return worker_batch.dataframe
+
+    def complete_successful_batch(
+        self,
+        worker_batch: _RayWorkerBatch,
+        generation_result: _RayWorkerGenerationResult,
+        batch_observer: _RayWorkerBatchObserver,
+    ) -> Any:
+        batch_observer.record_success(
+            worker_batch,
+            generation_result,
+            throttle_manager=self._worker_options.throttle_manager,
+        )
+        return generation_result.dataframe
+
+    def create_block_config(self, dataframe: Any) -> DataDesignerConfig:
+        block_config = DataDesignerConfig.model_validate_json(self._execution_payload.config_json)
+        if self._execution_payload.seed_window is not None:
+            if self._execution_payload.seed_config is None:
+                raise RayDatasetGenerationError("RayBackend seed window was provided without a seed config.")
+            block_config.seed_config = ray_seed_planning.create_seed_config_for_window(
+                seed_config=self._execution_payload.seed_config,
+                seed_readers=self._worker_options.seed_readers,
+                secret_resolver=self._worker_options.secret_resolver,
+                dataframe=dataframe,
+                seed_window=self._execution_payload.seed_window,
+            )
+        return block_config
+
+
+class _RayWorkerObserver:
+    def __init__(
+        self,
+        *,
+        metrics_collector: Any | None,
+        observability_options: _RayObservabilityOptions,
+    ) -> None:
+        self._metrics_collector = metrics_collector
+        self._observability_options = observability_options
+
+    def begin_batch(self, worker_batch: _RayWorkerBatch) -> _RayWorkerBatchObserver:
+        batch_observer = _RayWorkerBatchObserver(
+            metrics_collector=self._metrics_collector,
+            observability_options=self._observability_options,
+        )
+        batch_observer.record_block_started(worker_batch)
+        return batch_observer
+
+
+class _RayWorkerBatchObserver:
+    def __init__(
+        self,
+        *,
+        metrics_collector: Any | None,
+        observability_options: _RayObservabilityOptions,
+    ) -> None:
+        self._metrics_collector = metrics_collector
+        self._observability_options = observability_options
+        self._trace_events: list[RayTraceEvent] = []
+
+    def record_block_started(self, worker_batch: _RayWorkerBatch) -> None:
+        if not self._observability_options.trace_enabled:
+            return
+        self._trace_events.append(
+            _create_trace_event(
+                worker_batch.block_id,
+                "block_started",
+                worker_batch.start_time,
+                row_count=worker_batch.num_records,
+                worker_context=worker_batch.worker_context,
+                details={"input_columns": [str(column) for column in worker_batch.dataframe.columns]},
+            )
+        )
+
+    def record_generation_started(self, worker_batch: _RayWorkerBatch) -> None:
+        if not self._observability_options.trace_enabled:
+            return
+        self._trace_events.append(
+            _create_trace_event(
+                worker_batch.block_id,
+                "generation_started",
+                worker_batch.start_time,
+                row_count=worker_batch.num_records,
+                worker_context=worker_batch.worker_context,
+            )
+        )
+
+    def record_empty(self, worker_batch: _RayWorkerBatch) -> None:
+        elapsed_seconds = time.perf_counter() - worker_batch.start_time
+        if self._observability_options.trace_enabled:
+            self._trace_events.append(
+                _create_trace_event(
+                    worker_batch.block_id,
+                    "block_completed",
+                    worker_batch.start_time,
+                    row_count=0,
+                    worker_context=worker_batch.worker_context,
+                    details={"empty_batch": True},
+                )
+            )
+        _record_worker_metrics(
+            self._metrics_collector,
+            RayWorkerMetrics(
+                total_rows=0,
+                input_rows=0,
+                output_rows=0,
+                empty_input=True,
+                blocks=1,
+                elapsed_seconds=elapsed_seconds,
+                block_id=worker_batch.block_id,
+            ),
+        )
+        _record_worker_observability(
+            self._metrics_collector,
+            worker_profile=(
+                _profile_worker_output(worker_batch.dataframe, block_id=worker_batch.block_id, model_usage=None)
+                if self._observability_options.profile_workers
+                else None
+            ),
+            trace_events=self._trace_events,
+            throttle_snapshots=[],
+        )
+
+    def record_success(
+        self,
+        worker_batch: _RayWorkerBatch,
+        generation_result: _RayWorkerGenerationResult,
+        *,
+        throttle_manager: Any | None,
+    ) -> None:
+        elapsed_seconds = time.perf_counter() - worker_batch.start_time
+        block_result = generation_result.block_result
+        if self._observability_options.trace_enabled:
+            self._trace_events.extend(
+                _task_traces_to_events(
+                    block_result.task_traces,
+                    block_id=worker_batch.block_id,
+                    worker_context=worker_batch.worker_context,
+                )
+            )
+            self._trace_events.append(
+                _create_trace_event(
+                    worker_batch.block_id,
+                    "block_completed",
+                    worker_batch.start_time,
+                    row_count=len(generation_result.dataframe),
+                    worker_context=worker_batch.worker_context,
+                    details={
+                        "output_columns": [str(column) for column in generation_result.dataframe.columns],
+                        "input_rows": block_result.input_rows,
+                        "output_rows": block_result.output_rows,
+                        "dropped_rows": block_result.dropped_rows,
+                    },
+                )
+            )
+        _record_worker_metrics(
+            self._metrics_collector,
+            _metrics_from_block_result(
+                block_result,
+                elapsed_seconds=elapsed_seconds,
+                block_id=worker_batch.block_id,
+            ),
+        )
+        _record_worker_observability(
+            self._metrics_collector,
+            worker_profile=(
+                _profile_worker_output(
+                    generation_result.dataframe,
+                    block_id=worker_batch.block_id,
+                    model_usage=generation_result.model_usage,
+                )
+                if self._observability_options.profile_workers
+                else None
+            ),
+            trace_events=self._trace_events,
+            throttle_snapshots=_snapshot_worker_throttle(throttle_manager),
+        )
+
+    def record_all_rows_dropped(self, worker_batch: _RayWorkerBatch, block_result: BlockExecutionResult) -> None:
+        elapsed_seconds = time.perf_counter() - worker_batch.start_time
+        if self._observability_options.trace_enabled:
+            self._trace_events.append(
+                _create_trace_event(
+                    worker_batch.block_id,
+                    "block_failed",
+                    worker_batch.start_time,
+                    row_count=worker_batch.num_records,
+                    worker_context=worker_batch.worker_context,
+                    details={
+                        "error_type": "AllRowsDropped",
+                        "error": "all input rows were dropped",
+                        "input_rows": block_result.input_rows,
+                        "output_rows": block_result.output_rows,
+                        "dropped_rows": block_result.dropped_rows,
+                    },
+                )
+            )
+        _record_worker_metrics(
+            self._metrics_collector,
+            _metrics_from_block_result(
+                block_result,
+                elapsed_seconds=elapsed_seconds,
+                block_id=worker_batch.block_id,
+                failed_blocks=1,
+            ),
+        )
+        _record_worker_observability(
+            self._metrics_collector,
+            worker_profile=None,
+            trace_events=self._trace_events,
+            throttle_snapshots=[],
+        )
+
+    def record_failure(self, worker_batch: _RayWorkerBatch, exc: Exception) -> None:
+        if self._observability_options.trace_enabled:
+            self._trace_events.append(
+                _create_trace_event(
+                    worker_batch.block_id,
+                    "block_failed",
+                    worker_batch.start_time,
+                    row_count=worker_batch.num_records,
+                    worker_context=worker_batch.worker_context,
+                    details={"error_type": type(exc).__name__, "error": str(exc)},
+                )
+            )
+        _record_worker_metrics(
+            self._metrics_collector,
+            RayWorkerMetrics(
+                total_rows=0,
+                input_rows=worker_batch.num_records,
+                output_rows=0,
+                blocks=1,
+                failed_blocks=1,
+                elapsed_seconds=time.perf_counter() - worker_batch.start_time,
+                block_id=worker_batch.block_id,
+            ),
+        )
+        _record_worker_observability(
+            self._metrics_collector,
+            worker_profile=None,
+            trace_events=self._trace_events,
+            throttle_snapshots=[],
+        )
+
+
+def _prepare_worker_options(
+    execution_payload: _RayExecutionPayload,
+    *,
+    observability_options: _RayObservabilityOptions,
+) -> _RayWorkerOptions:
+    worker_options = execution_payload.worker_options
+    run_config = copy.deepcopy(worker_options.run_config)
+    if observability_options.trace_enabled:
+        run_config.async_trace = True
+    seed_readers = copy.deepcopy(worker_options.seed_readers)
+    if execution_payload.use_input_dataset:
+        seed_readers = ray_seed_planning.ensure_dataframe_seed_reader(seed_readers)
+    return replace(
+        worker_options,
+        seed_readers=seed_readers,
+        run_config=run_config,
+    )
+
+
+def _compile_ray_execution_payload(
+    *,
+    config_builder: DataDesignerConfigBuilder,
+    worker_options: _RayWorkerOptions,
+    use_input_dataset: bool,
+    seed_window: ray_seed_planning.RaySeedWindow | None = None,
+    hidden_order_column: str | None = None,
+) -> _RayExecutionPayload:
+    data_designer_config = config_builder.build()
+    payload_seed_config = data_designer_config.seed_config if seed_window is not None else None
+    if seed_window is not None:
+        data_designer_config.seed_config = None
+    config_json = data_designer_config.to_json(indent=None)
+    if config_json is None:
+        raise RayBackendConfigurationError("RayBackend failed to serialize the Data Designer configuration.")
+    payload = _RayExecutionPayload(
+        config_json=config_json,
+        worker_options=worker_options,
+        use_input_dataset=use_input_dataset,
+        seed_window=seed_window,
+        seed_config=payload_seed_config,
+        hidden_order_column=hidden_order_column,
+    )
+    _validate_worker_payload_serializable(payload)
+    return payload
+
+
+def _validate_worker_payload_serializable(payload: _RayExecutionPayload) -> None:
+    try:
+        serializer = importlib.import_module("cloudpickle")
+    except ImportError:
+        serializer = pickle
+    try:
+        serializer.dumps(payload)
+    except Exception as exc:
+        if payload.worker_options.throttle_manager is not None:
+            worker_options = replace(payload.worker_options, throttle_manager=None)
+            payload_without_throttle = replace(payload, worker_options=worker_options)
+            try:
+                serializer.dumps(payload_without_throttle)
+            except Exception:
+                pass
+            else:
+                return
+        raise RayBackendConfigurationError(
+            "RayBackend worker payload is not serializable. Check model providers, seed readers, "
+            "secret resolvers, and MCP providers for process-safe state before launching Ray workers."
+        ) from exc
+
+
+def _strip_internal_columns(dataframe: Any) -> Any:
+    columns_to_drop = [column for column in (_RAY_INTERNAL_ROW_ID_COLUMN,) if column in dataframe.columns]
+    if not columns_to_drop:
+        return dataframe.copy()
+    return dataframe.drop(columns=columns_to_drop).copy()
+
+
+def _get_hidden_order_values(dataframe: Any, *, hidden_order_column: str | None) -> list[int]:
+    if hidden_order_column is None:
+        return []
+    if hidden_order_column in dataframe.columns:
+        values = dataframe[hidden_order_column].tolist()
+    elif ray_seed_planning.RAY_RANGE_ID_COLUMN in dataframe.columns:
+        values = dataframe[ray_seed_planning.RAY_RANGE_ID_COLUMN].tolist()
+    else:
+        raise RayDatasetGenerationError(
+            "RayBackend preserve_order=True could not find the hidden row-id source column in a Ray worker batch."
+        )
+    return [int(value) for value in values]
+
+
+def _append_hidden_order_column(
+    output: Any,
+    *,
+    order_values: list[int],
+    hidden_order_column: str,
+) -> Any:
+    if len(output) != len(order_values):
+        raise RayDatasetGenerationError(
+            "RayBackend preserve_order=True requires each Ray worker batch to emit one output row for each "
+            f"input row. Input rows={len(order_values)}, output rows={len(output)}."
+        )
+    output = output.copy()
+    output[hidden_order_column] = order_values
+    return output
+
+
+def _metrics_from_block_result(
+    block_result: BlockExecutionResult,
+    *,
+    elapsed_seconds: float,
+    block_id: str,
+    failed_blocks: int = 0,
+) -> RayWorkerMetrics:
+    return RayWorkerMetrics(
+        total_rows=block_result.output_rows,
+        input_rows=block_result.input_rows,
+        output_rows=block_result.output_rows,
+        dropped_rows=block_result.dropped_rows,
+        all_rows_dropped=block_result.all_rows_dropped,
+        partial_rows_dropped=block_result.partial_rows_dropped,
+        blocks=1,
+        failed_blocks=failed_blocks,
+        elapsed_seconds=elapsed_seconds,
+        model_usage=block_result.model_usage_stats or None,
+        block_id=block_id,
+    )
+
+
+def _format_worker_failure_message(*, dataframe: Any, exc: Exception) -> str:
+    context_parts = [f"{len(dataframe)} input row(s)"]
+    if _RAY_INTERNAL_ROW_ID_COLUMN in dataframe.columns:
+        row_ids = [int(value) for value in dataframe[_RAY_INTERNAL_ROW_ID_COLUMN].tolist()]
+        if row_ids:
+            context_parts.append(f"logical rows {min(row_ids)}-{max(row_ids)}")
+    elif ray_seed_planning.RAY_RANGE_ID_COLUMN in dataframe.columns:
+        row_ids = [int(value) for value in dataframe[ray_seed_planning.RAY_RANGE_ID_COLUMN].tolist()]
+        if row_ids:
+            context_parts.append(f"range rows {min(row_ids)}-{max(row_ids)}")
+    task_context = _get_ray_task_context()
+    if task_context:
+        context_parts.append(task_context)
+    return f"RayBackend worker failed while generating a Ray block ({', '.join(context_parts)}): {exc}"
+
+
+def _get_ray_task_context() -> str | None:
+    try:
+        ray = importlib.import_module("ray")
+        get_runtime_context = getattr(ray, "get_runtime_context", None)
+        if not callable(get_runtime_context):
+            return None
+        runtime_context = get_runtime_context()
+    except Exception:
+        return None
+
+    context_values: list[str] = []
+    for attr, method_name in (
+        ("task_id", "get_task_id"),
+        ("actor_id", "get_actor_id"),
+        ("worker_id", "get_worker_id"),
+    ):
+        try:
+            method = getattr(runtime_context, method_name, None)
+            value = method() if callable(method) else getattr(runtime_context, attr, None)
+        except Exception:
+            continue
+        if value is None:
+            continue
+        context_values.append(f"{attr}={value}")
+    return ", ".join(context_values) if context_values else None
+
+
+def _record_worker_observability(
+    metrics_collector: Any | None,
+    *,
+    worker_profile: RayWorkerProfile | None,
+    trace_events: list[RayTraceEvent],
+    throttle_snapshots: list[RayThrottleSnapshot],
+) -> None:
+    if metrics_collector is None:
+        return
+    payload = {
+        "worker_profile": worker_profile.to_dict() if worker_profile is not None else None,
+        "trace_events": [event.to_dict() for event in trace_events],
+        "throttle_snapshots": [snapshot.to_dict() for snapshot in throttle_snapshots],
+    }
+    importlib.import_module("ray").get(metrics_collector.record_observability.remote(payload))
+
+
+def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:
+    if metrics_collector is None:
+        return
+    importlib.import_module("ray").get(metrics_collector.record.remote(metrics.to_dict()))
+
+
+def _profile_worker_output(
+    output: Any, *, block_id: str, model_usage: dict[str, dict[str, Any]] | None
+) -> RayWorkerProfile:
+    warnings: list[str] = []
+    try:
+        columns = [str(column) for column in output.columns]
+        column_dtypes = {str(column): str(dtype) for column, dtype in output.dtypes.items()}
+        non_null_counts = {str(column): int(value) for column, value in output.notna().sum().to_dict().items()}
+        null_counts = {str(column): int(value) for column, value in output.isna().sum().to_dict().items()}
+        memory_usage_bytes = int(output.memory_usage(deep=True).sum())
+    except Exception as exc:
+        columns = []
+        column_dtypes = {}
+        non_null_counts = {}
+        null_counts = {}
+        memory_usage_bytes = None
+        warnings.append(f"Failed to profile Ray worker output: {type(exc).__name__}: {exc}")
+    return RayWorkerProfile(
+        block_id=block_id,
+        total_rows=len(output),
+        columns=columns,
+        column_dtypes=column_dtypes,
+        non_null_counts=non_null_counts,
+        null_counts=null_counts,
+        memory_usage_bytes=memory_usage_bytes,
+        model_usage=model_usage,
+        warnings=warnings,
+    )
+
+
+def _snapshot_worker_throttle(throttle_manager: Any | None) -> list[RayThrottleSnapshot]:
+    if throttle_manager is None:
+        return []
+    snapshot = getattr(throttle_manager, "snapshot", None)
+    if not callable(snapshot):
+        return []
+    try:
+        payload = snapshot()
+    except Exception:
+        return []
+    if not isinstance(payload, Mapping):
+        return []
+    global_caps = _effective_max_by_throttle_key(payload.get("global_caps"))
+    domains = payload.get("domains")
+    if not isinstance(domains, list):
+        return []
+    snapshots: list[RayThrottleSnapshot] = []
+    for domain_payload in domains:
+        if not isinstance(domain_payload, Mapping):
+            continue
+        provider_name = domain_payload.get("provider_name")
+        model_id = domain_payload.get("model_id")
+        domain = domain_payload.get("domain")
+        if not all(isinstance(value, str) for value in (provider_name, model_id, domain)):
+            continue
+        effective_max = _safe_optional_int_mapping(domain_payload, "effective_max")
+        if effective_max is None:
+            effective_max = global_caps.get((provider_name, model_id))
+        snapshots.append(
+            RayThrottleSnapshot(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                current_limit=_safe_int_mapping(domain_payload, "current_limit"),
+                effective_max=effective_max,
+                in_flight=_safe_int_mapping(domain_payload, "in_flight"),
+                waiters=_safe_int_mapping(domain_payload, "waiters"),
+                rate_limit_ceiling=_safe_int_mapping(domain_payload, "rate_limit_ceiling"),
+                consecutive_rate_limits=_safe_int_mapping(
+                    domain_payload,
+                    "consecutive_rate_limits",
+                    fallback_field_name="consecutive_429s",
+                ),
+            )
+        )
+    return snapshots
+
+
+def _effective_max_by_throttle_key(global_caps: Any) -> dict[tuple[str, str], int]:
+    if not isinstance(global_caps, list):
+        return {}
+    effective_by_key: dict[tuple[str, str], int] = {}
+    for cap_payload in global_caps:
+        if not isinstance(cap_payload, Mapping):
+            continue
+        provider_name = cap_payload.get("provider_name")
+        model_id = cap_payload.get("model_id")
+        effective_max = cap_payload.get("effective_max")
+        if (
+            isinstance(provider_name, str)
+            and isinstance(model_id, str)
+            and isinstance(effective_max, int)
+            and not isinstance(effective_max, bool)
+            and effective_max >= 0
+        ):
+            effective_by_key[(provider_name, model_id)] = effective_max
+    return effective_by_key
+
+
+def _task_traces_to_events(
+    task_traces: list[Any],
+    *,
+    block_id: str,
+    worker_context: dict[str, Any],
+) -> list[RayTraceEvent]:
+    events: list[RayTraceEvent] = []
+    for task_trace in task_traces:
+        dispatched_at = _safe_float_attr(task_trace, "dispatched_at")
+        slot_acquired_at = _safe_float_attr(task_trace, "slot_acquired_at")
+        completed_at = _safe_float_attr(task_trace, "completed_at")
+        elapsed_seconds = max(completed_at - dispatched_at, 0.0) if completed_at > 0 and dispatched_at > 0 else 0.0
+        wait_seconds = max(slot_acquired_at - dispatched_at, 0.0) if slot_acquired_at > 0 and dispatched_at > 0 else 0.0
+        run_seconds = max(completed_at - slot_acquired_at, 0.0) if completed_at > 0 and slot_acquired_at > 0 else 0.0
+        events.append(
+            RayTraceEvent(
+                block_id=block_id,
+                event_type="engine_task",
+                timestamp_seconds=time.time(),
+                elapsed_seconds=elapsed_seconds,
+                row_count=0,
+                worker_hostname=worker_context["worker_hostname"],
+                worker_pid=worker_context["worker_pid"],
+                ray_task_id=worker_context.get("ray_task_id"),
+                ray_node_id=worker_context.get("ray_node_id"),
+                details={
+                    "column": getattr(task_trace, "column", None),
+                    "row_group": getattr(task_trace, "row_group", None),
+                    "row_index": getattr(task_trace, "row_index", None),
+                    "task_type": getattr(task_trace, "task_type", None),
+                    "status": getattr(task_trace, "status", None),
+                    "error": getattr(task_trace, "error", None),
+                    "queue_wait_seconds": wait_seconds,
+                    "run_seconds": run_seconds,
+                },
+            )
+        )
+    return events
+
+
+def _create_trace_event(
+    block_id: str,
+    event_type: str,
+    start_time: float,
+    *,
+    row_count: int,
+    worker_context: dict[str, Any],
+    details: dict[str, Any] | None = None,
+) -> RayTraceEvent:
+    return RayTraceEvent(
+        block_id=block_id,
+        event_type=event_type,
+        timestamp_seconds=time.time(),
+        elapsed_seconds=time.perf_counter() - start_time,
+        row_count=row_count,
+        worker_hostname=worker_context["worker_hostname"],
+        worker_pid=worker_context["worker_pid"],
+        ray_task_id=worker_context.get("ray_task_id"),
+        ray_node_id=worker_context.get("ray_node_id"),
+        details=details,
+    )
+
+
+def _get_ray_worker_context() -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "worker_hostname": socket.gethostname(),
+        "worker_pid": os.getpid(),
+        "ray_task_id": None,
+        "ray_node_id": None,
+    }
+    try:
+        ray = importlib.import_module("ray")
+        get_runtime_context = getattr(ray, "get_runtime_context", None)
+        runtime_context = get_runtime_context() if callable(get_runtime_context) else None
+    except Exception:
+        runtime_context = None
+    if runtime_context is None:
+        return context
+    context["ray_task_id"] = _runtime_context_value(runtime_context, "get_task_id")
+    context["ray_node_id"] = _runtime_context_value(runtime_context, "get_node_id")
+    return context
+
+
+def _runtime_context_value(runtime_context: Any, method_name: str) -> str | None:
+    method = getattr(runtime_context, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        value = method()
+    except Exception:
+        return None
+    return str(value) if value is not None else None
+
+
+def _safe_int_mapping(
+    payload: Mapping[str, Any],
+    field_name: str,
+    *,
+    fallback_field_name: str | None = None,
+) -> int:
+    value = payload.get(field_name)
+    if value is None and fallback_field_name is not None:
+        value = payload.get(fallback_field_name)
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _safe_optional_int_mapping(payload: Mapping[str, Any], field_name: str) -> int | None:
+    value = payload.get(field_name)
+    if value is None:
+        return None
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _safe_float_attr(value: Any, attr_name: str) -> float:
+    attr = getattr(value, attr_name, 0.0)
+    return float(attr) if isinstance(attr, (int, float)) and not isinstance(attr, bool) and attr >= 0 else 0.0
+
+
+def _coerce_pandas_dataframe(batch: Any) -> Any:
+    if isinstance(batch, lazy.pd.DataFrame):
+        return batch
+    if isinstance(batch, dict):
+        return lazy.pd.DataFrame(batch)
+    return lazy.pd.DataFrame(batch)

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pickle
 import sys
+import time
 import types
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,7 @@ from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
+from data_designer.integrations.ray import worker_pipeline as ray_worker_pipeline
 from data_designer.interface.data_designer import DataDesigner
 
 pytestmark = [pytest.mark.ray_fake, pytest.mark.ray_worker_boundary]
@@ -227,6 +229,109 @@ def test_ray_batch_worker_delegates_to_engine_block_api(
     assert all(call["runtime_context"] is worker._worker_options for call in calls)
     assert all(call["options"].use_async is True for call in calls)
     assert all(call["data_designer_config"].seed_config is None for call in calls)
+
+
+def test_worker_generation_pipeline_core_runs_without_metrics_actor_or_ray_runtime(
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    payload = ray_backend_module._compile_ray_execution_payload(
+        config_builder=_input_expression_config_builder(stub_model_configs),
+        worker_options=_worker_options_from_designer(designer),
+        use_input_dataset=True,
+        hidden_order_column=ray_worker_pipeline._RAY_INTERNAL_ROW_ID_COLUMN,
+    )
+    calls: list[dict[str, Any]] = []
+
+    def execute_dataset_block(**kwargs: Any) -> BlockExecutionResult:
+        calls.append(kwargs)
+        return _block_result(dataframe=lazy.pd.DataFrame({"row": [0, 1]}), input_rows=2)
+
+    pipeline = ray_worker_pipeline._RayWorkerGenerationPipeline(
+        execution_payload=payload,
+        execute_block=execute_dataset_block,
+    )
+    worker_batch = ray_worker_pipeline._RayWorkerBatch(
+        dataframe=lazy.pd.DataFrame(
+            {
+                "x": [1, 2],
+                "label": ["a", "b"],
+                ray_worker_pipeline._RAY_INTERNAL_ROW_ID_COLUMN: [7, 8],
+            }
+        ),
+        num_records=2,
+        block_id="block-core",
+        start_time=time.perf_counter(),
+        worker_context={
+            "worker_hostname": "host",
+            "worker_pid": 123,
+            "ray_task_id": None,
+            "ray_node_id": None,
+        },
+    )
+
+    result = pipeline.generate_rows(worker_batch)
+
+    assert result.dataframe.to_dict(orient="records") == [
+        {"row": 0, ray_worker_pipeline._RAY_INTERNAL_ROW_ID_COLUMN: 7},
+        {"row": 1, ray_worker_pipeline._RAY_INTERNAL_ROW_ID_COLUMN: 8},
+    ]
+    assert len(calls) == 1
+    assert calls[0]["input_frame"].to_dict(orient="records") == [
+        {"x": 1, "label": "a"},
+        {"x": 2, "label": "b"},
+    ]
+    assert calls[0]["runtime_context"] is pipeline.worker_options
+    assert calls[0]["num_records"] == 2
+
+
+def test_worker_observer_records_empty_batch_without_row_generation(
+    fake_ray_installer: Any,
+) -> None:
+    fake_ray = fake_ray_installer(with_remote=True)
+    collector = ray_backend_module._create_metrics_collector(fake_ray)
+    observer = ray_worker_pipeline._RayWorkerObserver(
+        metrics_collector=collector,
+        observability_options=ray_worker_pipeline._RayObservabilityOptions(
+            profile_workers=True,
+            trace_enabled=True,
+        ),
+    )
+    worker_batch = ray_worker_pipeline._RayWorkerBatch(
+        dataframe=lazy.pd.DataFrame({"x": []}),
+        num_records=0,
+        block_id="block-empty",
+        start_time=time.perf_counter(),
+        worker_context={
+            "worker_hostname": "host",
+            "worker_pid": 123,
+            "ray_task_id": "task-id",
+            "ray_node_id": "node-id",
+        },
+    )
+
+    batch_observer = observer.begin_batch(worker_batch)
+    batch_observer.record_empty(worker_batch)
+
+    metrics = fake_ray.get(collector.snapshot.remote())[0]
+    observability = fake_ray.get(collector.observability_snapshot.remote())
+    assert metrics["block_id"] == "block-empty"
+    assert metrics["empty_input"] is True
+    assert metrics["blocks"] == 1
+    assert metrics["input_rows"] == 0
+    assert [event["event_type"] for event in observability["trace_events"]] == [
+        "block_started",
+        "block_completed",
+    ]
+    assert observability["worker_profiles"][0]["block_id"] == "block-empty"
+    assert observability["worker_profiles"][0]["total_rows"] == 0
 
 
 def test_ray_batch_worker_records_partial_row_drop_metrics(


### PR DESCRIPTION
## 📋 Summary
Extracts the Ray worker generation path into an internal worker pipeline so row generation, worker observability, and Ray batch entrypoint orchestration are separated. `_RayBatchWorker.generate_batch()` now delegates through named phase boundaries while preserving existing Ray worker semantics.

## 🔗 Related Issue
Closes #58

## 🔄 Changes
- Added `worker_pipeline.py` to own Ray worker payload/options, batch preparation, block config construction, core row generation, hidden-order handling, failure formatting, metrics, profiling, trace events, and throttle snapshots.
- Reduced `_RayBatchWorker.generate_batch()` to a short phase orchestration method over the extracted pipeline while preserving backend-facing compatibility points used by existing tests.
- Added worker-boundary tests for core generation without a metrics actor or Ray runtime context, and observer recording without row generation.

## 🧪 Testing
- [ ] `make test` passes (not run; focused Ray suites below)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A — internal Ray worker boundary refactor)

Focused commands run:
- `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_semantics.py packages/data-designer/tests/integrations/ray/test_metrics.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py -q` — 107 passed, 1 skipped
- `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_processor_policy.py packages/data-designer/tests/integrations/ray/test_seed_planning.py packages/data-designer/tests/integrations/ray/test_public_api.py packages/data-designer/tests/integrations/ray/test_optional_extra.py -q` — 51 passed
- `uv run ruff check --output-format=full packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py` — passed
- `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py` — passed

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — internal worker pipeline refactor)