### PR TITLE
fix(ray): reject after-generation processors

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -27,7 +27,10 @@ from data_designer.integrations.ray.observability_collection import (
     _RayObservabilityOptions,
 )
 from data_designer.integrations.ray.options import RayBlockPlanning, RayExecutionOptions, resolve_ray_backend_options
-from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
+from data_designer.integrations.ray.processor_policy import (
+    validate_no_ray_after_generation_processors,
+    validate_ray_safe_processors,
+)
 from data_designer.integrations.ray.results import RayResultArtifacts
 from data_designer.integrations.ray.throttling import create_ray_throttle_manager
 from data_designer.integrations.ray.worker_pipeline import (
@@ -431,6 +434,7 @@ class RayDriverPlanner:
                 seed_window = seed_plan.seed_window
                 dataset_source_kind = "seed_window"
 
+        validate_no_ray_after_generation_processors(config_builder)
         if not self._backend.allow_unsafe_processors:
             validate_ray_safe_processors(config_builder)
 

--- a/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from data_designer.config.base import ProcessorConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.processors import ProcessorDistributedSafety, ProcessorSideEffect
+from data_designer.engine.processing.processors.base import Processor
+from data_designer.engine.registry.data_designer_registry import DataDesignerRegistry
 from data_designer.integrations.ray.errors import RayBackendConfigurationError
 
 _RAY_SUPPORTED_SIDE_EFFECTS = frozenset(
@@ -36,6 +38,36 @@ def validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> N
     )
 
 
+def validate_no_ray_after_generation_processors(config_builder: DataDesignerConfigBuilder) -> None:
+    """Reject processors whose implementation requires a completed dataset view.
+
+    RayBackend currently runs DataDesigner generation inside Ray Data
+    ``map_batches`` workers. A ``process_after_generation`` implementation would
+    therefore receive only one Ray block instead of the complete final dataset.
+    """
+    unsupported: list[str] = []
+    processor_registry = DataDesignerRegistry().processors
+    for processor in config_builder.get_processor_configs():
+        try:
+            processor_impl = processor_registry.get_for_config_type(type(processor))
+        except Exception:
+            continue
+        if getattr(processor_impl, "process_after_generation") is getattr(Processor, "process_after_generation"):
+            continue
+        unsupported.append(_format_processor_label(processor))
+
+    if not unsupported:
+        return
+
+    raise RayBackendConfigurationError(
+        "RayBackend does not support processors that implement process_after_generation because "
+        "Ray workers process independent data blocks, not the completed dataset. "
+        f"Unsupported processor(s): {'; '.join(unsupported)}. "
+        "Use the local backend or remove the after-generation processor until Ray-native global "
+        "processor execution is implemented."
+    )
+
+
 def _get_distributed_safety(processor: ProcessorConfig) -> ProcessorDistributedSafety | None:
     safety = getattr(processor, "distributed_safety", None)
     if isinstance(safety, ProcessorDistributedSafety):
@@ -52,8 +84,7 @@ def _is_supported_by_ray(safety: ProcessorDistributedSafety) -> bool:
 
 
 def _format_processor_violation(processor: ProcessorConfig, safety: ProcessorDistributedSafety | None) -> str:
-    processor_type = getattr(processor.processor_type, "value", processor.processor_type)
-    label = f"{processor.name} ({processor_type})"
+    label = _format_processor_label(processor)
     if safety is None:
         return f"{label}: missing distributed_safety metadata"
 
@@ -69,3 +100,8 @@ def _format_processor_violation(processor: ProcessorConfig, safety: ProcessorDis
     if safety.reason is not None:
         reasons.append(f"reason={safety.reason}")
     return f"{label}: {', '.join(reasons)}"
+
+
+def _format_processor_label(processor: ProcessorConfig) -> str:
+    processor_type = getattr(processor.processor_type, "value", processor.processor_type)
+    return f"{processor.name} ({processor_type})"

--- a/packages/data-designer/tests/integrations/ray/test_processor_policy.py
+++ b/packages/data-designer/tests/integrations/ray/test_processor_policy.py
@@ -19,10 +19,15 @@ from data_designer.config.processors import (
     ProcessorSideEffect,
     SchemaTransformProcessorConfig,
 )
+from data_designer.engine.processing.processors.base import Processor
+from data_designer.engine.registry.data_designer_registry import DataDesignerRegistry
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError
 from data_designer.integrations.ray import backend as ray_backend_module
-from data_designer.integrations.ray.processor_policy import validate_ray_safe_processors
+from data_designer.integrations.ray.processor_policy import (
+    validate_no_ray_after_generation_processors,
+    validate_ray_safe_processors,
+)
 from data_designer.interface.data_designer import DataDesigner
 
 pytestmark = pytest.mark.ray_fake
@@ -58,6 +63,28 @@ class LegacyRaySafeProcessorConfig(ProcessorConfig):
         side_effects=ProcessorSideEffect.NONE,
         reason="Uses legacy compatibility metadata.",
     )
+
+
+class AfterGenerationProcessorConfig(ProcessorConfig):
+    processor_type: Literal["after_generation"] = "after_generation"
+    distributed_safety: ClassVar[ProcessorDistributedSafety] = ProcessorDistributedSafety(
+        partition_safe=True,
+        requires_global_order=False,
+        side_effects=ProcessorSideEffect.NONE,
+        reason="Metadata is intentionally safe-looking to test implementation-stage validation.",
+    )
+
+
+class AfterGenerationProcessor(Processor[AfterGenerationProcessorConfig]):
+    def process_after_generation(self, data: Any) -> Any:
+        return data
+
+
+DataDesignerRegistry().processors.register(
+    "after_generation",
+    AfterGenerationProcessor,
+    AfterGenerationProcessorConfig,
+)
 
 
 def _managed_assets_path(tmp_path: Path) -> Path:
@@ -209,6 +236,35 @@ def test_ray_processor_policy_accepts_legacy_ray_safe_metadata(stub_model_config
     config_builder.add_processor(LegacyRaySafeProcessorConfig(name="legacy-processor"))
 
     validate_ray_safe_processors(config_builder)
+
+
+def test_ray_processor_policy_rejects_after_generation_processor_implementation(stub_model_configs: Any) -> None:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_processor(AfterGenerationProcessorConfig(name="global-processor"))
+
+    with pytest.raises(RayBackendConfigurationError, match="process_after_generation") as exc_info:
+        validate_no_ray_after_generation_processors(config_builder)
+
+    assert "global-processor (after_generation)" in str(exc_info.value)
+
+
+def test_ray_backend_rejects_after_generation_processors_even_when_unsafe_processors_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1], "label": ["a"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    config_builder.add_processor(AfterGenerationProcessorConfig(name="global-processor"))
+    designer = _designer(tmp_path, stub_model_providers, backend=RayBackend(allow_unsafe_processors=True))
+
+    with pytest.raises(RayBackendConfigurationError, match="process_after_generation") as exc_info:
+        designer.create(config_builder, input_dataset=input_dataset)
+
+    assert "global-processor (after_generation)" in str(exc_info.value)
+    assert input_dataset.map_batches_kwargs is None
 
 
 def test_ray_backend_allow_unsafe_processors_bypasses_schema_transform_preflight(


### PR DESCRIPTION
## Summary
- Add an unconditional Ray processor-stage guard for implementations that override process_after_generation.
- Keep the existing distributed-safety metadata guard for partition-safe post-batch processors.
- Add fake-Ray coverage proving allow_unsafe_processors cannot bypass the after-generation guard and validation happens before map_batches.

Closes #110

## Verification
- UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run --package data-designer pytest packages/data-designer/tests/integrations/ray/test_processor_policy.py packages/data-designer/tests/integrations/ray/test_backend.py
- UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff check packages/data-designer/src/data_designer/integrations/ray/processor_policy.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_processor_policy.py
- UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/processor_policy.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/test_processor_policy.py