### PR TITLE
fix: repair engine v2 benchmark resources

### DIFF
--- a/scripts/benchmarks/benchmark_engine_v2.py
+++ b/scripts/benchmarks/benchmark_engine_v2.py
@@ -590,12 +590,12 @@ def _dataset_fingerprint(df: pd.DataFrame) -> str:
 
 def _run_single_benchmark(settings: BenchmarkSettings, engine_mode: str) -> BenchmarkResult:
     # Imports are deferred so engine selection respects DATA_DESIGNER_ASYNC_ENGINE.
-    from data_designer.engine.dataset_builders.artifact_storage import ArtifactStorage
     from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
     from data_designer.engine.model_provider import resolve_model_provider_registry
     from data_designer.engine.resources.resource_provider import create_resource_provider
     from data_designer.engine.resources.seed_reader import SeedReaderRegistry
     from data_designer.engine.secret_resolver import CompositeResolver, EnvironmentResolver, PlaintextResolver
+    from data_designer.engine.storage.artifact_storage import ArtifactStorage
 
     random.seed(settings.seed)
     np.random.seed(settings.seed)
@@ -630,7 +630,6 @@ def _run_single_benchmark(settings: BenchmarkSettings, engine_mode: str) -> Benc
             secret_resolver=secret_resolver,
             model_provider_registry=model_provider_registry,
             seed_reader_registry=SeedReaderRegistry(readers=[]),
-            blob_storage=None,
             seed_dataset_source=None,
             run_config=run_config,
             mcp_providers=[mcp_provider],


### PR DESCRIPTION
## 📋 Summary

Fixes the engine v2 benchmark startup path after storage/resource-provider APIs moved during the Ray backend work. The benchmark now imports ArtifactStorage from the current storage module and calls create_resource_provider with its current keyword set.

## 🔗 Related Issue

Closes #109

## 🔄 Changes

- Updated scripts/benchmarks/benchmark_engine_v2.py to import ArtifactStorage from data_designer.engine.storage.artifact_storage.
- Removed the obsolete blob_storage=None argument from create_resource_provider.

## 🧪 Testing

- [x] UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff check scripts/benchmarks/benchmark_engine_v2.py - All checks passed!
- [x] UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff format --check scripts/benchmarks/benchmark_engine_v2.py - 1 file already formatted
- [x] UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run --package data-designer python scripts/benchmarks/benchmark_engine_v2.py --mode compare --iterations 1 --num-records 1 --buffer-size 1 --max-parallel-requests 3 --validator-batch-size 1 - completed sync and async tiny benchmark; content match yes

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (N/A - benchmark-only fix)