### PR TITLE
feat(ray): ingest filesystem seeds with Ray Data

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -50,7 +50,14 @@ from data_designer.interface.backends import BackendRuntimeContext
 
 RayOutputMode = Literal["dataset", "arrow_refs"]
 RayObjectRefInputFormat = Literal["arrow", "pandas"]
-RayDatasetSourceKind = Literal["range", "input_dataset", "object_refs", "driver_materialized_seed", "seed_window"]
+RayDatasetSourceKind = Literal[
+    "range",
+    "input_dataset",
+    "object_refs",
+    "driver_materialized_seed",
+    "ray_native_seed",
+    "seed_window",
+]
 
 
 @dataclass(frozen=True)
@@ -438,11 +445,16 @@ class RayDriverPlanner:
                 runtime_context=runtime_context,
                 seed_config=seed_config,
                 num_records=num_records,
+                ray=self._ray,
             )
             if seed_plan.input_dataframe is not None:
                 input_dataset = self._ray.data.from_pandas(seed_plan.input_dataframe)
                 use_input_dataset = True
                 dataset_source_kind = "driver_materialized_seed"
+            elif seed_plan.input_dataset is not None:
+                input_dataset = seed_plan.input_dataset
+                use_input_dataset = True
+                dataset_source_kind = "ray_native_seed"
             else:
                 seed_window = seed_plan.seed_window
                 dataset_source_kind = "seed_window"

--- a/packages/data-designer/src/data_designer/integrations/ray/seed_planning.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/seed_planning.py
@@ -6,22 +6,28 @@ from __future__ import annotations
 import copy
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.seed import IndexRange, PartitionBlock, SamplingStrategy, SeedConfig
+from data_designer.config.seed_source import FileContentsSeedSource
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import (
     DataFrameSeedReader,
+    FileContentsSeedReader,
     FileSystemSeedReader,
+    LocalFileSeedReader,
     SeedReader,
     SeedReaderRegistry,
+    create_seed_reader_output_dataframe,
 )
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.interface.backends import BackendRuntimeContext
 
 RAY_RANGE_ID_COLUMN = "id"
+RAY_SEED_ORDINAL_COLUMN = "__data_designer_ray_seed_ordinal"
 
 
 @dataclass(frozen=True)
@@ -33,6 +39,7 @@ class RaySeedWindow:
 @dataclass(frozen=True)
 class RaySeedPlan:
     input_dataframe: Any | None = None
+    input_dataset: Any | None = None
     seed_window: RaySeedWindow | None = None
 
 
@@ -41,7 +48,38 @@ def plan_seed_execution(
     runtime_context: BackendRuntimeContext,
     seed_config: SeedConfig,
     num_records: int,
+    ray: Any | None = None,
 ) -> RaySeedPlan:
