### PR TITLE
refactor: move ray observability collection

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -26,11 +26,12 @@ from data_designer.integrations.ray.metrics import (
     aggregate_ray_metrics,
     normalize_ray_worker_metrics,
 )
-from data_designer.integrations.ray.observability import (
-    RayDatasetAnalysis,
-    normalize_ray_throttle_snapshot,
-    normalize_ray_trace_event,
-    normalize_ray_worker_profile,
+from data_designer.integrations.ray.observability import RayDatasetAnalysis
+from data_designer.integrations.ray.observability_collection import (
+    _create_metrics_collector,
+    _has_observability_payload,
+    _RayObservabilityOptions,
+    assemble_ray_dataset_analysis,
 )
 from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, resolve_ray_backend_options
 from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
@@ -40,15 +41,8 @@ from data_designer.integrations.ray.worker_pipeline import (
     _coerce_pandas_dataframe,
     _compile_ray_execution_payload,
     _RayExecutionPayload,
-    _RayObservabilityOptions,
     _RayWorkerGenerationPipeline,
     _RayWorkerOptions,
-)
-from data_designer.integrations.ray.worker_pipeline import (
-    _record_worker_metrics as _record_worker_metrics,
-)
-from data_designer.integrations.ray.worker_pipeline import (
-    _snapshot_worker_throttle as _snapshot_worker_throttle,
 )
 from data_designer.interface.backends import BackendRuntimeContext
 
@@ -197,23 +191,7 @@ class RayDatasetCreationResults:
         if not _has_observability_payload(payload):
             return None
 
-        metrics = self.load_metrics()
-        worker_profiles = [
-            normalize_ray_worker_profile(profile) for profile in payload.get("worker_profiles", []) or []
-        ]
-        trace_events = [normalize_ray_trace_event(event) for event in payload.get("trace_events", []) or []]
-        throttle_snapshots = [
-            normalize_ray_throttle_snapshot(snapshot) for snapshot in payload.get("throttle_snapshots", []) or []
-        ]
-        self._analysis_cache = RayDatasetAnalysis(
-            total_rows=metrics.total_rows,
-            blocks=metrics.blocks,
-            failed_blocks=metrics.failed_blocks,
-            worker_profiles=worker_profiles,
-            trace_events=trace_events,
-            trace_events_dropped=int(payload.get("trace_events_dropped", 0) or 0),
-            throttle_snapshots=throttle_snapshots,
-        )
+        self._analysis_cache = assemble_ray_dataset_analysis(self.load_metrics(), payload)
         return self._analysis_cache
 
     @property
@@ -763,51 +741,6 @@ def _dataset_from_arrow_refs_via_items(ray: Any, refs: list[Any]) -> Any:
     return from_items(records, **kwargs)
 
 
-class _RayMetricsCollector:
-    def __init__(self, max_trace_events: int = 1000) -> None:
-        self._payloads: list[dict[str, Any]] = []
-        self._worker_profiles: list[dict[str, Any]] = []
-        self._trace_events: list[dict[str, Any]] = []
-        self._trace_events_dropped = 0
-        self._throttle_snapshots: list[dict[str, Any]] = []
-        self._max_trace_events = max_trace_events
-
-    def record(self, payload: dict[str, Any]) -> None:
-        self._payloads.append(payload)
-
-    def record_observability(self, payload: dict[str, Any]) -> None:
-        profile = payload.get("worker_profile")
-        if isinstance(profile, dict):
-            self._worker_profiles.append(profile)
-        for event in payload.get("trace_events", []) or []:
-            if len(self._trace_events) >= self._max_trace_events:
-                self._trace_events_dropped += 1
-                continue
-            if isinstance(event, dict):
-                self._trace_events.append(event)
-        for snapshot in payload.get("throttle_snapshots", []) or []:
-            if isinstance(snapshot, dict):
-                self._throttle_snapshots.append(snapshot)
-
-    def snapshot(self) -> list[dict[str, Any]]:
-        return list(self._payloads)
-
-    def observability_snapshot(self) -> dict[str, Any]:
-        return {
-            "worker_profiles": list(self._worker_profiles),
-            "trace_events": list(self._trace_events),
-            "trace_events_dropped": self._trace_events_dropped,
-            "throttle_snapshots": list(self._throttle_snapshots),
-        }
-
-
-def _create_metrics_collector(ray: Any, *, max_trace_events: int = 1000) -> Any | None:
-    remote = getattr(ray, "remote", None)
-    if not callable(remote):
-        return None
-    return remote(_RayMetricsCollector).remote(max_trace_events=max_trace_events)
-
-
 def _merge_driver_and_worker_metrics(
     driver_metrics: RayDatasetMetrics,
     worker_metrics: RayDatasetMetrics,
@@ -893,15 +826,6 @@ def _generate_batch(
         metrics_collector=metrics_collector,
         observability_options=observability_options,
     )(batch)
-
-
-def _has_observability_payload(payload: dict[str, Any]) -> bool:
-    return bool(
-        payload.get("worker_profiles")
-        or payload.get("trace_events")
-        or payload.get("trace_events_dropped")
-        or payload.get("throttle_snapshots")
-    )
 
 
 def _import_ray() -> Any:

--- a/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
@@ -1,0 +1,345 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import os
+import socket
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics
+from data_designer.integrations.ray.observability import (
+    RayDatasetAnalysis,
+    RayThrottleSnapshot,
+    RayTraceEvent,
+    RayWorkerProfile,
+    normalize_ray_throttle_snapshot,
+    normalize_ray_trace_event,
+    normalize_ray_worker_profile,
+)
+
+
+@dataclass(frozen=True)
+class _RayObservabilityOptions:
+    profile_workers: bool = False
+    trace_enabled: bool = False
+
+
+class _RayMetricsCollector:
+    def __init__(self, max_trace_events: int = 1000) -> None:
+        self._payloads: list[dict[str, Any]] = []
+        self._worker_profiles: list[dict[str, Any]] = []
+        self._trace_events: list[dict[str, Any]] = []
+        self._trace_events_dropped = 0
+        self._throttle_snapshots: list[dict[str, Any]] = []
+        self._max_trace_events = max_trace_events
+
+    def record(self, payload: dict[str, Any]) -> None:
+        self._payloads.append(payload)
+
+    def record_observability(self, payload: dict[str, Any]) -> None:
+        profile = payload.get("worker_profile")
+        if isinstance(profile, dict):
+            self._worker_profiles.append(profile)
+        for event in payload.get("trace_events", []) or []:
+            if len(self._trace_events) >= self._max_trace_events:
+                self._trace_events_dropped += 1
+                continue
+            if isinstance(event, dict):
+                self._trace_events.append(event)
+        for snapshot in payload.get("throttle_snapshots", []) or []:
+            if isinstance(snapshot, dict):
+                self._throttle_snapshots.append(snapshot)
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        return list(self._payloads)
+
+    def observability_snapshot(self) -> dict[str, Any]:
+        return {
+            "worker_profiles": list(self._worker_profiles),
+            "trace_events": list(self._trace_events),
+            "trace_events_dropped": self._trace_events_dropped,
+            "throttle_snapshots": list(self._throttle_snapshots),
+        }
+
+
+def _create_metrics_collector(ray: Any, *, max_trace_events: int = 1000) -> Any | None:
+    remote = getattr(ray, "remote", None)
+    if not callable(remote):
+        return None
+    return remote(_RayMetricsCollector).remote(max_trace_events=max_trace_events)
+
+
+def assemble_ray_dataset_analysis(
+    metrics: RayDatasetMetrics,
+    payload: Mapping[str, Any],
+) -> RayDatasetAnalysis | None:
+    if not _has_observability_payload(payload):
+        return None
+    worker_profiles = [normalize_ray_worker_profile(profile) for profile in payload.get("worker_profiles", []) or []]
+    trace_events = [normalize_ray_trace_event(event) for event in payload.get("trace_events", []) or []]
+    throttle_snapshots = [
+        normalize_ray_throttle_snapshot(snapshot) for snapshot in payload.get("throttle_snapshots", []) or []
+    ]
+    return RayDatasetAnalysis(
+        total_rows=metrics.total_rows,
+        blocks=metrics.blocks,
+        failed_blocks=metrics.failed_blocks,
+        worker_profiles=worker_profiles,
+        trace_events=trace_events,
+        trace_events_dropped=int(payload.get("trace_events_dropped", 0) or 0),
+        throttle_snapshots=throttle_snapshots,
+    )
+
+
+def _has_observability_payload(payload: Mapping[str, Any]) -> bool:
+    return bool(
+        payload.get("worker_profiles")
+        or payload.get("trace_events")
+        or payload.get("trace_events_dropped")
+        or payload.get("throttle_snapshots")
+    )
+
+
+def _record_worker_observability(
+    metrics_collector: Any | None,
+    *,
+    worker_profile: RayWorkerProfile | None,
+    trace_events: list[RayTraceEvent],
+    throttle_snapshots: list[RayThrottleSnapshot],
+) -> None:
+    if metrics_collector is None:
+        return
+    payload = {
+        "worker_profile": worker_profile.to_dict() if worker_profile is not None else None,
+        "trace_events": [event.to_dict() for event in trace_events],
+        "throttle_snapshots": [snapshot.to_dict() for snapshot in throttle_snapshots],
+    }
+    importlib.import_module("ray").get(metrics_collector.record_observability.remote(payload))
+
+
+def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:
+    if metrics_collector is None:
+        return
+    importlib.import_module("ray").get(metrics_collector.record.remote(metrics.to_dict()))
+
+
+def _profile_worker_output(
+    output: Any, *, block_id: str, model_usage: dict[str, dict[str, Any]] | None
+) -> RayWorkerProfile:
+    warnings: list[str] = []
+    try:
+        columns = [str(column) for column in output.columns]
+        column_dtypes = {str(column): str(dtype) for column, dtype in output.dtypes.items()}
+        non_null_counts = {str(column): int(value) for column, value in output.notna().sum().to_dict().items()}
+        null_counts = {str(column): int(value) for column, value in output.isna().sum().to_dict().items()}
+        memory_usage_bytes = int(output.memory_usage(deep=True).sum())
+    except Exception as exc:
+        columns = []
+        column_dtypes = {}
+        non_null_counts = {}
+        null_counts = {}
+        memory_usage_bytes = None
+        warnings.append(f"Failed to profile Ray worker output: {type(exc).__name__}: {exc}")
+    return RayWorkerProfile(
+        block_id=block_id,
+        total_rows=len(output),
+        columns=columns,
+        column_dtypes=column_dtypes,
+        non_null_counts=non_null_counts,
+        null_counts=null_counts,
+        memory_usage_bytes=memory_usage_bytes,
+        model_usage=model_usage,
+        warnings=warnings,
+    )
+
+
+def _snapshot_worker_throttle(throttle_manager: Any | None) -> list[RayThrottleSnapshot]:
+    if throttle_manager is None:
+        return []
+    snapshot = getattr(throttle_manager, "snapshot", None)
+    if not callable(snapshot):
+        return []
+    try:
+        payload = snapshot()
+    except Exception:
+        return []
+    if not isinstance(payload, Mapping):
+        return []
+    global_caps = _effective_max_by_throttle_key(payload.get("global_caps"))
+    domains = payload.get("domains")
+    if not isinstance(domains, list):
+        return []
+    snapshots: list[RayThrottleSnapshot] = []
+    for domain_payload in domains:
+        if not isinstance(domain_payload, Mapping):
+            continue
+        provider_name = domain_payload.get("provider_name")
+        model_id = domain_payload.get("model_id")
+        domain = domain_payload.get("domain")
+        if not all(isinstance(value, str) for value in (provider_name, model_id, domain)):
+            continue
+        effective_max = _safe_optional_int_mapping(domain_payload, "effective_max")
+        if effective_max is None:
+            effective_max = global_caps.get((provider_name, model_id))
+        snapshots.append(
+            RayThrottleSnapshot(
+                provider_name=provider_name,
+                model_id=model_id,
+                domain=domain,
+                current_limit=_safe_int_mapping(domain_payload, "current_limit"),
+                effective_max=effective_max,
+                in_flight=_safe_int_mapping(domain_payload, "in_flight"),
+                waiters=_safe_int_mapping(domain_payload, "waiters"),
+                rate_limit_ceiling=_safe_int_mapping(domain_payload, "rate_limit_ceiling"),
+                consecutive_rate_limits=_safe_int_mapping(
+                    domain_payload,
+                    "consecutive_rate_limits",
+                    fallback_field_name="consecutive_429s",
+                ),
+            )
+        )
+    return snapshots
+
+
+def _effective_max_by_throttle_key(global_caps: Any) -> dict[tuple[str, str], int]:
+    if not isinstance(global_caps, list):
+        return {}
+    effective_by_key: dict[tuple[str, str], int] = {}
+    for cap_payload in global_caps:
+        if not isinstance(cap_payload, Mapping):
+            continue
+        provider_name = cap_payload.get("provider_name")
+        model_id = cap_payload.get("model_id")
+        effective_max = cap_payload.get("effective_max")
+        if (
+            isinstance(provider_name, str)
+            and isinstance(model_id, str)
+            and isinstance(effective_max, int)
+            and not isinstance(effective_max, bool)
+            and effective_max >= 0
+        ):
+            effective_by_key[(provider_name, model_id)] = effective_max
+    return effective_by_key
+
+
+def _task_traces_to_events(
+    task_traces: list[Any],
+    *,
+    block_id: str,
+    worker_context: dict[str, Any],
+) -> list[RayTraceEvent]:
+    events: list[RayTraceEvent] = []
+    for task_trace in task_traces:
+        dispatched_at = _safe_float_attr(task_trace, "dispatched_at")
+        slot_acquired_at = _safe_float_attr(task_trace, "slot_acquired_at")
+        completed_at = _safe_float_attr(task_trace, "completed_at")
+        elapsed_seconds = max(completed_at - dispatched_at, 0.0) if completed_at > 0 and dispatched_at > 0 else 0.0
+        wait_seconds = max(slot_acquired_at - dispatched_at, 0.0) if slot_acquired_at > 0 and dispatched_at > 0 else 0.0
+        run_seconds = max(completed_at - slot_acquired_at, 0.0) if completed_at > 0 and slot_acquired_at > 0 else 0.0
+        events.append(
+            RayTraceEvent(
+                block_id=block_id,
+                event_type="engine_task",
+                timestamp_seconds=time.time(),
+                elapsed_seconds=elapsed_seconds,
+                row_count=0,
+                worker_hostname=worker_context["worker_hostname"],
+                worker_pid=worker_context["worker_pid"],
+                ray_task_id=worker_context.get("ray_task_id"),
+                ray_node_id=worker_context.get("ray_node_id"),
+                details={
+                    "column": getattr(task_trace, "column", None),
+                    "row_group": getattr(task_trace, "row_group", None),
+                    "row_index": getattr(task_trace, "row_index", None),
+                    "task_type": getattr(task_trace, "task_type", None),
+                    "status": getattr(task_trace, "status", None),
+                    "error": getattr(task_trace, "error", None),
+                    "queue_wait_seconds": wait_seconds,
+                    "run_seconds": run_seconds,
+                },
+            )
+        )
+    return events
+
+
+def _create_trace_event(
+    block_id: str,
+    event_type: str,
+    start_time: float,
+    *,
+    row_count: int,
+    worker_context: dict[str, Any],
+    details: dict[str, Any] | None = None,
+) -> RayTraceEvent:
+    return RayTraceEvent(
+        block_id=block_id,
+        event_type=event_type,
+        timestamp_seconds=time.time(),
+        elapsed_seconds=time.perf_counter() - start_time,
+        row_count=row_count,
+        worker_hostname=worker_context["worker_hostname"],
+        worker_pid=worker_context["worker_pid"],
+        ray_task_id=worker_context.get("ray_task_id"),
+        ray_node_id=worker_context.get("ray_node_id"),
+        details=details,
+    )
+
+
+def _get_ray_worker_context() -> dict[str, Any]:
+    context: dict[str, Any] = {
+        "worker_hostname": socket.gethostname(),
+        "worker_pid": os.getpid(),
+        "ray_task_id": None,
+        "ray_node_id": None,
+    }
+    try:
+        ray = importlib.import_module("ray")
+        get_runtime_context = getattr(ray, "get_runtime_context", None)
+        runtime_context = get_runtime_context() if callable(get_runtime_context) else None
+    except Exception:
+        runtime_context = None
+    if runtime_context is None:
+        return context
+    context["ray_task_id"] = _runtime_context_value(runtime_context, "get_task_id")
+    context["ray_node_id"] = _runtime_context_value(runtime_context, "get_node_id")
+    return context
+
+
+def _runtime_context_value(runtime_context: Any, method_name: str) -> str | None:
+    method = getattr(runtime_context, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        value = method()
+    except Exception:
+        return None
+    return str(value) if value is not None else None
+
+
+def _safe_int_mapping(
+    payload: Mapping[str, Any],
+    field_name: str,
+    *,
+    fallback_field_name: str | None = None,
+) -> int:
+    value = payload.get(field_name)
+    if value is None and fallback_field_name is not None:
+        value = payload.get(fallback_field_name)
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _safe_optional_int_mapping(payload: Mapping[str, Any], field_name: str) -> int | None:
+    value = payload.get(field_name)
+    if value is None:
+        return None
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _safe_float_attr(value: Any, attr_name: str) -> float:
+    attr = getattr(value, attr_name, 0.0)
+    return float(attr) if isinstance(attr, (int, float)) and not isinstance(attr, bool) and attr >= 0 else 0.0

--- a/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
@@ -7,10 +7,9 @@ import copy
 import importlib
 import os
 import pickle
-import socket
 import time
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
@@ -30,7 +29,17 @@ from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayWorkerMetrics
-from data_designer.integrations.ray.observability import RayThrottleSnapshot, RayTraceEvent, RayWorkerProfile
+from data_designer.integrations.ray.observability import RayTraceEvent
+from data_designer.integrations.ray.observability_collection import (
+    _create_trace_event,
+    _get_ray_worker_context,
+    _profile_worker_output,
+    _RayObservabilityOptions,
+    _record_worker_metrics,
+    _record_worker_observability,
+    _snapshot_worker_throttle,
+    _task_traces_to_events,
+)
 
 if TYPE_CHECKING:
     from data_designer.config.mcp import MCPProviderT
@@ -62,12 +71,6 @@ class _RayExecutionPayload:
     seed_window: ray_seed_planning.RaySeedWindow | None = None
     seed_config: SeedConfig | None = None
     hidden_order_column: str | None = None
-
-
-@dataclass(frozen=True)
-class _RayObservabilityOptions:
-    profile_workers: bool = False
-    trace_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -612,246 +615,6 @@ def _get_ray_task_context() -> str | None:
             continue
         context_values.append(f"{attr}={value}")
     return ", ".join(context_values) if context_values else None
-
-
-def _record_worker_observability(
-    metrics_collector: Any | None,
-    *,
-    worker_profile: RayWorkerProfile | None,
-    trace_events: list[RayTraceEvent],
-    throttle_snapshots: list[RayThrottleSnapshot],
-) -> None:
-    if metrics_collector is None:
-        return
-    payload = {
-        "worker_profile": worker_profile.to_dict() if worker_profile is not None else None,
-        "trace_events": [event.to_dict() for event in trace_events],
-        "throttle_snapshots": [snapshot.to_dict() for snapshot in throttle_snapshots],
-    }
-    importlib.import_module("ray").get(metrics_collector.record_observability.remote(payload))
-
-
-def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetrics) -> None:
-    if metrics_collector is None:
-        return
-    importlib.import_module("ray").get(metrics_collector.record.remote(metrics.to_dict()))
-
-
-def _profile_worker_output(
-    output: Any, *, block_id: str, model_usage: dict[str, dict[str, Any]] | None
-) -> RayWorkerProfile:
-    warnings: list[str] = []
-    try:
-        columns = [str(column) for column in output.columns]
-        column_dtypes = {str(column): str(dtype) for column, dtype in output.dtypes.items()}
-        non_null_counts = {str(column): int(value) for column, value in output.notna().sum().to_dict().items()}
-        null_counts = {str(column): int(value) for column, value in output.isna().sum().to_dict().items()}
-        memory_usage_bytes = int(output.memory_usage(deep=True).sum())
-    except Exception as exc:
-        columns = []
-        column_dtypes = {}
-        non_null_counts = {}
-        null_counts = {}
-        memory_usage_bytes = None
-        warnings.append(f"Failed to profile Ray worker output: {type(exc).__name__}: {exc}")
-    return RayWorkerProfile(
-        block_id=block_id,
-        total_rows=len(output),
-        columns=columns,
-        column_dtypes=column_dtypes,
-        non_null_counts=non_null_counts,
-        null_counts=null_counts,
-        memory_usage_bytes=memory_usage_bytes,
-        model_usage=model_usage,
-        warnings=warnings,
-    )
-
-
-def _snapshot_worker_throttle(throttle_manager: Any | None) -> list[RayThrottleSnapshot]:
-    if throttle_manager is None:
-        return []
-    snapshot = getattr(throttle_manager, "snapshot", None)
-    if not callable(snapshot):
-        return []
-    try:
-        payload = snapshot()
-    except Exception:
-        return []
-    if not isinstance(payload, Mapping):
-        return []
-    global_caps = _effective_max_by_throttle_key(payload.get("global_caps"))
-    domains = payload.get("domains")
-    if not isinstance(domains, list):
-        return []
-    snapshots: list[RayThrottleSnapshot] = []
-    for domain_payload in domains:
-        if not isinstance(domain_payload, Mapping):
-            continue
-        provider_name = domain_payload.get("provider_name")
-        model_id = domain_payload.get("model_id")
-        domain = domain_payload.get("domain")
-        if not all(isinstance(value, str) for value in (provider_name, model_id, domain)):
-            continue
-        effective_max = _safe_optional_int_mapping(domain_payload, "effective_max")
-        if effective_max is None:
-            effective_max = global_caps.get((provider_name, model_id))
-        snapshots.append(
-            RayThrottleSnapshot(
-                provider_name=provider_name,
-                model_id=model_id,
-                domain=domain,
-                current_limit=_safe_int_mapping(domain_payload, "current_limit"),
-                effective_max=effective_max,
-                in_flight=_safe_int_mapping(domain_payload, "in_flight"),
-                waiters=_safe_int_mapping(domain_payload, "waiters"),
-                rate_limit_ceiling=_safe_int_mapping(domain_payload, "rate_limit_ceiling"),
-                consecutive_rate_limits=_safe_int_mapping(
-                    domain_payload,
-                    "consecutive_rate_limits",
-                    fallback_field_name="consecutive_429s",
-                ),
-            )
-        )
-    return snapshots
-
-
-def _effective_max_by_throttle_key(global_caps: Any) -> dict[tuple[str, str], int]:
-    if not isinstance(global_caps, list):
-        return {}
-    effective_by_key: dict[tuple[str, str], int] = {}
-    for cap_payload in global_caps:
-        if not isinstance(cap_payload, Mapping):
-            continue
-        provider_name = cap_payload.get("provider_name")
-        model_id = cap_payload.get("model_id")
-        effective_max = cap_payload.get("effective_max")
-        if (
-            isinstance(provider_name, str)
-            and isinstance(model_id, str)
-            and isinstance(effective_max, int)
-            and not isinstance(effective_max, bool)
-            and effective_max >= 0
-        ):
-            effective_by_key[(provider_name, model_id)] = effective_max
-    return effective_by_key
-
-
-def _task_traces_to_events(
-    task_traces: list[Any],
-    *,
-    block_id: str,
-    worker_context: dict[str, Any],
-) -> list[RayTraceEvent]:
-    events: list[RayTraceEvent] = []
-    for task_trace in task_traces:
-        dispatched_at = _safe_float_attr(task_trace, "dispatched_at")
-        slot_acquired_at = _safe_float_attr(task_trace, "slot_acquired_at")
-        completed_at = _safe_float_attr(task_trace, "completed_at")
-        elapsed_seconds = max(completed_at - dispatched_at, 0.0) if completed_at > 0 and dispatched_at > 0 else 0.0
-        wait_seconds = max(slot_acquired_at - dispatched_at, 0.0) if slot_acquired_at > 0 and dispatched_at > 0 else 0.0
-        run_seconds = max(completed_at - slot_acquired_at, 0.0) if completed_at > 0 and slot_acquired_at > 0 else 0.0
-        events.append(
-            RayTraceEvent(
-                block_id=block_id,
-                event_type="engine_task",
-                timestamp_seconds=time.time(),
-                elapsed_seconds=elapsed_seconds,
-                row_count=0,
-                worker_hostname=worker_context["worker_hostname"],
-                worker_pid=worker_context["worker_pid"],
-                ray_task_id=worker_context.get("ray_task_id"),
-                ray_node_id=worker_context.get("ray_node_id"),
-                details={
-                    "column": getattr(task_trace, "column", None),
-                    "row_group": getattr(task_trace, "row_group", None),
-                    "row_index": getattr(task_trace, "row_index", None),
-                    "task_type": getattr(task_trace, "task_type", None),
-                    "status": getattr(task_trace, "status", None),
-                    "error": getattr(task_trace, "error", None),
-                    "queue_wait_seconds": wait_seconds,
-                    "run_seconds": run_seconds,
-                },
-            )
-        )
-    return events
-
-
-def _create_trace_event(
-    block_id: str,
-    event_type: str,
-    start_time: float,
-    *,
-    row_count: int,
-    worker_context: dict[str, Any],
-    details: dict[str, Any] | None = None,
-) -> RayTraceEvent:
-    return RayTraceEvent(
-        block_id=block_id,
-        event_type=event_type,
-        timestamp_seconds=time.time(),
-        elapsed_seconds=time.perf_counter() - start_time,
-        row_count=row_count,
-        worker_hostname=worker_context["worker_hostname"],
-        worker_pid=worker_context["worker_pid"],
-        ray_task_id=worker_context.get("ray_task_id"),
-        ray_node_id=worker_context.get("ray_node_id"),
-        details=details,
-    )
-
-
-def _get_ray_worker_context() -> dict[str, Any]:
-    context: dict[str, Any] = {
-        "worker_hostname": socket.gethostname(),
-        "worker_pid": os.getpid(),
-        "ray_task_id": None,
-        "ray_node_id": None,
-    }
-    try:
-        ray = importlib.import_module("ray")
-        get_runtime_context = getattr(ray, "get_runtime_context", None)
-        runtime_context = get_runtime_context() if callable(get_runtime_context) else None
-    except Exception:
-        runtime_context = None
-    if runtime_context is None:
-        return context
-    context["ray_task_id"] = _runtime_context_value(runtime_context, "get_task_id")
-    context["ray_node_id"] = _runtime_context_value(runtime_context, "get_node_id")
-    return context
-
-
-def _runtime_context_value(runtime_context: Any, method_name: str) -> str | None:
-    method = getattr(runtime_context, method_name, None)
-    if not callable(method):
-        return None
-    try:
-        value = method()
-    except Exception:
-        return None
-    return str(value) if value is not None else None
-
-
-def _safe_int_mapping(
-    payload: Mapping[str, Any],
-    field_name: str,
-    *,
-    fallback_field_name: str | None = None,
-) -> int:
-    value = payload.get(field_name)
-    if value is None and fallback_field_name is not None:
-        value = payload.get(fallback_field_name)
-    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
-
-
-def _safe_optional_int_mapping(payload: Mapping[str, Any], field_name: str) -> int | None:
-    value = payload.get(field_name)
-    if value is None:
-        return None
-    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
-
-
-def _safe_float_attr(value: Any, attr_name: str) -> float:
-    attr = getattr(value, attr_name, 0.0)
-    return float(attr) if isinstance(attr, (int, float)) and not isinstance(attr, bool) and attr >= 0 else 0.0
 
 
 def _coerce_pandas_dataframe(batch: Any) -> Any:

--- a/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
@@ -15,6 +15,7 @@ from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayDatasetCreationResults, RayDatasetMetrics
 from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray import observability_collection as ray_observability_collection
 from data_designer.integrations.ray.metrics import RayWorkerMetrics, aggregate_ray_metrics
 from data_designer.interface.data_designer import DataDesigner
 
@@ -162,7 +163,7 @@ def test_ray_backend_load_metrics_aggregates_worker_emitted_payloads(
         batch: lazy.pd.DataFrame, *, metrics_collector: Any | None = None, **_: Any
     ) -> lazy.pd.DataFrame:
         row_count = len(batch)
-        ray_backend_module._record_worker_metrics(
+        ray_observability_collection._record_worker_metrics(
             metrics_collector,
             RayWorkerMetrics(
                 total_rows=row_count,

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -21,7 +21,7 @@ from data_designer.integrations.ray import (
     RayTraceEvent,
     RayWorkerProfile,
 )
-from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray import observability_collection as ray_observability_collection
 from data_designer.integrations.ray.observability import normalize_ray_trace_event, normalize_ray_worker_profile
 
 pytestmark = pytest.mark.ray_fake
@@ -31,7 +31,7 @@ def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
     tmp_path: Path,
     stub_sampler_only_config_builder: DataDesignerConfigBuilder,
 ) -> None:
-    collector = ray_backend_module._RayMetricsCollector(max_trace_events=1)
+    collector = ray_observability_collection._RayMetricsCollector(max_trace_events=1)
     collector.record({"total_rows": 2, "blocks": 1, "elapsed_seconds": 0.5, "block_id": "block-a"})
     collector.record_observability(
         {
@@ -101,7 +101,7 @@ def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
 def test_ray_results_load_analysis_returns_none_without_observability_payload(
     stub_sampler_only_config_builder: DataDesignerConfigBuilder,
 ) -> None:
-    collector = ray_backend_module._RayMetricsCollector(max_trace_events=0)
+    collector = ray_observability_collection._RayMetricsCollector(max_trace_events=0)
     collector.record({"total_rows": 0, "blocks": 1, "elapsed_seconds": 0.25})
     results = RayDatasetCreationResults(
         dataset=lazy.pd.DataFrame({"id": []}),
@@ -112,6 +112,10 @@ def test_ray_results_load_analysis_returns_none_without_observability_payload(
     )
 
     assert results.load_analysis() is None
+
+
+def test_assemble_ray_dataset_analysis_returns_none_without_observability_payload() -> None:
+    assert ray_observability_collection.assemble_ray_dataset_analysis(RayDatasetMetrics(blocks=1), {}) is None
 
 
 def test_ray_dataset_analysis_to_report_filters_json_sections(tmp_path: Path) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
+++ b/packages/data-designer/tests/integrations/ray/test_provider_throttling.py
@@ -17,6 +17,7 @@ from data_designer.engine.models.clients.throttle_manager import CAPACITY_POLL_I
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend
 from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray import observability_collection as ray_observability_collection
 from data_designer.integrations.ray.metrics import RayWorkerMetrics
 from data_designer.integrations.ray.throttling import RayThrottleManagerProxy, create_ray_throttle_manager
 from data_designer.interface.data_designer import DataDesigner
@@ -60,7 +61,7 @@ def test_ray_throttle_proxy_coordinates_shared_provider_cap(monkeypatch: pytest.
             "limits_by_alias": {"writer": 1},
         }
     ]
-    worker_snapshots = ray_backend_module._snapshot_worker_throttle(second_worker)
+    worker_snapshots = ray_observability_collection._snapshot_worker_throttle(second_worker)
     assert len(worker_snapshots) == 1
     assert worker_snapshots[0].provider_name == "openai"
     assert worker_snapshots[0].model_id == "gpt-4.1"
@@ -85,7 +86,7 @@ def test_snapshot_worker_throttle_uses_local_manager_public_snapshot() -> None:
         retry_after=0.01,
     )
 
-    snapshots = ray_backend_module._snapshot_worker_throttle(throttle_manager)
+    snapshots = ray_observability_collection._snapshot_worker_throttle(throttle_manager)
 
     assert len(snapshots) == 1
     assert snapshots[0].provider_name == "openai"
@@ -164,7 +165,7 @@ def test_ray_backend_exposes_global_throttle_snapshot_in_metrics(
         )
         throttle_manager.acquire_sync(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
         throttle_manager.release_success(provider_name="openai", model_id="gpt-4.1", domain=ThrottleDomain.CHAT)
-        ray_backend_module._record_worker_metrics(
+        ray_observability_collection._record_worker_metrics(
             metrics_collector,
             RayWorkerMetrics(total_rows=len(batch), blocks=1, elapsed_seconds=0.25),
         )

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -24,6 +24,7 @@ from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray import observability_collection as ray_observability_collection
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.integrations.ray import worker_pipeline as ray_worker_pipeline
 from data_designer.interface.data_designer import DataDesigner
@@ -296,10 +297,10 @@ def test_worker_observer_records_empty_batch_without_row_generation(
     fake_ray_installer: Any,
 ) -> None:
     fake_ray = fake_ray_installer(with_remote=True)
-    collector = ray_backend_module._create_metrics_collector(fake_ray)
+    collector = ray_observability_collection._create_metrics_collector(fake_ray)
     observer = ray_worker_pipeline._RayWorkerObserver(
         metrics_collector=collector,
-        observability_options=ray_worker_pipeline._RayObservabilityOptions(
+        observability_options=ray_observability_collection._RayObservabilityOptions(
             profile_workers=True,
             trace_enabled=True,
         ),
@@ -342,7 +343,7 @@ def test_ray_batch_worker_records_partial_row_drop_metrics(
     stub_model_providers: Any,
 ) -> None:
     fake_ray = fake_ray_installer(with_remote=True)
-    collector = ray_backend_module._create_metrics_collector(fake_ray)
+    collector = ray_observability_collection._create_metrics_collector(fake_ray)
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -382,7 +383,7 @@ def test_ray_batch_worker_fails_all_row_drop_blocks(
     stub_model_providers: Any,
 ) -> None:
     fake_ray = fake_ray_installer(with_remote=True)
-    collector = ray_backend_module._create_metrics_collector(fake_ray)
+    collector = ray_observability_collection._create_metrics_collector(fake_ray)
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,


### PR DESCRIPTION
## 📋 Summary
Move Ray observability collection mechanics into a dedicated internal boundary so backend planning/results and worker generation no longer own collector details. This keeps `_RayWorkerGenerationPipeline` as the worker generation owner while preserving profile, trace, throttle, and metrics collection behavior.

## 🔗 Related Issue
Fixes #60

## 🔄 Changes
- Added `observability_collection.py` for the collector actor, observability options, worker collector writes, trace/profile/throttle helpers, and dataset analysis assembly.
- Updated `backend.py` to delegate collector creation, payload detection, and analysis assembly to the new boundary.
- Updated `worker_pipeline.py` to import collection helpers while preserving `_RayWorkerGenerationPipeline` ownership of worker generation phases.
- Updated Ray tests to import collector and helper coverage from the observability collection boundary.

## 🧪 Testing
- [ ] `make test` passes (not run; targeted Ray integration tests run instead)
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A)

Targeted checks run:
- `uv run pytest packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_public_api.py -q` — 81 passed, 1 skipped
- `uv run pytest packages/data-designer/tests/integrations/ray/test_provider_throttling.py -q` — 4 passed
- `uv run ruff check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py packages/data-designer/src/data_designer/integrations/ray/observability_collection.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py` — passed
- `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py packages/data-designer/src/data_designer/integrations/ray/observability_collection.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py` — passed

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A; internal module boundary move only)
