### PR TITLE
feat: add Ray input dataset repartitioning

### DIFF
--- a/docs/concepts/deployment-options.md
+++ b/docs/concepts/deployment-options.md
@@ -154,7 +154,12 @@ to Ray workers so each worker can construct its local generation engine.
 Use option objects for Ray-specific planning and execution controls, while keeping common constructor arguments direct:
 
 ```python
-from data_designer.integrations.ray import RayBackend, RayBlockPlanning, RayExecutionOptions
+from data_designer.integrations.ray import (
+    RayBackend,
+    RayBlockPlanning,
+    RayExecutionOptions,
+    RayInputRepartition,
+)
 
 backend = RayBackend(
     batch_size=128,
@@ -169,6 +174,24 @@ backend = RayBackend(
 Ray planning and execution kwargs such as `override_num_blocks`, `read_concurrency`, `num_cpus`, and
 `map_concurrency` are still accepted as compatibility shims, but do not combine them with `block_planning` or
 `execution_options`; effective mixed values raise a configuration error. Prefer the option objects for new code.
+
+When passing an existing Ray Dataset or ObjectRefs through `input_dataset`, use `RayInputRepartition` to retune input
+blocks before Data Designer maps generation over them:
+
+```python
+backend = RayBackend(
+    batch_size=512,
+    input_repartition=RayInputRepartition(num_blocks=64),
+)
+
+results = dd.create(config_builder, input_dataset=ray_dataset)
+```
+
+Use `num_blocks` when downstream file or task parallelism needs an exact block count. Use
+`target_num_rows_per_block` when large input blocks should be split with Ray's streaming repartitioning. These controls
+are only for existing `input_dataset` inputs; for from-scratch generation, keep using `RayBlockPlanning`. If an upstream
+Ray pipeline already performs domain-specific partitioning, prefer repartitioning there and leave
+`input_repartition` unset so Data Designer preserves the upstream block layout.
 
 Ray observability is bounded on the metrics actor. `profile_workers=True` is enabled by default and computes
 per-block worker summaries before retaining up to `max_worker_profiles=1000` profiles. Trace events are retained up

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -30,6 +30,7 @@ from data_designer.integrations.ray.observability import (
 from data_designer.integrations.ray.options import (
     RayBlockPlanning,
     RayExecutionOptions,
+    RayInputRepartition,
 )
 
 __all__ = [
@@ -41,6 +42,7 @@ __all__ = [
     "RayDatasetGenerationError",
     "RayDatasetMetrics",
     "RayExecutionOptions",
+    "RayInputRepartition",
     "RayIntegrationError",
     "RayMetricsError",
     "RayThrottleSnapshot",

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -26,7 +26,12 @@ from data_designer.integrations.ray.observability_collection import (
     _create_metrics_collector,
     _RayObservabilityOptions,
 )
-from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, resolve_ray_backend_options
+from data_designer.integrations.ray.options import (
+    RayBlockPlanning,
+    RayExecutionOptions,
+    RayInputRepartition,
+    resolve_ray_backend_options,
+)
 from data_designer.integrations.ray.processor_policy import (
     validate_no_ray_after_generation_processors,
     validate_ray_safe_processors,
@@ -241,6 +246,7 @@ class RayBackend:
         zero_copy_batch: bool = True,
         block_planning: RayBlockPlanning | None = None,
         execution_options: RayExecutionOptions | None = None,
+        input_repartition: RayInputRepartition | None = None,
         preflight_model_health_check: bool = True,
         worker_model_health_checks: bool = False,
         order_column: str | None = None,
@@ -269,10 +275,12 @@ class RayBackend:
         resolved_options = resolve_ray_backend_options(
             block_planning=block_planning,
             execution_options=execution_options,
+            input_repartition=input_repartition,
             legacy_options=legacy_options,
         )
         self.block_planning = resolved_options.block_planning
         self.execution_options = resolved_options.execution_options
+        self.input_repartition = resolved_options.input_repartition
         self.batch_size = batch_size
         self.output = output
         self.object_ref_format = object_ref_format
@@ -383,7 +391,7 @@ class RayBackend:
             if self.object_ref_format == "pandas":
                 return ray.data.from_pandas_refs(refs)
             return ray.data.from_arrow_refs(refs)
-        raise TypeError(
+        raise RayBackendConfigurationError(
             "RayBackend input_dataset must be a ray.data.Dataset or a sequence of Ray ObjectRefs "
             "containing PyArrow tables or pandas DataFrames."
         )
@@ -418,6 +426,11 @@ class RayDriverPlanner:
                 "range dataset. Remove override_num_blocks, target_block_size, min_blocks, max_blocks, "
                 "and read_concurrency when passing input_dataset."
             )
+        if not external_input_dataset and self._backend.input_repartition.has_explicit_controls:
+            raise RayBackendConfigurationError(
+                "RayBackend input_repartition requires input_dataset. "
+                "Use RayBlockPlanning for from-scratch range datasets."
+            )
 
         seed_window: ray_seed_planning.RaySeedWindow | None = None
         if not use_input_dataset and seed_config is not None:
@@ -449,6 +462,8 @@ class RayDriverPlanner:
             num_records=num_records,
             block_plan=block_plan,
         )
+        if external_input_dataset:
+            dataset = _repartition_input_dataset(dataset, self._backend.input_repartition)
         ordering_mode = RayOrderingMode(
             order_column=self._backend.order_column,
             hidden_order_column=(
@@ -560,6 +575,19 @@ def _initial_dataset_source_kind(input_dataset: Any | None) -> RayDatasetSourceK
     if hasattr(input_dataset, "map_batches"):
         return "input_dataset"
     return "object_refs"
+
+
+def _repartition_input_dataset(dataset: Any, input_repartition: RayInputRepartition) -> Any:
+    repartition_kwargs = input_repartition.to_repartition_kwargs()
+    if not repartition_kwargs:
+        return dataset
+    repartition = getattr(dataset, "repartition", None)
+    if not callable(repartition):
+        raise RayBackendConfigurationError("RayBackend input_repartition requires ray.data.Dataset.repartition().")
+    try:
+        return repartition(**repartition_kwargs)
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend failed to repartition the input dataset.") from exc
 
 
 def _create_driver_metrics(

--- a/packages/data-designer/src/data_designer/integrations/ray/options.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/options.py
@@ -231,17 +231,56 @@ class RayExecutionOptions:
 
 
 @dataclass(frozen=True, slots=True)
+class RayInputRepartition:
+    """Controls for Ray Data repartitioning of an existing input dataset."""
+
+    num_blocks: int | None = None
+    target_num_rows_per_block: int | None = None
+    shuffle: bool = False
+
+    def __post_init__(self) -> None:
+        _validate_optional_positive_int("num_blocks", self.num_blocks)
+        _validate_optional_positive_int("target_num_rows_per_block", self.target_num_rows_per_block)
+        if not isinstance(self.shuffle, bool):
+            raise RayBackendConfigurationError("RayInputRepartition shuffle must be a boolean.")
+        if self.num_blocks is not None and self.target_num_rows_per_block is not None:
+            raise RayBackendConfigurationError(
+                "RayInputRepartition num_blocks cannot be combined with target_num_rows_per_block."
+            )
+        if self.shuffle and self.target_num_rows_per_block is not None:
+            raise RayBackendConfigurationError(
+                "RayInputRepartition shuffle can only be used with num_blocks. "
+                "Ray target_num_rows_per_block repartitioning is streaming and does not shuffle."
+            )
+
+    @property
+    def has_explicit_controls(self) -> bool:
+        """Return whether the input dataset should be repartitioned."""
+        return self.num_blocks is not None or self.target_num_rows_per_block is not None
+
+    def to_repartition_kwargs(self) -> dict[str, Any]:
+        """Return keyword arguments accepted by ``ray.data.Dataset.repartition``."""
+        if self.num_blocks is not None:
+            return {"num_blocks": self.num_blocks, "shuffle": self.shuffle}
+        if self.target_num_rows_per_block is not None:
+            return {"target_num_rows_per_block": self.target_num_rows_per_block}
+        return {}
+
+
+@dataclass(frozen=True, slots=True)
 class RayBackendOptionResolution:
     """Resolved RayBackend option objects after applying compatibility shims."""
 
     block_planning: RayBlockPlanning
     execution_options: RayExecutionOptions
+    input_repartition: RayInputRepartition
 
 
 def resolve_ray_backend_options(
     *,
     block_planning: RayBlockPlanning | None = None,
     execution_options: RayExecutionOptions | None = None,
+    input_repartition: RayInputRepartition | None = None,
     legacy_options: Mapping[str, Any] | None = None,
 ) -> RayBackendOptionResolution:
     """Resolve RayBackend planning and execution option objects.
@@ -249,6 +288,7 @@ def resolve_ray_backend_options(
     Args:
         block_planning: Primary block-planning option object.
         execution_options: Primary Ray execution option object.
+        input_repartition: Primary input-dataset repartition option object.
         legacy_options: Backwards-compatible constructor kwargs for individual
             block-planning or execution settings.
 
@@ -279,6 +319,7 @@ def resolve_ray_backend_options(
     return RayBackendOptionResolution(
         block_planning=_resolve_ray_block_planning(block_planning, block_planning_kwargs),
         execution_options=_resolve_ray_execution_options(execution_options, execution_options_kwargs),
+        input_repartition=_resolve_ray_input_repartition(input_repartition),
     )
 
 
@@ -334,6 +375,14 @@ def _resolve_ray_execution_options(
         actor_pool_max_size=legacy_options.get("actor_pool_max_size"),
         actor_pool_initial_size=legacy_options.get("actor_pool_initial_size"),
     )
+
+
+def _resolve_ray_input_repartition(input_repartition: RayInputRepartition | None) -> RayInputRepartition:
+    if input_repartition is None:
+        return RayInputRepartition()
+    if not isinstance(input_repartition, RayInputRepartition):
+        raise RayBackendConfigurationError("RayBackend input_repartition must be a RayInputRepartition instance.")
+    return input_repartition
 
 
 def _has_effective_execution_legacy_options(legacy_options: Mapping[str, Any]) -> bool:

--- a/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
@@ -41,6 +41,7 @@ class FakeRayDataset:
         self.map_batches_kwargs: dict[str, Any] | None = None
         self.map_batches_fn: Any | None = None
         self.map_batches_calls: list[FakeMapBatchesCall] = []
+        self.repartition_calls: list[dict[str, Any]] = []
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         if self.data_module is not None:
@@ -51,11 +52,39 @@ class FakeRayDataset:
         blocks = map_batches_blocks(fn, self.blocks, kwargs)
         if self.reverse_mapped_blocks:
             blocks.reverse()
-        return FakeRayDataset(
+        mapped = FakeRayDataset(
             blocks,
             data_module=self.data_module,
             reverse_mapped_blocks=self.reverse_mapped_blocks,
         )
+        mapped.repartition_calls = list(self.repartition_calls)
+        return mapped
+
+    def repartition(
+        self,
+        num_blocks: int | None = None,
+        *,
+        target_num_rows_per_block: int | None = None,
+        shuffle: bool = False,
+    ) -> FakeRayDataset:
+        self.repartition_calls.append(
+            {
+                "num_blocks": num_blocks,
+                "target_num_rows_per_block": target_num_rows_per_block,
+                "shuffle": shuffle,
+            }
+        )
+        repartitioned = FakeRayDataset(
+            repartition_blocks(
+                self.blocks,
+                num_blocks=num_blocks,
+                target_num_rows_per_block=target_num_rows_per_block,
+            ),
+            data_module=self.data_module,
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
+        repartitioned.repartition_calls = list(self.repartition_calls)
+        return repartitioned
 
     def zip(self, other: FakeRayDataset) -> FakeRayDataset:
         other_df = other.to_pandas()
@@ -67,11 +96,13 @@ class FakeRayDataset:
             other_block = other_df.iloc[offset : offset + block_len].reset_index(drop=True)
             blocks.append(lazy.pd.concat([block_df.reset_index(drop=True), other_block], axis=1))
             offset += block_len
-        return FakeRayDataset(
+        zipped = FakeRayDataset(
             blocks,
             data_module=self.data_module or other.data_module,
             reverse_mapped_blocks=self.reverse_mapped_blocks,
         )
+        zipped.repartition_calls = list(self.repartition_calls)
+        return zipped
 
     def to_arrow_refs(self) -> list[Any]:
         if self.data_module is None:
@@ -88,14 +119,18 @@ class FakeRayDataset:
 
     def sort(self, column: str) -> FakeRayDataset:
         sorted_df = self.to_pandas().sort_values(column, kind="stable").reset_index(drop=True)
-        return FakeRayDataset([sorted_df], data_module=self.data_module)
+        sorted_dataset = FakeRayDataset([sorted_df], data_module=self.data_module)
+        sorted_dataset.repartition_calls = list(self.repartition_calls)
+        return sorted_dataset
 
     def drop_columns(self, columns: list[str]) -> FakeRayDataset:
-        return FakeRayDataset(
+        dropped = FakeRayDataset(
             [coerce_pandas_dataframe(block).drop(columns=columns) for block in self.blocks],
             data_module=self.data_module,
             reverse_mapped_blocks=self.reverse_mapped_blocks,
         )
+        dropped.repartition_calls = list(self.repartition_calls)
+        return dropped
 
     def num_blocks(self) -> int:
         return len(self.blocks)
@@ -270,6 +305,40 @@ def map_batches_blocks(fn: Any, blocks: list[Any], kwargs: dict[str, Any]) -> li
     fn_constructor_kwargs = kwargs.get("fn_constructor_kwargs") or {}
     map_fn = fn(**fn_constructor_kwargs) if isinstance(fn, type) else fn
     return [coerce_pandas_dataframe(map_fn(coerce_pandas_dataframe(block), **fn_kwargs)) for block in blocks]
+
+
+def repartition_blocks(
+    blocks: list[Any],
+    *,
+    num_blocks: int | None,
+    target_num_rows_per_block: int | None,
+) -> list[lazy.pd.DataFrame]:
+    if num_blocks is None and target_num_rows_per_block is None:
+        return [coerce_pandas_dataframe(block) for block in blocks]
+    dataframe = (
+        lazy.pd.concat([coerce_pandas_dataframe(block) for block in blocks], ignore_index=True)
+        if blocks
+        else lazy.pd.DataFrame()
+    )
+    if num_blocks is not None:
+        return split_exact_blocks(dataframe, num_blocks)
+    if target_num_rows_per_block is None:
+        return [coerce_pandas_dataframe(block) for block in blocks]
+    return [
+        dataframe.iloc[start : start + target_num_rows_per_block].reset_index(drop=True)
+        for start in range(0, max(len(dataframe), 1), target_num_rows_per_block)
+    ]
+
+
+def split_exact_blocks(dataframe: lazy.pd.DataFrame, num_blocks: int) -> list[lazy.pd.DataFrame]:
+    block_size, remainder = divmod(len(dataframe), num_blocks)
+    blocks: list[lazy.pd.DataFrame] = []
+    start = 0
+    for block_index in range(num_blocks):
+        stop = start + block_size + (1 if block_index < remainder else 0)
+        blocks.append(dataframe.iloc[start:stop].reset_index(drop=True))
+        start = stop
+    return blocks
 
 
 def coerce_pandas_dataframe(value: Any) -> lazy.pd.DataFrame:

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -28,6 +28,7 @@ from data_designer.integrations.ray import (
     RayDatasetGenerationError,
     RayDatasetMetrics,
     RayExecutionOptions,
+    RayInputRepartition,
 )
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
@@ -176,6 +177,91 @@ def test_ray_backend_rejects_block_planning_with_input_dataset(
     assert input_dataset.map_batches_kwargs is None
 
 
+def test_ray_backend_repartitions_input_dataset_by_num_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1, 2, 3, 4], "label": ["a", "b", "c", "d"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=2,
+            input_repartition=RayInputRepartition(num_blocks=2, shuffle=True),
+        ),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset)
+    output_dataset = results.load_dataset()
+    output_df = output_dataset.to_pandas()
+
+    assert input_dataset.repartition_calls == [{"num_blocks": 2, "target_num_rows_per_block": None, "shuffle": True}]
+    assert output_dataset.repartition_calls == input_dataset.repartition_calls
+    assert output_dataset.num_blocks() == 2
+    assert output_df.to_dict(orient="records") == [
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+        {"x": 3, "label": "c", "x_label": "3-c"},
+        {"x": 4, "label": "d", "x_label": "4-d"},
+    ]
+
+
+def test_ray_backend_repartitions_object_refs_by_target_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    input_refs = [
+        lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]}),
+        lazy.pd.DataFrame({"x": [3], "label": ["c"]}),
+    ]
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=2,
+            input_repartition=RayInputRepartition(target_num_rows_per_block=2),
+        ),
+    )
+
+    output_dataset = designer.create(config_builder, input_dataset=input_refs).load_dataset()
+
+    assert fake_ray.data.from_arrow_refs_input == input_refs
+    assert output_dataset.repartition_calls == [{"num_blocks": None, "target_num_rows_per_block": 2, "shuffle": False}]
+    assert [len(block) for block in output_dataset.blocks] == [2, 1]
+
+
+def test_ray_backend_rejects_input_repartition_without_input_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_sampler_only_config_builder: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(input_repartition=RayInputRepartition(num_blocks=2)),
+    )
+
+    with pytest.raises(RayBackendConfigurationError, match="input_repartition requires input_dataset"):
+        designer.create(stub_sampler_only_config_builder, num_records=4)
+
+    assert fake_ray.data.range_kwargs is None
+
+
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
@@ -203,6 +289,11 @@ def test_ray_backend_validates_invalid_block_planning_options(kwargs: dict[str, 
 def test_ray_backend_constructor_uses_configuration_error(kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(RayBackendConfigurationError, match=match):
         RayBackend(**kwargs)
+
+
+def test_ray_backend_rejects_invalid_input_repartition_object() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="input_repartition"):
+        RayBackend(input_repartition=object())
 
 
 def test_ray_backend_defaults_bound_observability_storage() -> None:
@@ -345,6 +436,41 @@ def test_ray_driver_planner_captures_preserve_order_input_resolution(
     assert plan.ordering_mode.hidden_order_column == ray_backend_module._RAY_INTERNAL_ROW_ID_COLUMN
     assert plan.worker_payload.hidden_order_column == ray_backend_module._RAY_INTERNAL_ROW_ID_COLUMN
     assert ray_backend_module._RAY_INTERNAL_ROW_ID_COLUMN in plan.dataset_source.dataset.to_pandas().columns
+    assert plan.block_plan is None
+
+
+def test_ray_driver_planner_applies_input_repartition_before_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset(
+        [lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]}), lazy.pd.DataFrame({"x": [3], "label": ["c"]})]
+    )
+    backend = RayBackend(input_repartition=RayInputRepartition(num_blocks=3))
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=backend,
+    )
+
+    plan = ray_backend_module.RayDriverPlanner(backend=backend, ray=fake_ray).plan(
+        runtime_context=designer._create_backend_runtime_context(),
+        config_builder=_input_expression_config_builder(stub_model_configs),
+        num_records=3,
+        input_dataset=input_dataset,
+    )
+
+    assert plan.dataset_source.kind == "input_dataset"
+    assert plan.dataset_source.external_input_dataset is True
+    assert plan.dataset_source.dataset.repartition_calls == [
+        {"num_blocks": 3, "target_num_rows_per_block": None, "shuffle": False}
+    ]
+    assert plan.input_blocks == 3
     assert plan.block_plan is None
 
 
@@ -774,7 +900,7 @@ def test_ray_backend_rejects_invalid_input_dataset_type(
         backend=RayBackend(),
     )
 
-    with pytest.raises(TypeError, match="ray.data.Dataset or a sequence of Ray ObjectRefs"):
+    with pytest.raises(RayBackendConfigurationError, match="ray.data.Dataset or a sequence of Ray ObjectRefs"):
         designer.create(stub_sampler_only_config_builder, input_dataset=object())
 
 

--- a/packages/data-designer/tests/integrations/ray/test_options.py
+++ b/packages/data-designer/tests/integrations/ray/test_options.py
@@ -7,7 +7,12 @@ from typing import Any
 
 import pytest
 
-from data_designer.integrations.ray import RayBackendConfigurationError, RayBlockPlanning, RayExecutionOptions
+from data_designer.integrations.ray import (
+    RayBackendConfigurationError,
+    RayBlockPlanning,
+    RayExecutionOptions,
+    RayInputRepartition,
+)
 from data_designer.integrations.ray.options import resolve_ray_backend_options
 
 pytestmark = pytest.mark.ray_fake
@@ -100,10 +105,12 @@ def test_ray_backend_option_resolution_rejects_execution_option_conflicts() -> N
 def test_ray_backend_option_resolution_allows_noop_legacy_values_with_option_objects() -> None:
     block_planning = RayBlockPlanning(override_num_blocks=2)
     execution_options = RayExecutionOptions(num_cpus=0.5)
+    input_repartition = RayInputRepartition(num_blocks=4)
 
     resolved = resolve_ray_backend_options(
         block_planning=block_planning,
         execution_options=execution_options,
+        input_repartition=input_repartition,
         legacy_options={
             "override_num_blocks": None,
             "num_cpus": None,
@@ -113,8 +120,40 @@ def test_ray_backend_option_resolution_allows_noop_legacy_values_with_option_obj
 
     assert resolved.block_planning is block_planning
     assert resolved.execution_options is execution_options
+    assert resolved.input_repartition is input_repartition
 
 
 def test_ray_backend_option_resolution_rejects_unknown_legacy_options() -> None:
     with pytest.raises(RayBackendConfigurationError, match="unsupported Ray option arguments: unknown"):
         resolve_ray_backend_options(legacy_options={"unknown": 1})
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"num_blocks": 0}, "num_blocks.*positive integer"),
+        ({"target_num_rows_per_block": 0}, "target_num_rows_per_block.*positive integer"),
+        ({"shuffle": "yes"}, "shuffle.*boolean"),
+        ({"num_blocks": 2, "target_num_rows_per_block": 100}, "cannot be combined"),
+        ({"target_num_rows_per_block": 100, "shuffle": True}, "shuffle can only be used"),
+    ],
+)
+def test_ray_input_repartition_validation_uses_configuration_error(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(RayBackendConfigurationError, match=match):
+        RayInputRepartition(**kwargs)
+
+
+def test_ray_input_repartition_resolves_repartition_kwargs() -> None:
+    assert RayInputRepartition(num_blocks=3, shuffle=True).to_repartition_kwargs() == {
+        "num_blocks": 3,
+        "shuffle": True,
+    }
+    assert RayInputRepartition(target_num_rows_per_block=100).to_repartition_kwargs() == {
+        "target_num_rows_per_block": 100,
+    }
+    assert RayInputRepartition().to_repartition_kwargs() == {}
+
+
+def test_ray_backend_option_resolution_rejects_invalid_input_repartition_object() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="input_repartition"):
+        resolve_ray_backend_options(input_repartition=object())

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -20,6 +20,7 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayDatasetGenerationError",
         "RayDatasetMetrics",
         "RayExecutionOptions",
+        "RayInputRepartition",
         "RayIntegrationError",
         "RayMetricsError",
         "RayThrottleSnapshot",

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -21,7 +21,7 @@ from data_designer.config.default_model_settings import (
     resolve_seed_default_model_settings,
 )
 from data_designer.engine.secret_resolver import PlaintextResolver
-from data_designer.integrations.ray import RayBackend
+from data_designer.integrations.ray import RayBackend, RayInputRepartition
 from data_designer.interface.data_designer import DataDesigner
 
 pytestmark = pytest.mark.ray_real_smoke
@@ -157,6 +157,38 @@ def test_real_ray_streaming_out_of_core_parquet_smoke(
     assert sample["ticket_key"].notna().all()
     assert sample["routing_key"].str.contains("::").all()
     assert list(parquet_dir.glob("*.parquet"))
+
+
+def test_real_ray_input_dataset_repartition_smoke(
+    local_ray: Any,
+    real_ray_smoke_paths: Any,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    input_dataframe = lazy.pd.DataFrame({"x": [1, 2, 3, 4], "label": ["a", "b", "c", "d"]})
+    input_dataset = local_ray.data.from_pandas(input_dataframe)
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="x_label", expr="{{ x }}-{{ label }}"))
+    designer = DataDesigner(
+        artifact_path=real_ray_smoke_paths.artifact_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=real_ray_smoke_paths.managed_assets_path,
+        backend=RayBackend(
+            batch_size=2,
+            output="arrow_refs",
+            input_repartition=RayInputRepartition(num_blocks=2),
+        ),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset)
+    output_df = results.load_dataset().to_pandas()
+    metrics = results.load_metrics()
+
+    assert len(results.output) == 2
+    assert metrics.blocks == 2
+    assert sorted(output_df["x"].tolist()) == [1, 2, 3, 4]
+    assert output_df["x_label"].notna().all()
 
 
 def _repo_root() -> Path:


### PR DESCRIPTION
## 📋 Summary

Adds `RayInputRepartition` as an additive Ray option object alongside the current `RayBlockPlanning` and `RayExecutionOptions` architecture. Existing Ray `input_dataset` inputs can now be repartitioned before Data Designer maps generation, while from-scratch range planning remains a separate mode.

## 🔗 Related Issue

Closes #42

## 🔄 Changes

- Add `RayInputRepartition` with exact `num_blocks` and streaming `target_num_rows_per_block` controls.
- Resolve the new option through `resolve_ray_backend_options` and store it on `RayBackend` with existing option objects.
- Apply input repartitioning in `RayDriverPlanner` only for external `input_dataset` inputs, before hidden order columns and `map_batches`.
- Extend the current fake Ray harness with `Dataset.repartition(...)` support instead of adding a duplicate harness.
- Add fake-Ray unit coverage, public API coverage, and an opt-in real-Ray smoke path.
- Document when to use input repartitioning versus upstream partitioning or from-scratch `RayBlockPlanning`.

## 🧪 Testing

- [ ] `make test` passes (not run; focused Ray checks run instead)
- [x] Unit tests added/updated
- [x] E2E tests added/updated (opt-in real-Ray smoke path)

Focused checks:

- `UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run --package data-designer pytest packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_public_api.py packages/data-designer/tests/integrations/ray/test_real_smoke.py packages/data-designer/tests/integrations/ray/test_fake_ray_harness.py` - 100 passed, 4 skipped
- `UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff check packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_public_api.py packages/data-designer/tests/integrations/ray/test_real_smoke.py` - passed
- `UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_public_api.py packages/data-designer/tests/integrations/ray/test_real_smoke.py` - passed

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A; user-facing deployment docs updated)
