### PR TITLE
fix(ray): bound observability collector storage

### DIFF
--- a/docs/concepts/deployment-options.md
+++ b/docs/concepts/deployment-options.md
@@ -170,6 +170,13 @@ Ray planning and execution kwargs such as `override_num_blocks`, `read_concurren
 `map_concurrency` are still accepted as compatibility shims, but do not combine them with `block_planning` or
 `execution_options`; effective mixed values raise a configuration error. Prefer the option objects for new code.
 
+Ray observability is bounded on the metrics actor. `profile_workers=True` is enabled by default and computes
+per-block worker summaries before retaining up to `max_worker_profiles=1000` profiles. Trace events are retained up
+to `max_trace_events=1000` when `trace_enabled=True`, and worker-local provider throttle snapshots are retained up to
+`max_throttle_snapshots=1000`. Very large jobs should disable `profile_workers` or lower these limits when driver-side
+diagnostics are less important than profiling overhead and metrics actor memory. `RayDatasetAnalysis` reports dropped
+profile, trace, and throttle snapshot counts when limits are exceeded.
+
 Use Ray only when the driver and workers are inside the same trusted operational boundary, such as a single-tenant
 cluster or a managed cluster with equivalent isolation. A Ray worker may receive provider endpoint configuration and
 may be able to resolve API keys through the configured `SecretResolver` or worker environment. Treat every Ray worker

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -220,6 +220,12 @@ class RayBackend:
     ``execution_options=RayExecutionOptions(...)`` for Ray-specific controls.
     Individual Ray planning and execution kwargs are still accepted as
     backwards-compatible shims.
+
+    Observability artifacts are bounded on the metrics actor. ``profile_workers=True``
+    computes one per-block worker profile before the collector applies
+    ``max_worker_profiles``; trace events and throttle snapshots are bounded by
+    ``max_trace_events`` and ``max_throttle_snapshots``. Keep worker profiling
+    disabled for jobs where profiling overhead matters more than diagnostics.
     """
 
     def __init__(
@@ -243,6 +249,8 @@ class RayBackend:
         profile_workers: bool = True,
         trace_enabled: bool = False,
         max_trace_events: int = 1000,
+        max_worker_profiles: int = 1000,
+        max_throttle_snapshots: int = 1000,
         **legacy_options: Any,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
@@ -252,8 +260,9 @@ class RayBackend:
         _validate_ray_backend_batch_size(batch_size)
         if order_column is not None and order_column == "":
             raise RayBackendConfigurationError("RayBackend order_column must be a non-empty string when provided.")
-        if max_trace_events < 0:
-            raise RayBackendConfigurationError("RayBackend max_trace_events must be non-negative.")
+        _validate_ray_backend_non_negative_int("max_trace_events", max_trace_events)
+        _validate_ray_backend_non_negative_int("max_worker_profiles", max_worker_profiles)
+        _validate_ray_backend_non_negative_int("max_throttle_snapshots", max_throttle_snapshots)
         resolved_options = resolve_ray_backend_options(
             block_planning=block_planning,
             execution_options=execution_options,
@@ -278,6 +287,8 @@ class RayBackend:
         self.profile_workers = profile_workers
         self.trace_enabled = trace_enabled
         self.max_trace_events = max_trace_events
+        self.max_worker_profiles = max_worker_profiles
+        self.max_throttle_snapshots = max_throttle_snapshots
 
     def create(
         self,
@@ -451,10 +462,17 @@ class RayDriverPlanner:
                 hidden_order_column=_RAY_INTERNAL_ROW_ID_COLUMN,
             )
 
-        metrics_collector = _create_metrics_collector(self._ray, max_trace_events=self._backend.max_trace_events)
+        metrics_collector = _create_metrics_collector(
+            self._ray,
+            max_trace_events=self._backend.max_trace_events,
+            max_worker_profiles=self._backend.max_worker_profiles,
+            max_throttle_snapshots=self._backend.max_throttle_snapshots,
+        )
         observability_options = _RayObservabilityOptions(
             profile_workers=self._backend.profile_workers,
             trace_enabled=self._backend.trace_enabled,
+            max_worker_profiles=self._backend.max_worker_profiles,
+            max_throttle_snapshots=self._backend.max_throttle_snapshots,
         )
         throttle_manager = self._create_throttle_manager(runtime_context, config_builder)
         worker_config_builder = _clone_config_builder_for_worker(
@@ -561,6 +579,11 @@ def _validate_ray_backend_batch_size(batch_size: int | None) -> None:
         return
     if isinstance(batch_size, bool) or not isinstance(batch_size, int) or batch_size <= 0:
         raise RayBackendConfigurationError("RayBackend batch_size must be a positive integer or None.")
+
+
+def _validate_ray_backend_non_negative_int(field_name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise RayBackendConfigurationError(f"RayBackend {field_name} must be a non-negative integer.")
 
 
 def _model_health_check_aliases(config_builder: DataDesignerConfigBuilder) -> list[str]:

--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -175,9 +175,11 @@ class RayDatasetAnalysis:
     blocks: int = 0
     failed_blocks: int = 0
     worker_profiles: list[RayWorkerProfile] = field(default_factory=list)
+    worker_profiles_dropped: int = 0
     trace_events: list[RayTraceEvent] = field(default_factory=list)
     trace_events_dropped: int = 0
     throttle_snapshots: list[RayThrottleSnapshot] = field(default_factory=list)
+    throttle_snapshots_dropped: int = 0
 
     def __post_init__(self) -> None:
         validate_non_negative_int_field("total_rows", self.total_rows, field_label=_OBSERVABILITY_FIELD_LABEL)
@@ -189,8 +191,18 @@ class RayDatasetAnalysis:
             field_label=_OBSERVABILITY_FIELD_LABEL,
         )
         validate_non_negative_int_field(
+            "worker_profiles_dropped",
+            self.worker_profiles_dropped,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
             "trace_events_dropped",
             self.trace_events_dropped,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "throttle_snapshots_dropped",
+            self.throttle_snapshots_dropped,
             field_label=_OBSERVABILITY_FIELD_LABEL,
         )
 
@@ -238,15 +250,19 @@ class RayDatasetAnalysis:
                 "failed_blocks": self.failed_blocks,
                 "successful_blocks": self.successful_blocks,
                 "column_names": self.column_names,
+                "worker_profiles_dropped": self.worker_profiles_dropped,
                 "trace_events_dropped": self.trace_events_dropped,
+                "throttle_snapshots_dropped": self.throttle_snapshots_dropped,
             }
         if "worker_profiles" in sections:
             payload["worker_profiles"] = [profile.to_dict() for profile in self.worker_profiles]
+            payload["worker_profiles_dropped"] = self.worker_profiles_dropped
         if "trace_events" in sections:
             payload["trace_events"] = [event.to_dict() for event in self.trace_events]
             payload["trace_events_dropped"] = self.trace_events_dropped
         if "throttle_snapshots" in sections:
             payload["throttle_snapshots"] = [snapshot.to_dict() for snapshot in self.throttle_snapshots]
+            payload["throttle_snapshots_dropped"] = self.throttle_snapshots_dropped
         return payload
 
 

--- a/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
@@ -27,16 +27,27 @@ from data_designer.integrations.ray.observability import (
 class _RayObservabilityOptions:
     profile_workers: bool = False
     trace_enabled: bool = False
+    max_worker_profiles: int = 1000
+    max_throttle_snapshots: int = 1000
 
 
 class _RayMetricsCollector:
-    def __init__(self, max_trace_events: int = 1000) -> None:
+    def __init__(
+        self,
+        max_trace_events: int = 1000,
+        max_worker_profiles: int = 1000,
+        max_throttle_snapshots: int = 1000,
+    ) -> None:
         self._payloads: list[dict[str, Any]] = []
         self._worker_profiles: list[dict[str, Any]] = []
+        self._worker_profiles_dropped = 0
         self._trace_events: list[dict[str, Any]] = []
         self._trace_events_dropped = 0
         self._throttle_snapshots: list[dict[str, Any]] = []
+        self._throttle_snapshots_dropped = 0
         self._max_trace_events = max_trace_events
+        self._max_worker_profiles = max_worker_profiles
+        self._max_throttle_snapshots = max_throttle_snapshots
 
     def record(self, payload: dict[str, Any]) -> None:
         self._payloads.append(payload)
@@ -44,16 +55,24 @@ class _RayMetricsCollector:
     def record_observability(self, payload: dict[str, Any]) -> None:
         profile = payload.get("worker_profile")
         if isinstance(profile, dict):
-            self._worker_profiles.append(profile)
+            if len(self._worker_profiles) >= self._max_worker_profiles:
+                self._worker_profiles_dropped += 1
+            else:
+                self._worker_profiles.append(profile)
         for event in payload.get("trace_events", []) or []:
+            if not isinstance(event, dict):
+                continue
             if len(self._trace_events) >= self._max_trace_events:
                 self._trace_events_dropped += 1
                 continue
-            if isinstance(event, dict):
-                self._trace_events.append(event)
+            self._trace_events.append(event)
         for snapshot in payload.get("throttle_snapshots", []) or []:
-            if isinstance(snapshot, dict):
-                self._throttle_snapshots.append(snapshot)
+            if not isinstance(snapshot, dict):
+                continue
+            if len(self._throttle_snapshots) >= self._max_throttle_snapshots:
+                self._throttle_snapshots_dropped += 1
+                continue
+            self._throttle_snapshots.append(snapshot)
 
     def snapshot(self) -> list[dict[str, Any]]:
         return list(self._payloads)
@@ -61,17 +80,29 @@ class _RayMetricsCollector:
     def observability_snapshot(self) -> dict[str, Any]:
         return {
             "worker_profiles": list(self._worker_profiles),
+            "worker_profiles_dropped": self._worker_profiles_dropped,
             "trace_events": list(self._trace_events),
             "trace_events_dropped": self._trace_events_dropped,
             "throttle_snapshots": list(self._throttle_snapshots),
+            "throttle_snapshots_dropped": self._throttle_snapshots_dropped,
         }
 
 
-def _create_metrics_collector(ray: Any, *, max_trace_events: int = 1000) -> Any | None:
+def _create_metrics_collector(
+    ray: Any,
+    *,
+    max_trace_events: int = 1000,
+    max_worker_profiles: int = 1000,
+    max_throttle_snapshots: int = 1000,
+) -> Any | None:
     remote = getattr(ray, "remote", None)
     if not callable(remote):
         return None
-    return remote(_RayMetricsCollector).remote(max_trace_events=max_trace_events)
+    return remote(_RayMetricsCollector).remote(
+        max_trace_events=max_trace_events,
+        max_worker_profiles=max_worker_profiles,
+        max_throttle_snapshots=max_throttle_snapshots,
+    )
 
 
 def assemble_ray_dataset_analysis(
@@ -90,18 +121,22 @@ def assemble_ray_dataset_analysis(
         blocks=metrics.blocks,
         failed_blocks=metrics.failed_blocks,
         worker_profiles=worker_profiles,
+        worker_profiles_dropped=int(payload.get("worker_profiles_dropped", 0) or 0),
         trace_events=trace_events,
         trace_events_dropped=int(payload.get("trace_events_dropped", 0) or 0),
         throttle_snapshots=throttle_snapshots,
+        throttle_snapshots_dropped=int(payload.get("throttle_snapshots_dropped", 0) or 0),
     )
 
 
 def _has_observability_payload(payload: Mapping[str, Any]) -> bool:
     return bool(
         payload.get("worker_profiles")
+        or payload.get("worker_profiles_dropped")
         or payload.get("trace_events")
         or payload.get("trace_events_dropped")
         or payload.get("throttle_snapshots")
+        or payload.get("throttle_snapshots_dropped")
     )
 
 

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -196,11 +196,22 @@ def test_ray_backend_validates_invalid_block_planning_options(kwargs: dict[str, 
         ({"object_ref_format": "json"}, "object_ref_format"),
         ({"order_column": ""}, "order_column"),
         ({"max_trace_events": -1}, "max_trace_events"),
+        ({"max_worker_profiles": -1}, "max_worker_profiles"),
+        ({"max_throttle_snapshots": -1}, "max_throttle_snapshots"),
     ],
 )
 def test_ray_backend_constructor_uses_configuration_error(kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(RayBackendConfigurationError, match=match):
         RayBackend(**kwargs)
+
+
+def test_ray_backend_defaults_bound_observability_storage() -> None:
+    backend = RayBackend()
+
+    assert backend.profile_workers is True
+    assert backend.max_trace_events == 1000
+    assert backend.max_worker_profiles == 1000
+    assert backend.max_throttle_snapshots == 1000
 
 
 @pytest.mark.parametrize("batch_size", [True, "10", 0, -1])
@@ -230,6 +241,40 @@ def test_ray_backend_batch_size_none_uses_run_config_buffer_size(
 
     assert input_dataset.map_batches_kwargs is not None
     assert input_dataset.map_batches_kwargs["batch_size"] == 7
+
+
+def test_ray_backend_threads_observability_limits_to_collector_and_workers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch, with_remote=True)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            max_trace_events=7,
+            max_worker_profiles=8,
+            max_throttle_snapshots=9,
+        ),
+    )
+
+    designer.create(_input_expression_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    constructor_kwargs = input_dataset.map_batches_kwargs["fn_constructor_kwargs"]
+    observability_options = constructor_kwargs["observability_options"]
+    metrics_collector = constructor_kwargs["metrics_collector"]
+    assert observability_options.max_worker_profiles == 8
+    assert observability_options.max_throttle_snapshots == 9
+    assert metrics_collector._actor._max_trace_events == 7
+    assert metrics_collector._actor._max_worker_profiles == 8
+    assert metrics_collector._actor._max_throttle_snapshots == 9
 
 
 def test_ray_driver_planner_captures_from_scratch_plan(

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -88,15 +88,94 @@ def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
     assert analysis.blocks == 1
     assert analysis.worker_profiles[0].block_id == "block-a"
     assert analysis.worker_profiles[0].null_counts == {"id": 0, "label": 1}
+    assert analysis.worker_profiles_dropped == 0
     assert analysis.trace_events[0].event_type == "block_started"
     assert analysis.trace_events_dropped == 1
     assert analysis.throttle_snapshots[0].rate_limit_ceiling == 3
+    assert analysis.throttle_snapshots_dropped == 0
     assert results.load_worker_metrics()[0].block_id == analysis.worker_profiles[0].block_id
 
     report_path = tmp_path / "ray-analysis.json"
     analysis.to_report(report_path)
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["worker_profiles"][0]["block_id"] == "block-a"
+    assert report["worker_profiles_dropped"] == 0
+    assert report["throttle_snapshots_dropped"] == 0
+
+
+def test_ray_metrics_collector_bounds_profiles_and_throttle_snapshots() -> None:
+    collector = ray_observability_collection._RayMetricsCollector(
+        max_trace_events=1,
+        max_worker_profiles=1,
+        max_throttle_snapshots=1,
+    )
+
+    collector.record_observability(
+        {
+            "worker_profile": RayWorkerProfile(block_id="block-a", total_rows=1).to_dict(),
+            "trace_events": [
+                RayTraceEvent(block_id="block-a", event_type="block_started", timestamp_seconds=1.0).to_dict(),
+                RayTraceEvent(block_id="block-a", event_type="block_completed", timestamp_seconds=2.0).to_dict(),
+            ],
+            "throttle_snapshots": [
+                RayThrottleSnapshot(
+                    provider_name="provider",
+                    model_id="model",
+                    domain="chat",
+                    current_limit=1,
+                ).to_dict(),
+                RayThrottleSnapshot(
+                    provider_name="provider",
+                    model_id="model",
+                    domain="embedding",
+                    current_limit=2,
+                ).to_dict(),
+            ],
+        }
+    )
+    collector.record_observability(
+        {
+            "worker_profile": RayWorkerProfile(block_id="block-b", total_rows=1).to_dict(),
+            "trace_events": [
+                RayTraceEvent(block_id="block-b", event_type="block_started", timestamp_seconds=3.0).to_dict()
+            ],
+            "throttle_snapshots": [
+                RayThrottleSnapshot(
+                    provider_name="provider",
+                    model_id="model",
+                    domain="chat",
+                    current_limit=3,
+                ).to_dict()
+            ],
+        }
+    )
+
+    snapshot = collector.observability_snapshot()
+    assert [profile["block_id"] for profile in snapshot["worker_profiles"]] == ["block-a"]
+    assert snapshot["worker_profiles_dropped"] == 1
+    assert [event["block_id"] for event in snapshot["trace_events"]] == ["block-a"]
+    assert snapshot["trace_events_dropped"] == 2
+    assert [throttle_snapshot["domain"] for throttle_snapshot in snapshot["throttle_snapshots"]] == ["chat"]
+    assert snapshot["throttle_snapshots_dropped"] == 2
+
+
+def test_assemble_ray_dataset_analysis_reports_dropped_observability_counts() -> None:
+    analysis = ray_observability_collection.assemble_ray_dataset_analysis(
+        RayDatasetMetrics(total_rows=2, blocks=2),
+        {
+            "worker_profiles_dropped": 2,
+            "trace_events_dropped": 3,
+            "throttle_snapshots_dropped": 4,
+        },
+    )
+
+    assert analysis is not None
+    assert analysis.worker_profiles == []
+    assert analysis.worker_profiles_dropped == 2
+    assert analysis.trace_events == []
+    assert analysis.trace_events_dropped == 3
+    assert analysis.throttle_snapshots == []
+    assert analysis.throttle_snapshots_dropped == 4
 
 
 def test_ray_results_load_analysis_returns_none_without_observability_payload(
@@ -157,11 +236,13 @@ def test_ray_dataset_analysis_to_report_filters_json_sections(tmp_path: Path) ->
         total_rows=2,
         blocks=1,
         worker_profiles=[RayWorkerProfile(block_id="block-a", total_rows=2, columns=["label"])],
+        worker_profiles_dropped=4,
         trace_events=[RayTraceEvent(block_id="block-a", event_type="block_started", timestamp_seconds=1.0)],
         trace_events_dropped=3,
         throttle_snapshots=[
             RayThrottleSnapshot(provider_name="provider", model_id="model", domain="chat", current_limit=1)
         ],
+        throttle_snapshots_dropped=5,
     )
     report_path = tmp_path / "ray-analysis.json"
 
@@ -174,8 +255,10 @@ def test_ray_dataset_analysis_to_report_filters_json_sections(tmp_path: Path) ->
             "column_names": ["label"],
             "failed_blocks": 0,
             "successful_blocks": 1,
+            "throttle_snapshots_dropped": 5,
             "total_rows": 2,
             "trace_events_dropped": 3,
+            "worker_profiles_dropped": 4,
         },
         "trace_events": [
             {


### PR DESCRIPTION
## 📋 Summary
Bound the Ray metrics collector's observability storage for worker profiles and provider throttle snapshots, matching the existing bounded trace-event behavior. This prevents large Ray jobs from accumulating unbounded analysis payloads on the metrics actor while preserving dropped-count visibility in `RayDatasetAnalysis`.

## 🔗 Related Issue
Fixes #77

## 🔄 Changes
- Added `max_worker_profiles` and `max_throttle_snapshots` Ray backend constructor options with 1000-item defaults.
- Bounded `_RayMetricsCollector` worker profile and throttle snapshot retention and added dropped counters for both payload types.
- Threaded dropped counts into `RayDatasetAnalysis`, `to_dict()`, filtered report payloads, and result loading assembly.
- Documented the default observability bounds and the cost of `profile_workers=True` in the Ray deployment docs.
- Added fake-Ray tests for collector overflow, dropped-count-only analysis payloads, backend option threading, and default values.

## 🧪 Testing
- [ ] `make test` passes (not run; targeted Ray suites below)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A)

Targeted checks run:
- `uv run pytest packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py packages/data-designer/tests/integrations/ray/test_public_api.py -q` — 77 passed
- `uv run pytest packages/data-designer/tests/integrations/ray -m ray_fake -q` — 177 passed, 1 skipped, 13 deselected
- `uv run ruff check docs/concepts/deployment-options.md packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/observability_collection.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_observability.py` — passed
- `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/observability_collection.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_observability.py` — passed
- `uv run ruff format --check --preview docs/concepts/deployment-options.md` — passed

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A; Ray deployment docs updated)