+    seed_reader = _get_detached_seed_reader(runtime_context=runtime_context, seed_config=seed_config)
+    if ray is not None and isinstance(seed_reader, LocalFileSeedReader):
+        return RaySeedPlan(
+            input_dataset=create_ray_local_file_seed_dataset(
+                ray=ray,
+                seed_reader=seed_reader,
+                seed_config=seed_config,
+                num_records=num_records,
+            )
+        )
+    if ray is not None and isinstance(seed_reader, FileContentsSeedReader):
+        return RaySeedPlan(
+            input_dataset=create_ray_file_contents_seed_dataset(
+                ray=ray,
+                seed_reader=seed_reader,
+                seed_config=seed_config,
+                num_records=num_records,
+            )
+        )
+    if ray is not None and isinstance(seed_reader, FileSystemSeedReader):
+        return RaySeedPlan(
+            input_dataset=create_ray_filesystem_seed_dataset(
+                ray=ray,
+                seed_reader=seed_reader,
+                seed_config=seed_config,
+                num_records=num_records,
+                secret_resolver=runtime_context.secret_resolver,
+            )
+        )
+
     if should_materialize_seed_on_driver(runtime_context=runtime_context, seed_config=seed_config):
         return RaySeedPlan(
             input_dataframe=materialize_seed_dataframe(
@@ -57,6 +95,276 @@ def plan_seed_execution(
             num_records=num_records,
         )
     )
+
+
+def create_ray_local_file_seed_dataset(
+    *,
+    ray: Any,
+    seed_reader: LocalFileSeedReader,
+    seed_config: SeedConfig,
+    num_records: int,
+) -> Any:
+    """Create a Ray Dataset for an ordered local structured-file seed."""
+    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
+        raise RayBackendConfigurationError(
+            "RayBackend Ray-native local-file seed ingestion currently supports only ordered sampling. "
+            "Use input_dataset for shuffled Ray-native seeds or the local backend for shuffled seed sampling."
+        )
+    seed_dataset_size = seed_reader.get_seed_dataset_size()
+    index_range = resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=seed_dataset_size)
+    _validate_no_seed_ordinal_column(seed_reader.get_column_names())
+    dataset = _read_local_file_seed_dataset(ray, seed_reader.get_dataset_uri())
+    return _apply_ordered_seed_selection_and_cycling(
+        ray=ray,
+        dataset=dataset,
+        seed_dataset_size=seed_dataset_size,
+        index_range=index_range,
+        num_records=num_records,
+    )
+
+
+def create_ray_file_contents_seed_dataset(
+    *,
+    ray: Any,
+    seed_reader: FileContentsSeedReader,
+    seed_config: SeedConfig,
+    num_records: int,
+) -> Any:
+    """Create a Ray Dataset for ordered file-content seeds without driver content reads."""
+    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
+        raise RayBackendConfigurationError(
+            "RayBackend Ray-native file-content seed ingestion currently supports only ordered sampling. "
+            "Use input_dataset for shuffled Ray-native seeds or the local backend for shuffled seed sampling."
+        )
+    source = seed_reader.source
+    if not isinstance(source, FileContentsSeedSource):
+        raise RayBackendConfigurationError("RayBackend file-content seed ingestion expected FileContentsSeedSource.")
+    context = seed_reader.create_filesystem_context(source.runtime_path)
+    relative_paths = seed_reader.get_matching_relative_paths(
+        context=context,
+        file_pattern=source.file_pattern,
+        recursive=source.recursive,
+    )
+    index_range = resolve_seed_config_index_range(seed_config=seed_config, seed_dataset_size=len(relative_paths))
+    absolute_paths = [str(context.root_path / relative_path) for relative_path in relative_paths]
+    dataset = ray.data.read_binary_files(
+        absolute_paths,
+        include_paths=True,
+        partitioning=None,
+    ).map_batches(
+        _file_contents_seed_batch_to_dataframe,
+        fn_kwargs={"root_path": str(context.root_path), "encoding": source.encoding},
+        batch_format="pandas",
+    )
+    return _apply_ordered_seed_selection_and_cycling(
+        ray=ray,
+        dataset=dataset,
+        seed_dataset_size=len(relative_paths),
+        index_range=index_range,
+        num_records=num_records,
+    )
+
+
+def create_ray_filesystem_seed_dataset(
+    *,
+    ray: Any,
+    seed_reader: FileSystemSeedReader[Any],
+    seed_config: SeedConfig,
+    num_records: int,
+    secret_resolver: SecretResolver,
+) -> Any:
+    """Create a Ray Dataset that hydrates filesystem seed manifest rows on workers."""
+    if seed_config.sampling_strategy != SamplingStrategy.ORDERED:
+        raise RayBackendConfigurationError(
+            "RayBackend Ray-native filesystem seed ingestion currently supports only ordered sampling. "
+            "Use input_dataset for shuffled Ray-native seeds or the local backend for shuffled seed sampling."
+        )
+    manifest_dataframe = _filesystem_manifest_dataframe(seed_reader)
+    index_range = resolve_seed_config_index_range(
+        seed_config=seed_config,
+        seed_dataset_size=len(manifest_dataframe),
+    )
+    output_columns = seed_reader.get_output_column_names()
+    _validate_no_seed_ordinal_column(output_columns)
+    manifest_dataset = ray.data.from_items(manifest_dataframe.to_dict(orient="records"))
+    selected_manifest_dataset = _apply_ordered_seed_selection_and_cycling(
+        ray=ray,
+        dataset=manifest_dataset,
+        seed_dataset_size=len(manifest_dataframe),
+        index_range=index_range,
+        num_records=num_records,
+    )
+    return selected_manifest_dataset.map_batches(
+        _hydrate_filesystem_seed_manifest_batch,
+        fn_kwargs={
+            "seed_reader": seed_reader,
+            "seed_source": seed_reader.source,
+            "secret_resolver": secret_resolver,
+            "output_columns": output_columns,
+        },
+        batch_format="pandas",
+    ).limit(num_records)
+
+
+def _filesystem_manifest_dataframe(seed_reader: FileSystemSeedReader[Any]) -> Any:
+    context = seed_reader.create_filesystem_context(seed_reader.source.runtime_path)
+    manifest = seed_reader.build_manifest(context=context)
+    manifest_dataframe = manifest.copy() if isinstance(manifest, lazy.pd.DataFrame) else lazy.pd.DataFrame(manifest)
+    if manifest_dataframe.empty:
+        raise RayBackendConfigurationError(
+            f"RayBackend filesystem seed source at {seed_reader.source.runtime_path} did not produce any rows."
+        )
+    return manifest_dataframe
+
+
+def _hydrate_filesystem_seed_manifest_batch(
+    batch: Any,
+    *,
+    seed_reader: FileSystemSeedReader[Any],
+    seed_source: Any,
+    secret_resolver: SecretResolver,
+    output_columns: list[str],
+) -> Any:
+    reader = _clone_seed_reader_for_worker(seed_reader)
+    reader.attach(seed_source, secret_resolver)
+    context = reader.create_filesystem_context(seed_source.runtime_path)
+    hydrated_records = reader._hydrate_rows(
+        manifest_rows=lazy.pd.DataFrame(batch).to_dict(orient="records"),
+        context=context,
+    )
+    return create_seed_reader_output_dataframe(records=hydrated_records, output_columns=output_columns)
+
+
+def _read_local_file_seed_dataset(ray: Any, dataset_uri: str) -> Any:
+    normalized_uri = dataset_uri.lower()
+    read_kwargs: dict[str, Any] = {"partitioning": None}
+    if _path_matches_suffix(normalized_uri, ".parquet"):
+        return ray.data.read_parquet(dataset_uri, **read_kwargs)
+    if _path_matches_suffix(normalized_uri, ".csv"):
+        return ray.data.read_csv(dataset_uri, **read_kwargs)
+    if _path_matches_suffix(normalized_uri, ".jsonl"):
+        return ray.data.read_json(dataset_uri, lines=True, **read_kwargs)
+    if _path_matches_suffix(normalized_uri, ".json"):
+        return ray.data.read_json(dataset_uri, lines=False, **read_kwargs)
+    raise RayBackendConfigurationError(
+        "RayBackend Ray-native local-file seed ingestion supports parquet, csv, json, and jsonl seed files."
+    )
+
+
+def _path_matches_suffix(path: str, suffix: str) -> bool:
+    return path.endswith((suffix, f"{suffix}'")) or f"*{suffix}" in path
+
+
+def _apply_ordered_seed_selection_and_cycling(
+    *,
+    ray: Any,
+    dataset: Any,
+    seed_dataset_size: int,
+    index_range: IndexRange,
+    num_records: int,
+) -> Any:
+    if num_records < 0:
+        raise RayBackendConfigurationError("RayBackend seed num_records must be non-negative.")
+    selected = _select_seed_dataset_range(
+        ray=ray,
+        dataset=dataset,
+        seed_dataset_size=seed_dataset_size,
+        index_range=index_range,
+    )
+    return _cycle_seed_dataset(selected, selected_size=index_range.size, num_records=num_records)
+
+
+def _select_seed_dataset_range(
+    *,
+    ray: Any,
+    dataset: Any,
+    seed_dataset_size: int,
+    index_range: IndexRange,
+) -> Any:
+    if index_range.start == 0 and index_range.end == seed_dataset_size - 1:
+        return dataset
+    ordinal_dataset = ray.data.range(seed_dataset_size).map_batches(
+        _rename_range_id_to_seed_ordinal,
+        batch_format="pandas",
+    )
+    return (
+        dataset.zip(ordinal_dataset)
+        .filter(
+            _row_in_seed_index_range,
+            fn_kwargs={"start": index_range.start, "end": index_range.end},
+        )
+        .drop_columns([RAY_SEED_ORDINAL_COLUMN])
+    )
+
+
+def _cycle_seed_dataset(dataset: Any, *, selected_size: int, num_records: int) -> Any:
+    if selected_size <= 0:
+        raise RayBackendConfigurationError("RayBackend seed config resolved to an empty selected seed range.")
+    if num_records <= selected_size:
+        return dataset.limit(num_records)
+    full_repetitions, remainder = divmod(num_records, selected_size)
+    pieces = [dataset for _ in range(full_repetitions)]
+    if remainder:
+        pieces.append(dataset.limit(remainder))
+    if not pieces:
+        return dataset.limit(0)
+    return pieces[0].union(*pieces[1:]) if len(pieces) > 1 else pieces[0]
+
+
+def _rename_range_id_to_seed_ordinal(batch: Any) -> Any:
+    dataframe = lazy.pd.DataFrame(batch)
+    if RAY_RANGE_ID_COLUMN not in dataframe.columns:
+        raise RayDatasetGenerationError(
+            f"RayBackend expected ray.data.range() batches to include {RAY_RANGE_ID_COLUMN!r}."
+        )
+    return lazy.pd.DataFrame({RAY_SEED_ORDINAL_COLUMN: dataframe[RAY_RANGE_ID_COLUMN].tolist()})
+
+
+def _row_in_seed_index_range(row: dict[str, Any], *, start: int, end: int) -> bool:
+    ordinal = int(row[RAY_SEED_ORDINAL_COLUMN])
+    return start <= ordinal <= end
+
+
+def _file_contents_seed_batch_to_dataframe(batch: Any, *, root_path: str, encoding: str) -> Any:
+    dataframe = lazy.pd.DataFrame(batch)
+    path_column = _first_present_column(dataframe, ("path", "paths"))
+    bytes_column = _first_present_column(dataframe, ("bytes", "data", "item"))
+    records: list[dict[str, Any]] = []
+    root = Path(root_path).resolve()
+    for row in dataframe.to_dict(orient="records"):
+        source_path = Path(str(row[path_column])).resolve()
+        try:
+            relative_path = source_path.relative_to(root).as_posix()
+        except ValueError:
+            relative_path = source_path.name
+        payload = row[bytes_column]
+        content = (
+            bytes(payload).decode(encoding) if isinstance(payload, (bytes, bytearray, memoryview)) else str(payload)
+        )
+        records.append(
+            {
+                "source_kind": "file_contents",
+                "source_path": str(source_path),
+                "relative_path": relative_path,
+                "file_name": source_path.name,
+                "content": content,
+            }
+        )
+    return lazy.pd.DataFrame(records)
+
+
+def _first_present_column(dataframe: Any, names: tuple[str, ...]) -> str:
+    for name in names:
+        if name in dataframe.columns:
+            return name
+    raise RayDatasetGenerationError(f"RayBackend file-content seed ingestion expected one of {names!r}.")
+
+
+def _validate_no_seed_ordinal_column(column_names: Sequence[str]) -> None:
+    if RAY_SEED_ORDINAL_COLUMN in column_names:
+        raise RayBackendConfigurationError(
+            f"RayBackend Ray-native seed ingestion reserves column {RAY_SEED_ORDINAL_COLUMN!r}."
+        )
 
 
 def preflight_seed_window(

--- a/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import sys
 import types
 from dataclasses import dataclass
+from glob import glob
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -104,6 +106,50 @@ class FakeRayDataset:
         zipped.repartition_calls = list(self.repartition_calls)
         return zipped
 
+    def filter(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
+        fn_kwargs = kwargs.get("fn_kwargs") or {}
+        blocks: list[lazy.pd.DataFrame] = []
+        for block in self.blocks:
+            block_df = coerce_pandas_dataframe(block)
+            rows = [row for row in block_df.to_dict(orient="records") if fn(row, **fn_kwargs)]
+            blocks.append(lazy.pd.DataFrame(rows, columns=list(block_df.columns)))
+        filtered = FakeRayDataset(
+            blocks,
+            data_module=self.data_module,
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
+        filtered.repartition_calls = list(self.repartition_calls)
+        return filtered
+
+    def limit(self, limit: int) -> FakeRayDataset:
+        remaining = limit
+        blocks: list[lazy.pd.DataFrame] = []
+        for block in self.blocks:
+            block_df = coerce_pandas_dataframe(block)
+            if remaining <= 0:
+                break
+            selected = block_df.iloc[:remaining].reset_index(drop=True)
+            blocks.append(selected)
+            remaining -= len(selected)
+        if not blocks and self.blocks:
+            blocks = [coerce_pandas_dataframe(self.blocks[0]).iloc[:0].reset_index(drop=True)]
+        limited = FakeRayDataset(
+            blocks,
+            data_module=self.data_module,
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
+        limited.repartition_calls = list(self.repartition_calls)
+        return limited
+
+    def union(self, *others: FakeRayDataset) -> FakeRayDataset:
+        unioned = FakeRayDataset(
+            [*self.blocks, *(block for other in others for block in other.blocks)],
+            data_module=self.data_module,
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+        )
+        unioned.repartition_calls = list(self.repartition_calls)
+        return unioned
+
     def to_arrow_refs(self) -> list[Any]:
         if self.data_module is None:
             return list(self.blocks)
@@ -159,6 +205,14 @@ class FakeRayDataModule:
         self.from_pandas_input: Any | None = None
         self.from_items_input: list[Any] | None = None
         self.from_items_kwargs: dict[str, Any] | None = None
+        self.read_binary_files_input: Any | None = None
+        self.read_binary_files_kwargs: dict[str, Any] | None = None
+        self.read_csv_input: Any | None = None
+        self.read_csv_kwargs: dict[str, Any] | None = None
+        self.read_json_input: Any | None = None
+        self.read_json_kwargs: dict[str, Any] | None = None
+        self.read_parquet_input: Any | None = None
+        self.read_parquet_kwargs: dict[str, Any] | None = None
         self.range_blocks = range_blocks
         self.reverse_mapped_blocks = reverse_mapped_blocks
         self.range_kwargs: dict[str, Any] | None = None
@@ -214,6 +268,34 @@ class FakeRayDataModule:
     def from_pandas_refs(self, refs: list[Any]) -> FakeRayDataset:
         self.from_pandas_refs_input = refs
         return self.dataset(list(refs))
+
+    def read_binary_files(self, paths: Any, **kwargs: Any) -> FakeRayDataset:
+        self.read_binary_files_input = paths
+        self.read_binary_files_kwargs = dict(kwargs)
+        include_paths = bool(kwargs.get("include_paths"))
+        records: list[dict[str, Any]] = []
+        for path in _expand_paths(paths):
+            record = {"bytes": path.read_bytes()}
+            if include_paths:
+                record["path"] = str(path)
+            records.append(record)
+        return self.dataset([lazy.pd.DataFrame(records)])
+
+    def read_csv(self, paths: Any, **kwargs: Any) -> FakeRayDataset:
+        self.read_csv_input = paths
+        self.read_csv_kwargs = dict(kwargs)
+        return self.dataset([_read_pandas_files(paths, lambda path: lazy.pd.read_csv(path))])
+
+    def read_json(self, paths: Any, **kwargs: Any) -> FakeRayDataset:
+        self.read_json_input = paths
+        self.read_json_kwargs = dict(kwargs)
+        lines = bool(kwargs.get("lines"))
+        return self.dataset([_read_pandas_files(paths, lambda path: lazy.pd.read_json(path, lines=lines))])
+
+    def read_parquet(self, paths: Any, **kwargs: Any) -> FakeRayDataset:
+        self.read_parquet_input = paths
+        self.read_parquet_kwargs = dict(kwargs)
+        return self.dataset([_read_pandas_files(paths, lambda path: lazy.pd.read_parquet(path))])
 
     def validate_map_batches_kwargs(self, kwargs: dict[str, Any]) -> None:
         if not self.validate_map_batches:
@@ -348,3 +430,20 @@ def coerce_pandas_dataframe(value: Any) -> lazy.pd.DataFrame:
     if callable(to_pandas):
         return to_pandas()
     return value
+
+
+def _expand_paths(paths: Any) -> list[Path]:
+    raw_paths = [paths] if isinstance(paths, str) else list(paths)
+    expanded: list[Path] = []
+    for raw_path in raw_paths:
+        path = str(raw_path)
+        matches = sorted(glob(path)) if "*" in path else [path]
+        expanded.extend(Path(match) for match in matches)
+    return expanded
+
+
+def _read_pandas_files(paths: Any, read_file: Any) -> lazy.pd.DataFrame:
+    dataframes = [read_file(path) for path in _expand_paths(paths)]
+    if not dataframes:
+        return lazy.pd.DataFrame()
+    return lazy.pd.concat(dataframes, ignore_index=True)

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -15,7 +15,8 @@ from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextC
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.processors import SchemaTransformProcessorConfig
 from data_designer.config.run_config import RunConfig
-from data_designer.config.seed_source import DirectorySeedSource
+from data_designer.config.seed import IndexRange, SamplingStrategy
+from data_designer.config.seed_source import DirectorySeedSource, FileContentsSeedSource, LocalFileSeedSource
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
@@ -991,7 +992,7 @@ def test_ray_backend_arrow_refs_dataset_rebuild_falls_back_to_items(monkeypatch:
     ]
 
 
-def test_ray_backend_materializes_filesystem_seed_reader_fanout_as_input_dataset(
+def test_ray_backend_hydrates_filesystem_seed_reader_fanout_with_ray_data(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     stub_model_providers: Any,
@@ -1021,12 +1022,177 @@ def test_ray_backend_materializes_filesystem_seed_reader_fanout_as_input_dataset
 
     output_df = designer.create(config_builder, num_records=3).load_dataset().to_pandas()
 
-    assert fake_ray.data.from_pandas_input is not None
+    assert fake_ray.data.from_pandas_input is None
+    assert fake_ray.data.from_items_input == [
+        {"relative_path": "a.txt"},
+        {"relative_path": "b.txt"},
+    ]
     assert fake_ray.data.range_kwargs is None
     assert output_df.to_dict(orient="records") == [
         {"relative_path": "a.txt", "line_index": 0, "line": "alpha", "line_label": "a.txt:0:alpha"},
         {"relative_path": "a.txt", "line_index": 1, "line": "beta", "line_label": "a.txt:1:beta"},
         {"relative_path": "b.txt", "line_index": 0, "line": "gamma", "line_label": "b.txt:0:gamma"},
+    ]
+
+
+def test_ray_backend_reads_local_file_seed_with_ray_data(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    seed_path = tmp_path / "seed.csv"
+    lazy.pd.DataFrame({"value": [1, 2, 3], "label": ["a", "b", "c"]}).to_csv(seed_path, index=False)
+
+    config_builder = DataDesignerConfigBuilder(model_configs=[])
+    config_builder.with_seed_dataset(LocalFileSeedSource(path=str(seed_path)))
+    config_builder.add_column(ExpressionColumnConfig(name="value_label", expr="{{ value }}:{{ label }}"))
+    designer = DataDesigner(
+        artifact_path=tmp_path / "artifacts",
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2),
+    )
+
+    output_df = designer.create(config_builder, num_records=5).load_dataset().to_pandas()
+
+    assert fake_ray.data.read_csv_input == str(seed_path)
+    assert fake_ray.data.read_csv_kwargs == {"partitioning": None}
+    assert fake_ray.data.from_pandas_input is None
+    assert output_df.to_dict(orient="records") == [
+        {"value": 1, "label": "a", "value_label": "1:a"},
+        {"value": 2, "label": "b", "value_label": "2:b"},
+        {"value": 3, "label": "c", "value_label": "3:c"},
+        {"value": 1, "label": "a", "value_label": "1:a"},
+        {"value": 2, "label": "b", "value_label": "2:b"},
+    ]
+
+
+def test_ray_backend_applies_local_file_seed_range_without_leaking_ordinal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    seed_path = tmp_path / "seed.jsonl"
+    lazy.pd.DataFrame({"value": [10, 20, 30, 40], "label": ["a", "b", "c", "d"]}).to_json(
+        seed_path,
+        orient="records",
+        lines=True,
+    )
+
+    config_builder = DataDesignerConfigBuilder(model_configs=[])
+    config_builder.with_seed_dataset(
+        LocalFileSeedSource(path=str(seed_path)),
+        selection_strategy=IndexRange(start=1, end=2),
+    )
+    config_builder.add_column(ExpressionColumnConfig(name="value_label", expr="{{ value }}:{{ label }}"))
+    designer = DataDesigner(
+        artifact_path=tmp_path / "artifacts",
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2),
+    )
+
+    output_df = designer.create(config_builder, num_records=3).load_dataset().to_pandas()
+
+    assert fake_ray.data.read_json_input == str(seed_path)
+    assert fake_ray.data.read_json_kwargs == {"lines": True, "partitioning": None}
+    assert fake_ray.data.from_pandas_input is None
+    assert "__data_designer_ray_seed_ordinal" not in output_df.columns
+    assert output_df.to_dict(orient="records") == [
+        {"value": 20, "label": "b", "value_label": "20:b"},
+        {"value": 30, "label": "c", "value_label": "30:c"},
+        {"value": 20, "label": "b", "value_label": "20:b"},
+    ]
+
+
+def test_ray_backend_rejects_shuffled_ray_native_local_file_seed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    seed_path = tmp_path / "seed.csv"
+    lazy.pd.DataFrame({"value": [1, 2]}).to_csv(seed_path, index=False)
+    config_builder = DataDesignerConfigBuilder(model_configs=[])
+    config_builder.with_seed_dataset(
+        LocalFileSeedSource(path=str(seed_path)),
+        sampling_strategy=SamplingStrategy.SHUFFLE,
+    )
+    config_builder.add_column(ExpressionColumnConfig(name="value_copy", expr="{{ value }}"))
+    designer = DataDesigner(
+        artifact_path=tmp_path / "artifacts",
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2),
+    )
+
+    with pytest.raises(RayBackendConfigurationError, match="local-file seed ingestion.*ordered sampling"):
+        designer.create(config_builder, num_records=1)
+
+    assert fake_ray.data.read_csv_input is None
+    assert fake_ray.data.from_pandas_input is None
+
+
+def test_ray_backend_reads_file_contents_seed_with_ray_data(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    seed_dir = tmp_path / "seeds"
+    seed_dir.mkdir()
+    (seed_dir / "a.txt").write_text("alpha", encoding="utf-8")
+    (seed_dir / "b.txt").write_text("beta", encoding="utf-8")
+
+    config_builder = DataDesignerConfigBuilder(model_configs=[])
+    config_builder.with_seed_dataset(FileContentsSeedSource(path=str(seed_dir), file_pattern="*.txt"))
+    config_builder.add_column(ExpressionColumnConfig(name="content_label", expr="{{ file_name }}:{{ content }}"))
+    designer = DataDesigner(
+        artifact_path=tmp_path / "artifacts",
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2),
+    )
+
+    output_df = designer.create(config_builder, num_records=3).load_dataset().to_pandas()
+
+    assert fake_ray.data.read_binary_files_input == [
+        str(seed_dir / "a.txt"),
+        str(seed_dir / "b.txt"),
+    ]
+    assert fake_ray.data.read_binary_files_kwargs == {"include_paths": True, "partitioning": None}
+    assert fake_ray.data.from_pandas_input is None
+    assert output_df.to_dict(orient="records") == [
+        {
+            "source_kind": "file_contents",
+            "source_path": str(seed_dir / "a.txt"),
+            "relative_path": "a.txt",
+            "file_name": "a.txt",
+            "content": "alpha",
+            "content_label": "a.txt:alpha",
+        },
+        {
+            "source_kind": "file_contents",
+            "source_path": str(seed_dir / "b.txt"),
+            "relative_path": "b.txt",
+            "file_name": "b.txt",
+            "content": "beta",
+            "content_label": "b.txt:beta",
+        },
+        {
+            "source_kind": "file_contents",
+            "source_path": str(seed_dir / "a.txt"),
+            "relative_path": "a.txt",
+            "file_name": "a.txt",
+            "content": "alpha",
+            "content_label": "a.txt:alpha",
+        },
     ]
 
 

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -20,6 +20,7 @@ from data_designer.config.default_model_settings import (
     get_builtin_model_providers,
     resolve_seed_default_model_settings,
 )
+from data_designer.config.seed_source import LocalFileSeedSource
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayInputRepartition
 from data_designer.interface.data_designer import DataDesigner
@@ -189,6 +190,39 @@ def test_real_ray_input_dataset_repartition_smoke(
     assert metrics.blocks == 2
     assert sorted(output_df["x"].tolist()) == [1, 2, 3, 4]
     assert output_df["x_label"].notna().all()
+
+
+def test_real_ray_local_file_seed_ingestion_smoke(
+    tmp_path: Path,
+    local_ray: Any,
+    real_ray_smoke_paths: Any,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    seed_path = tmp_path / "seed.csv"
+    lazy.pd.DataFrame({"x": [1, 2, 3], "label": ["a", "b", "c"]}).to_csv(seed_path, index=False)
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.with_seed_dataset(LocalFileSeedSource(path=str(seed_path)))
+    config_builder.add_column(ExpressionColumnConfig(name="x_label", expr="{{ x }}-{{ label }}"))
+    designer = DataDesigner(
+        artifact_path=real_ray_smoke_paths.artifact_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=real_ray_smoke_paths.managed_assets_path,
+        backend=RayBackend(batch_size=2, output="dataset"),
+    )
+
+    results = designer.create(config_builder, num_records=5)
+    output_df = results.load_dataset().to_pandas()
+
+    assert local_ray.is_initialized()
+    assert output_df.to_dict(orient="records") == [
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+        {"x": 3, "label": "c", "x_label": "3-c"},
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+    ]
 
 
 def _repo_root() -> Path:


### PR DESCRIPTION
## 📋 Summary

Moves RayBackend seed ingestion for file-backed seeds off the fully hydrated driver path. Structured local files are read through Ray Data readers, file-content seeds use Ray binary file ingestion, and generic filesystem seed readers now hydrate manifest rows inside Ray batches.

## 🔗 Related Issue

Fixes #43

## 🔄 Changes

- Added Ray-native seed plans that can return a Ray Dataset directly instead of a driver-created pandas DataFrame.
- Wired `RayDriverPlanner` to use internal `ray_native_seed` datasets as worker input seeds.
- Added ordered range selection, cycling, and ordinal-column cleanup for Ray-native seed datasets.
- Extended the fake Ray harness with `read_*`, `filter`, `limit`, and `union` support for seed-ingestion coverage.
- Added fake-Ray coverage for local CSV/JSONL seeds, file-content seeds, generic filesystem fanout hydration, shuffled-seed rejection, and an opt-in real-Ray local-file smoke test.

## 🧪 Testing

- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run pytest packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_seed_planning.py packages/data-designer/tests/integrations/ray/test_real_smoke.py packages/data-designer/tests/integrations/ray/test_fake_ray_harness.py -q` -> 74 passed, 5 skipped
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run pytest packages/data-designer/tests/integrations/ray -m 'ray_fake or ray_worker_boundary or ray_benchmark' -q` -> 205 passed, 1 skipped, 5 deselected
- [x] `DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run pytest packages/data-designer/tests/integrations/ray/test_real_smoke.py::test_real_ray_local_file_seed_ingestion_smoke -q` -> 1 passed
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/seed_planning.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_real_smoke.py`
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray-veracity uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/seed_planning.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_real_smoke.py`

## ✅ Checklist

- [x] Follows commit message conventions
- [ ] Commits are signed off (DCO) — repository history does not appear to require signed-off commits for this branch
- [x] Architecture docs updated (if applicable) — N/A, implementation covered by issue and tests