### PR TITLE
refactor(ray): decouple result artifact loading

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -20,21 +20,15 @@ from data_designer.engine.dataset_builders.block_execution import execute_datase
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
-from data_designer.integrations.ray.metrics import (
-    RayDatasetMetrics,
-    RayWorkerMetrics,
-    aggregate_ray_metrics,
-    normalize_ray_worker_metrics,
-)
+from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics
 from data_designer.integrations.ray.observability import RayDatasetAnalysis
 from data_designer.integrations.ray.observability_collection import (
     _create_metrics_collector,
-    _has_observability_payload,
     _RayObservabilityOptions,
-    assemble_ray_dataset_analysis,
 )
 from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, resolve_ray_backend_options
 from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
+from data_designer.integrations.ray.results import RayResultArtifacts
 from data_designer.integrations.ray.throttling import create_ray_throttle_manager
 from data_designer.integrations.ray.worker_pipeline import (
     _RAY_INTERNAL_ROW_ID_COLUMN,
@@ -112,7 +106,7 @@ class RayJobPlan:
 
 
 class RayDatasetCreationResults:
-    """Results wrapper for Ray-resident Data Designer outputs."""
+    """Public results facade for Ray-resident Data Designer outputs."""
 
     def __init__(
         self,
@@ -126,126 +120,92 @@ class RayDatasetCreationResults:
         output: Any | None = None,
         observability_options: _RayObservabilityOptions | None = None,
     ) -> None:
-        self.dataset = dataset
-        self._config_builder = config_builder
-        self._driver_metrics = metrics
-        self._metrics_cache: RayDatasetMetrics | None = None
-        self._worker_metrics_cache: list[RayWorkerMetrics] | None = None
-        self._analysis_cache: RayDatasetAnalysis | None = None
-        self._ray = ray
-        self._metrics_collector = metrics_collector
-        self._throttle_manager = throttle_manager
-        self._output = output
-        self._observability_options = observability_options or _RayObservabilityOptions()
+        del config_builder, observability_options
+        self._artifacts = RayResultArtifacts(
+            dataset=dataset,
+            metrics=metrics,
+            ray=ray,
+            metrics_collector=metrics_collector,
+            throttle_manager=throttle_manager,
+            output=output,
+        )
+
+    @property
+    def dataset(self) -> Any:
+        """Return the Ray Dataset reference without Ray actor reads or driver materialization."""
+        return self._artifacts.dataset
+
+    @dataset.setter
+    def dataset(self, value: Any) -> None:
+        self._artifacts.dataset = value
 
     def load_dataset(self) -> Any:
-        """Return the Ray Dataset without materializing it on the driver."""
-        return self.dataset
+        """Return the Ray Dataset without Ray actor reads or driver materialization."""
+        return self._artifacts.load_dataset()
 
     def load_analysis(self) -> RayDatasetAnalysis | None:
-        """Return Ray-native worker profiles and bounded traces when available."""
+        """Return Ray-native analysis.
+
+        This may read the Ray metrics actor and can materialize the Ray Dataset
+        once if worker metrics or observability payloads have not been emitted
+        yet.
+        """
         return self.load_observability()
 
     def load_metrics(self) -> RayDatasetMetrics:
-        """Return driver-visible Ray execution metrics."""
-        if self._metrics_cache is not None:
-            return self._metrics_cache
-        if self._ray is None or self._metrics_collector is None:
-            return self._driver_metrics
-        try:
-            worker_metrics_payloads = self._load_worker_metrics_payloads()
-        except Exception as exc:
-            raise RayDatasetGenerationError("RayBackend failed to load worker metrics.") from exc
-        if not worker_metrics_payloads:
-            return self._driver_metrics
-        worker_metrics = aggregate_ray_metrics(
-            worker_metrics_payloads,
-            elapsed_seconds=self._driver_metrics.elapsed_seconds,
-        )
-        self._metrics_cache = _merge_driver_and_worker_metrics(
-            self._driver_metrics,
-            worker_metrics,
-            throttle_metrics=self._load_throttle_metrics(),
-        )
-        return self._metrics_cache
+        """Return driver-visible Ray execution metrics.
+
+        This may read the Ray metrics actor. If the first metrics snapshot is
+        empty, it explicitly materializes the Ray Dataset once and reads the
+        actor again so lazy Ray execution has a chance to emit worker metrics.
+        """
+        return self._artifacts.load_metrics()
 
     def load_worker_metrics(self) -> list[RayWorkerMetrics]:
-        """Return per-worker metrics payloads before dataset-level aggregation."""
-        if self._ray is None or self._metrics_collector is None:
-            return []
-        try:
-            return list(self._load_worker_metrics_payloads())
-        except Exception as exc:
-            raise RayDatasetGenerationError("RayBackend failed to load worker metrics.") from exc
+        """Return per-worker metrics payloads before dataset-level aggregation.
+
+        This may read the Ray metrics actor. If the first metrics snapshot is
+        empty, it explicitly materializes the Ray Dataset once and reads the
+        actor again so lazy Ray execution has a chance to emit worker metrics.
+        """
+        return self._artifacts.load_worker_metrics()
 
     def load_observability(self) -> RayDatasetAnalysis | None:
-        """Return bounded Ray-native profiles, traces, and worker-local throttle snapshots."""
-        if self._analysis_cache is not None:
-            return self._analysis_cache
-        if self._ray is None or self._metrics_collector is None:
-            return None
-        try:
-            payload = self._load_observability_payload()
-        except Exception as exc:
-            raise RayDatasetGenerationError("RayBackend failed to load Ray observability artifacts.") from exc
-        if not _has_observability_payload(payload):
-            return None
+        """Return bounded Ray-native profiles, traces, and worker-local throttle snapshots.
 
-        self._analysis_cache = assemble_ray_dataset_analysis(self.load_metrics(), payload)
-        return self._analysis_cache
+        This may read the Ray metrics actor. If observability is missing before
+        worker execution, it asks the metrics loader to run its explicit
+        materialization fallback before reading observability again.
+        """
+        return self._artifacts.load_observability()
 
     @property
     def metrics(self) -> RayDatasetMetrics:
-        """Return the latest available Ray execution metrics."""
+        """Return the latest available Ray execution metrics.
+
+        This has the same Ray actor read and materialization side effects as
+        ``load_metrics()``.
+        """
         return self.load_metrics()
 
-    def _materialize_dataset_for_metrics(self) -> None:
-        materialize = getattr(self.dataset, "materialize", None)
-        if not callable(materialize):
-            return
-        self.dataset = materialize()
-
-    def _load_worker_metrics_payloads(self) -> list[RayWorkerMetrics]:
-        if self._worker_metrics_cache is not None:
-            return self._worker_metrics_cache
-        payloads = self._ray.get(self._metrics_collector.snapshot.remote())
-        if not payloads:
-            self._materialize_dataset_for_metrics()
-            payloads = self._ray.get(self._metrics_collector.snapshot.remote())
-        self._worker_metrics_cache = [normalize_ray_worker_metrics(payload) for payload in payloads]
-        return self._worker_metrics_cache
-
-    def _load_observability_payload(self) -> dict[str, Any]:
-        observability_snapshot = getattr(self._metrics_collector, "observability_snapshot", None)
-        if observability_snapshot is None:
-            return {}
-        payload = self._ray.get(observability_snapshot.remote())
-        if not _has_observability_payload(payload):
-            self._load_worker_metrics_payloads()
-            payload = self._ray.get(observability_snapshot.remote())
-        return dict(payload)
-
-    def _load_throttle_metrics(self) -> dict[str, Any] | None:
-        if self._throttle_manager is None:
-            return None
-        snapshot = getattr(self._throttle_manager, "snapshot", None)
-        if not callable(snapshot):
-            return None
-        return snapshot()
-
     def to_arrow_refs(self) -> list[Any]:
-        """Return Ray ObjectRefs containing PyArrow tables, one per Ray block."""
-        if self._output is not None:
-            return self._output
-        try:
-            return self.dataset.to_arrow_refs()
-        except Exception as exc:
-            raise RayDatasetGenerationError("RayBackend failed to materialize Arrow ObjectRefs.") from exc
+        """Return Ray ObjectRefs containing PyArrow tables, one per Ray block.
+
+        If the backend already selected ``output="arrow_refs"``, this returns
+        the cached refs. Otherwise it calls ``Ray Dataset.to_arrow_refs()``,
+        which materializes Ray output blocks.
+        """
+        return self._artifacts.to_arrow_refs()
 
     @property
     def output(self) -> Any:
-        """Backend-selected output object."""
-        return self._output if self._output is not None else self.dataset
+        """Backend-selected output object without additional Ray actor reads.
+
+        For dataset output this returns the Ray Dataset reference. For
+        ``output="arrow_refs"`` this returns the refs materialized during
+        backend execution.
+        """
+        return self._artifacts.output
 
 
 class RayBackend:
@@ -739,29 +699,6 @@ def _dataset_from_arrow_refs_via_items(ray: Any, refs: list[Any]) -> Any:
         raise RayDatasetGenerationError("RayBackend Arrow ObjectRef fallback expected PyArrow tables with to_pylist().")
     kwargs = {"override_num_blocks": len(refs)} if refs else {}
     return from_items(records, **kwargs)
-
-
-def _merge_driver_and_worker_metrics(
-    driver_metrics: RayDatasetMetrics,
-    worker_metrics: RayDatasetMetrics,
-    *,
-    throttle_metrics: dict[str, Any] | None = None,
-) -> RayDatasetMetrics:
-    return RayDatasetMetrics(
-        total_rows=worker_metrics.total_rows,
-        input_rows=worker_metrics.input_rows,
-        output_rows=worker_metrics.output_rows,
-        dropped_rows=worker_metrics.dropped_rows,
-        all_rows_dropped_blocks=worker_metrics.all_rows_dropped_blocks,
-        partial_rows_dropped_blocks=worker_metrics.partial_rows_dropped_blocks,
-        empty_input_blocks=worker_metrics.empty_input_blocks,
-        blocks=worker_metrics.blocks,
-        failed_blocks=worker_metrics.failed_blocks,
-        elapsed_seconds=driver_metrics.elapsed_seconds,
-        worker_elapsed_seconds=worker_metrics.worker_elapsed_seconds,
-        model_usage=worker_metrics.model_usage or driver_metrics.model_usage,
-        throttle=throttle_metrics or worker_metrics.throttle or driver_metrics.throttle,
-    )
 
 
 class _RayBatchWorker:

--- a/packages/data-designer/src/data_designer/integrations/ray/results.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/results.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from data_designer.integrations.ray.errors import RayDatasetGenerationError
+from data_designer.integrations.ray.metrics import (
+    RayDatasetMetrics,
+    RayWorkerMetrics,
+    aggregate_ray_metrics,
+    normalize_ray_worker_metrics,
+)
+from data_designer.integrations.ray.observability import RayDatasetAnalysis
+from data_designer.integrations.ray.observability_collection import (
+    _has_observability_payload,
+    assemble_ray_dataset_analysis,
+)
+
+
+class RayResultArtifacts:
+    """Loader boundary for Ray result datasets, metrics, analysis, and output artifacts."""
+
+    def __init__(
+        self,
+        *,
+        dataset: Any,
+        metrics: RayDatasetMetrics,
+        ray: Any | None = None,
+        metrics_collector: Any | None = None,
+        throttle_manager: Any | None = None,
+        output: Any | None = None,
+    ) -> None:
+        self._dataset = dataset
+        self._output = output
+        self._metrics_loader = RayMetricsLoader(
+            driver_metrics=metrics,
+            ray=ray,
+            metrics_collector=metrics_collector,
+            throttle_manager=throttle_manager,
+            materialize_dataset_for_metrics=self._materialize_dataset_for_metrics,
+        )
+        self._analysis_loader = RayAnalysisLoader(
+            ray=ray,
+            metrics_collector=metrics_collector,
+            metrics_loader=self._metrics_loader,
+        )
+
+    @property
+    def dataset(self) -> Any:
+        """Return the current Ray Dataset reference."""
+        return self._dataset
+
+    @dataset.setter
+    def dataset(self, value: Any) -> None:
+        self._dataset = value
+
+    @property
+    def output(self) -> Any:
+        """Return the backend-selected output object without triggering new Ray work."""
+        return self._output if self._output is not None else self._dataset
+
+    def load_dataset(self) -> Any:
+        """Return the current Ray Dataset reference."""
+        return self._dataset
+
+    def load_metrics(self) -> RayDatasetMetrics:
+        """Load dataset-level metrics through the metrics loader."""
+        return self._metrics_loader.load_metrics()
+
+    def load_worker_metrics(self) -> list[RayWorkerMetrics]:
+        """Load per-worker metrics through the metrics loader."""
+        return self._metrics_loader.load_worker_metrics()
+
+    def load_observability(self) -> RayDatasetAnalysis | None:
+        """Load Ray-native analysis through the analysis loader."""
+        return self._analysis_loader.load_observability()
+
+    def to_arrow_refs(self) -> list[Any]:
+        """Return materialized Arrow ObjectRefs for the Ray result dataset."""
+        if self._output is not None:
+            return self._output
+        try:
+            return self._dataset.to_arrow_refs()
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed to materialize Arrow ObjectRefs.") from exc
+
+    def _materialize_dataset_for_metrics(self) -> bool:
+        materialize = getattr(self._dataset, "materialize", None)
+        if not callable(materialize):
+            return False
+        self._dataset = materialize()
+        return True
+
+
+class RayMetricsLoader:
+    """Load and aggregate Ray worker metrics without depending on the public result wrapper."""
+
+    def __init__(
+        self,
+        *,
+        driver_metrics: RayDatasetMetrics,
+        ray: Any | None = None,
+        metrics_collector: Any | None = None,
+        throttle_manager: Any | None = None,
+        materialize_dataset_for_metrics: Callable[[], bool] | None = None,
+    ) -> None:
+        self._driver_metrics = driver_metrics
+        self._ray = ray
+        self._metrics_collector = metrics_collector
+        self._throttle_manager = throttle_manager
+        self._materialize_dataset_for_metrics = materialize_dataset_for_metrics
+        self._metrics_cache: RayDatasetMetrics | None = None
+        self._worker_metrics_cache: list[RayWorkerMetrics] | None = None
+
+    def load_metrics(self) -> RayDatasetMetrics:
+        """Return driver metrics merged with worker metrics and throttle state when available."""
+        if self._metrics_cache is not None:
+            return self._metrics_cache
+        if self._ray is None or self._metrics_collector is None:
+            return self._driver_metrics
+        worker_metrics_payloads = self.load_worker_metrics()
+        if not worker_metrics_payloads:
+            return self._driver_metrics
+        worker_metrics = aggregate_ray_metrics(
+            worker_metrics_payloads,
+            elapsed_seconds=self._driver_metrics.elapsed_seconds,
+        )
+        self._metrics_cache = _merge_driver_and_worker_metrics(
+            self._driver_metrics,
+            worker_metrics,
+            throttle_metrics=self._load_throttle_metrics(),
+        )
+        return self._metrics_cache
+
+    def load_worker_metrics(self) -> list[RayWorkerMetrics]:
+        """Return per-worker metrics, materializing the dataset once if the first snapshot is empty."""
+        if self._ray is None or self._metrics_collector is None:
+            return []
+        try:
+            return list(self._load_worker_metrics_payloads())
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed to load worker metrics.") from exc
+
+    def _load_worker_metrics_payloads(self) -> list[RayWorkerMetrics]:
+        if self._worker_metrics_cache is not None:
+            return self._worker_metrics_cache
+        payloads = self._read_worker_metrics_snapshot()
+        if not payloads:
+            payloads = self._read_worker_metrics_after_materialization_fallback()
+        self._worker_metrics_cache = [normalize_ray_worker_metrics(payload) for payload in payloads]
+        return self._worker_metrics_cache
+
+    def _read_worker_metrics_snapshot(self) -> list[Any]:
+        return list(self._ray.get(self._metrics_collector.snapshot.remote()))
+
+    def _read_worker_metrics_after_materialization_fallback(self) -> list[Any]:
+        if self._materialize_dataset_for_metrics is None:
+            return []
+        if not self._materialize_dataset_for_metrics():
+            return []
+        return self._read_worker_metrics_snapshot()
+
+    def _load_throttle_metrics(self) -> dict[str, Any] | None:
+        if self._throttle_manager is None:
+            return None
+        snapshot = getattr(self._throttle_manager, "snapshot", None)
+        if not callable(snapshot):
+            return None
+        return snapshot()
+
+
+class RayAnalysisLoader:
+    """Load and normalize Ray observability artifacts without the public result wrapper."""
+
+    def __init__(
+        self,
+        *,
+        ray: Any | None = None,
+        metrics_collector: Any | None = None,
+        metrics_loader: RayMetricsLoader,
+    ) -> None:
+        self._ray = ray
+        self._metrics_collector = metrics_collector
+        self._metrics_loader = metrics_loader
+        self._analysis_cache: RayDatasetAnalysis | None = None
+
+    def load_observability(self) -> RayDatasetAnalysis | None:
+        """Return bounded Ray-native profiles, traces, and worker-local throttle snapshots."""
+        if self._analysis_cache is not None:
+            return self._analysis_cache
+        if self._ray is None or self._metrics_collector is None:
+            return None
+        try:
+            payload = self._load_observability_payload()
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed to load Ray observability artifacts.") from exc
+        if not _has_observability_payload(payload):
+            return None
+
+        self._analysis_cache = assemble_ray_dataset_analysis(self._metrics_loader.load_metrics(), payload)
+        return self._analysis_cache
+
+    def _load_observability_payload(self) -> dict[str, Any]:
+        observability_snapshot = getattr(self._metrics_collector, "observability_snapshot", None)
+        if observability_snapshot is None:
+            return {}
+        payload = self._ray.get(observability_snapshot.remote())
+        if not _has_observability_payload(payload):
+            self._metrics_loader.load_worker_metrics()
+            payload = self._ray.get(observability_snapshot.remote())
+        return dict(payload)
+
+
+def _merge_driver_and_worker_metrics(
+    driver_metrics: RayDatasetMetrics,
+    worker_metrics: RayDatasetMetrics,
+    *,
+    throttle_metrics: dict[str, Any] | None = None,
+) -> RayDatasetMetrics:
+    return RayDatasetMetrics(
+        total_rows=worker_metrics.total_rows,
+        input_rows=worker_metrics.input_rows,
+        output_rows=worker_metrics.output_rows,
+        dropped_rows=worker_metrics.dropped_rows,
+        all_rows_dropped_blocks=worker_metrics.all_rows_dropped_blocks,
+        partial_rows_dropped_blocks=worker_metrics.partial_rows_dropped_blocks,
+        empty_input_blocks=worker_metrics.empty_input_blocks,
+        blocks=worker_metrics.blocks,
+        failed_blocks=worker_metrics.failed_blocks,
+        elapsed_seconds=driver_metrics.elapsed_seconds,
+        worker_elapsed_seconds=worker_metrics.worker_elapsed_seconds,
+        model_usage=worker_metrics.model_usage or driver_metrics.model_usage,
+        throttle=throttle_metrics or worker_metrics.throttle or driver_metrics.throttle,
+    )

--- a/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
+++ b/packages/data-designer/tests/integrations/ray/test_metrics_execution.py
@@ -17,6 +17,7 @@ from data_designer.integrations.ray import RayBackend, RayDatasetCreationResults
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.integrations.ray import observability_collection as ray_observability_collection
 from data_designer.integrations.ray.metrics import RayWorkerMetrics, aggregate_ray_metrics
+from data_designer.integrations.ray.results import RayResultArtifacts
 from data_designer.interface.data_designer import DataDesigner
 
 pytestmark = pytest.mark.ray_fake
@@ -111,6 +112,52 @@ def test_ray_results_load_metrics_preserves_zero_worker_total_rows(
     assert metrics.blocks == 1
     assert metrics.elapsed_seconds == 10.0
     assert metrics.worker_elapsed_seconds == 0.25
+
+
+def test_ray_result_artifacts_load_metrics_materializes_lazy_dataset_when_snapshot_empty() -> None:
+    state = {"materialized": False}
+
+    class LazyMetricsDataset:
+        def __init__(self) -> None:
+            self.materialize_calls = 0
+
+        def materialize(self) -> LazyMetricsDataset:
+            self.materialize_calls += 1
+            state["materialized"] = True
+            return self
+
+    class LazyMetricsCollector:
+        def __init__(self) -> None:
+            self.snapshot_calls = 0
+
+        def snapshot(self) -> list[dict[str, Any]]:
+            self.snapshot_calls += 1
+            if not state["materialized"]:
+                return []
+            return [{"total_rows": 4, "blocks": 1, "elapsed_seconds": 2.0}]
+
+    dataset = LazyMetricsDataset()
+    collector = LazyMetricsCollector()
+    artifacts = RayResultArtifacts(
+        dataset=dataset,
+        metrics=RayDatasetMetrics(total_rows=4, blocks=1, elapsed_seconds=10.0),
+        ray=types.SimpleNamespace(get=lambda ref: ref.value),
+        metrics_collector=FakeActorHandle(collector),
+    )
+
+    metrics = artifacts.load_metrics()
+
+    assert dataset.materialize_calls == 1
+    assert collector.snapshot_calls == 2
+    assert metrics.total_rows == 4
+    assert metrics.blocks == 1
+    assert metrics.elapsed_seconds == 10.0
+    assert metrics.worker_elapsed_seconds == 2.0
+    assert artifacts.load_dataset() is dataset
+
+    assert artifacts.load_metrics() is metrics
+    assert dataset.materialize_calls == 1
+    assert collector.snapshot_calls == 2
 
 
 def test_ray_backend_load_metrics_aggregates_worker_emitted_payloads(

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -23,6 +23,7 @@ from data_designer.integrations.ray import (
 )
 from data_designer.integrations.ray import observability_collection as ray_observability_collection
 from data_designer.integrations.ray.observability import normalize_ray_trace_event, normalize_ray_worker_profile
+from data_designer.integrations.ray.results import RayResultArtifacts
 
 pytestmark = pytest.mark.ray_fake
 
@@ -116,6 +117,39 @@ def test_ray_results_load_analysis_returns_none_without_observability_payload(
 
 def test_assemble_ray_dataset_analysis_returns_none_without_observability_payload() -> None:
     assert ray_observability_collection.assemble_ray_dataset_analysis(RayDatasetMetrics(blocks=1), {}) is None
+
+
+def test_ray_result_artifacts_load_observability_without_public_results() -> None:
+    collector = ray_observability_collection._RayMetricsCollector(max_trace_events=2)
+    collector.record({"total_rows": 1, "blocks": 1, "elapsed_seconds": 0.5, "block_id": "block-a"})
+    collector.record_observability(
+        {
+            "worker_profile": RayWorkerProfile(block_id="block-a", total_rows=1, columns=["id"]).to_dict(),
+            "trace_events": [
+                RayTraceEvent(
+                    block_id="block-a",
+                    event_type="block_completed",
+                    timestamp_seconds=2.0,
+                    elapsed_seconds=0.5,
+                    row_count=1,
+                ).to_dict()
+            ],
+        }
+    )
+    artifacts = RayResultArtifacts(
+        dataset=lazy.pd.DataFrame({"id": [1]}),
+        metrics=RayDatasetMetrics(total_rows=0, blocks=1, elapsed_seconds=1.0),
+        ray=types.SimpleNamespace(get=lambda ref: ref.value),
+        metrics_collector=FakeActorHandle(collector),
+    )
+
+    analysis = artifacts.load_observability()
+
+    assert analysis is not None
+    assert analysis.total_rows == 1
+    assert analysis.blocks == 1
+    assert analysis.worker_profiles[0].block_id == "block-a"
+    assert analysis.trace_events[0].event_type == "block_completed"
 
 
 def test_ray_dataset_analysis_to_report_filters_json_sections(tmp_path: Path) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -41,6 +41,7 @@ def test_ray_package_root_does_not_export_internal_helpers() -> None:
         "normalize_ray_trace_event",
         "normalize_ray_worker_metrics",
         "normalize_ray_worker_profile",
+        "RayResultArtifacts",
     }
 
     assert internal_helpers.isdisjoint(ray.__all__)


### PR DESCRIPTION
## 📋 Summary

This PR makes `RayDatasetCreationResults` a thin public facade and moves metrics, observability, and output artifact loading into focused result collaborators. The result analysis path now delegates to the shared `observability_collection.py` boundary added by #60, while preserving the public result method names and return types.

## 🔗 Related Issue

Fixes #64

## 🔄 Changes

- Added `data_designer.integrations.ray.results` with `RayResultArtifacts`, `RayMetricsLoader`, and `RayAnalysisLoader`.
- Updated `RayDatasetCreationResults` to hold minimal state, delegate loading behavior, and document which methods can read Ray actors or materialize datasets.
- Kept metrics fallback explicit: empty worker snapshots materialize the Ray Dataset once before re-reading the metrics actor.
- Added direct artifact-loader tests for metrics fallback and observability loading without constructing the public result facade.
- Kept `RayResultArtifacts` out of the package-root public API.

## 🧪 Testing

- [ ] `make test` passes (not run; focused Ray suites run below)
- [x] Unit tests added/updated
- [x] E2E tests added/updated (N/A — no E2E changes)

Commands run:
- [x] `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/results.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_public_api.py` — 5 files already formatted
- [x] `uv run ruff check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/results.py packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_public_api.py` — all checks passed
- [x] `uv run pytest packages/data-designer/tests/integrations/ray/test_metrics_execution.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_public_api.py -q` — 22 passed
- [x] `uv run pytest -m ray_fake packages/data-designer/tests/integrations/ray -q` — 171 passed, 1 skipped, 13 deselected

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — no architecture docs changed)
