### PR TITLE
docs(ray): clarify actor-pool scaling controls

### DIFF
--- a/docs/concepts/deployment-options.md
+++ b/docs/concepts/deployment-options.md
@@ -166,7 +166,12 @@ backend = RayBackend(
     output="dataset",
     auto_init=False,
     block_planning=RayBlockPlanning(target_block_size=10_000, min_blocks=4),
-    execution_options=RayExecutionOptions(num_cpus=1, concurrency=8),
+    execution_options=RayExecutionOptions(
+        num_cpus=1,
+        use_actor_pool=True,
+        actor_pool_min_size=2,
+        actor_pool_max_size=8,
+    ),
 )
 ```
 
@@ -174,6 +179,10 @@ backend = RayBackend(
 Ray planning and execution kwargs such as `override_num_blocks`, `read_concurrency`, `num_cpus`, and
 `map_concurrency` are still accepted as compatibility shims, but do not combine them with `block_planning` or
 `execution_options`; effective mixed values raise a configuration error. Prefer the option objects for new code.
+For scaling map workers, prefer `RayExecutionOptions(use_actor_pool=True, actor_pool_min_size=...,
+actor_pool_max_size=...)` or an explicit Ray `compute` strategy. `RayExecutionOptions(concurrency=...)` and the legacy
+`map_concurrency=...` shim remain covered for compatibility with older RayBackend callers, but new examples should use
+actor-pool or compute controls so placement, autoscaling, and provider throttling are easier to reason about.
 
 When passing an existing Ray Dataset or ObjectRefs through `input_dataset`, use `RayInputRepartition` to retune input
 blocks before Data Designer maps generation over them:

--- a/packages/data-designer/tests/integrations/ray/README.md
+++ b/packages/data-designer/tests/integrations/ray/README.md
@@ -21,3 +21,8 @@ The real-Ray smoke fixtures own local `ray.init`/`ray.shutdown`, use isolated te
 runtime state under a short `/tmp/dd-ray-*` path for macOS socket compatibility, disable the dashboard, and set
 `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` before importing Ray when the caller has not provided a value. They also centralize
 the macOS sandbox compatibility patch for Ray process discovery and restore it after each test.
+
+RayBackend tests intentionally cover both current and compatibility execution controls. New examples should prefer
+`RayExecutionOptions(use_actor_pool=True, actor_pool_min_size=..., actor_pool_max_size=...)` or explicit Ray `compute`
+strategies. Legacy `map_concurrency` / `RayExecutionOptions(concurrency=...)` coverage remains in place to prevent API
+regressions for existing callers.


### PR DESCRIPTION
## Summary
- Update Ray backend docs to show actor-pool sizing as the preferred map worker scaling control.
- Document `RayExecutionOptions(concurrency=...)` and legacy `map_concurrency=...` as compatibility surfaces.
- Add a Ray integration test README note explaining why tests still cover both legacy and preferred controls.

Closes #48

## Verification
- UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff check docs/concepts/deployment-options.md packages/data-designer/tests/integrations/ray/README.md packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py
- UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run --package data-designer pytest packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py -k "actor_pool or map_concurrency or legacy or option_resolution"