### PR TITLE
perf: validate Ray map batch row counts

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from data_designer.integrations.ray.backend import RayBackend, RayDatasetCreationResults
 from data_designer.integrations.ray.errors import (
     RayBackendConfigurationError,
+    RayBackendRowCountError,
     RayDatasetGenerationError,
     RayIntegrationError,
     RayMetricsError,
@@ -39,6 +40,7 @@ from data_designer.integrations.ray.options import (
 __all__ = [
     "RayBackend",
     "RayBackendConfigurationError",
+    "RayBackendRowCountError",
     "RayBlockPlanning",
     "RayDataCheckpointConfig",
     "RayDataContextOptions",

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -15,6 +15,7 @@ import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import CustomColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.data_designer_config import DataDesignerConfig
+from data_designer.config.processors import ProcessorType
 from data_designer.engine.column_generators.utils.generator_classification import column_type_is_model_generated
 from data_designer.engine.dataset_builders.block_execution import execute_dataset_block
 from data_designer.engine.storage.artifact_storage import ArtifactStorage
@@ -44,6 +45,7 @@ from data_designer.integrations.ray.worker_pipeline import (
     _RAY_INTERNAL_ROW_ID_COLUMN,
     _coerce_pandas_dataframe,
     _compile_ray_execution_payload,
+    _iter_dataframe_chunks,
     _RayExecutionPayload,
     _RayWorkerGenerationPipeline,
     _RayWorkerOptions,
@@ -60,6 +62,10 @@ RayDatasetSourceKind = Literal[
     "ray_native_seed",
     "seed_window",
 ]
+_ROW_COUNT_PRESERVING_PROCESSOR_TYPES = {
+    ProcessorType.DROP_COLUMNS.value,
+    ProcessorType.SCHEMA_TRANSFORM.value,
+}
 
 
 @dataclass(frozen=True)
@@ -272,6 +278,7 @@ class RayBackend:
         max_trace_events: int = 1000,
         max_worker_profiles: int = 1000,
         max_throttle_snapshots: int = 1000,
+        output_chunk_rows: int | None = None,
         **legacy_options: Any,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
@@ -284,6 +291,7 @@ class RayBackend:
         _validate_ray_backend_non_negative_int("max_trace_events", max_trace_events)
         _validate_ray_backend_non_negative_int("max_worker_profiles", max_worker_profiles)
         _validate_ray_backend_non_negative_int("max_throttle_snapshots", max_throttle_snapshots)
+        _validate_ray_backend_output_chunk_rows(output_chunk_rows)
         resolved_options = resolve_ray_backend_options(
             block_planning=block_planning,
             execution_options=execution_options,
@@ -314,6 +322,7 @@ class RayBackend:
         self.max_trace_events = max_trace_events
         self.max_worker_profiles = max_worker_profiles
         self.max_throttle_snapshots = max_throttle_snapshots
+        self.output_chunk_rows = output_chunk_rows
 
     def create(
         self,
@@ -510,6 +519,7 @@ class RayDriverPlanner:
         validate_no_ray_after_generation_processors(config_builder)
         if not self._backend.allow_unsafe_processors:
             validate_ray_safe_processors(config_builder)
+        row_count_preserving = _is_row_count_preserving_config(config_builder)
 
         model_aliases = _model_health_check_aliases(config_builder)
         if self._backend.preflight_model_health_check:
@@ -580,6 +590,8 @@ class RayDriverPlanner:
             use_input_dataset=use_input_dataset,
             seed_window=seed_window,
             hidden_order_column=ordering_mode.hidden_order_column,
+            preserve_output_row_count=row_count_preserving,
+            output_chunk_rows=self._backend.output_chunk_rows,
         )
 
         map_batches_kwargs: dict[str, Any] = {
@@ -595,6 +607,7 @@ class RayDriverPlanner:
             "zero_copy_batch": self._backend.zero_copy_batch,
         }
         map_batches_kwargs.update(self._backend.execution_options.to_map_batches_kwargs(self._ray))
+        map_batches_kwargs["udf_modifying_row_count"] = not row_count_preserving
 
         return RayJobPlan(
             dataset_source=RayDatasetSource(
@@ -691,6 +704,27 @@ def _validate_ray_backend_non_negative_int(field_name: str, value: int) -> None:
         raise RayBackendConfigurationError(f"RayBackend {field_name} must be a non-negative integer.")
 
 
+def _validate_ray_backend_output_chunk_rows(output_chunk_rows: int | None) -> None:
+    if output_chunk_rows is None:
+        return
+    if isinstance(output_chunk_rows, bool) or not isinstance(output_chunk_rows, int) or output_chunk_rows <= 0:
+        raise RayBackendConfigurationError("RayBackend output_chunk_rows must be a positive integer or None.")
+
+
+def _is_row_count_preserving_config(config_builder: DataDesignerConfigBuilder) -> bool:
+    if any(getattr(column_config, "allow_resize", False) for column_config in config_builder.get_column_configs()):
+        return False
+    return all(
+        _processor_type_value(processor_config.processor_type) in _ROW_COUNT_PRESERVING_PROCESSOR_TYPES
+        for processor_config in config_builder.get_processor_configs()
+    )
+
+
+def _processor_type_value(processor_type: Any) -> str:
+    value = getattr(processor_type, "value", processor_type)
+    return str(value)
+
+
 def _model_health_check_aliases(config_builder: DataDesignerConfigBuilder) -> list[str]:
     model_aliases: set[str] = set()
     for config in config_builder.get_column_configs():
@@ -770,6 +804,7 @@ def _attach_hidden_row_id_column(ray: Any, dataset: Any, *, hidden_order_column:
             _rename_range_id_column,
             fn_kwargs={"hidden_order_column": hidden_order_column},
             batch_format="pandas",
+            udf_modifying_row_count=False,
         )
         zip_dataset = getattr(dataset, "zip", None)
         if not callable(zip_dataset):
@@ -850,7 +885,10 @@ class _RayBatchWorker:
         self._worker_options: _RayWorkerOptions = self._pipeline.worker_options
 
     def __call__(self, batch: Any) -> Any:
-        return _generate_batch(batch, worker=self, metrics_collector=self._metrics_collector)
+        output = _generate_batch(batch, worker=self, metrics_collector=self._metrics_collector)
+        if self._execution_payload.output_chunk_rows is None:
+            return output
+        return _iter_dataframe_chunks(output, rows_per_chunk=self._execution_payload.output_chunk_rows)
 
     def close(self) -> None:
         return None
@@ -872,6 +910,8 @@ def _generate_batch(
     use_input_dataset: bool | None = None,
     seed_window: ray_seed_planning.RaySeedWindow | None = None,
     hidden_order_column: str | None = None,
+    preserve_output_row_count: bool = False,
+    output_chunk_rows: int | None = None,
     metrics_collector: Any | None = None,
     observability_options: _RayObservabilityOptions | None = None,
 ) -> Any:
@@ -885,6 +925,8 @@ def _generate_batch(
         use_input_dataset=use_input_dataset,
         seed_window=seed_window,
         hidden_order_column=hidden_order_column,
+        preserve_output_row_count=preserve_output_row_count,
+        output_chunk_rows=output_chunk_rows,
     )
     return _RayBatchWorker(
         execution_payload=execution_payload,

--- a/packages/data-designer/src/data_designer/integrations/ray/errors.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/errors.py
@@ -19,5 +19,9 @@ class RayDatasetGenerationError(RayIntegrationError, DataDesignerGenerationError
     """Raised when Ray-backed dataset generation fails."""
 
 
+class RayBackendRowCountError(RayDatasetGenerationError):
+    """Raised when a Ray worker violates a row-preserving map_batches contract."""
+
+
 class RayMetricsError(RayIntegrationError):
     """Raised when Ray metrics cannot be normalized or aggregated."""

--- a/packages/data-designer/src/data_designer/integrations/ray/options.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/options.py
@@ -22,6 +22,7 @@ _DATA_DESIGNER_OWNED_MAP_BATCHES_KEYS = frozenset(
         "fn_constructor_args",
         "fn_constructor_kwargs",
         "fn_kwargs",
+        "udf_modifying_row_count",
         "zero_copy_batch",
     }
 )

--- a/packages/data-designer/src/data_designer/integrations/ray/seed_planning.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/seed_planning.py
@@ -155,6 +155,7 @@ def create_ray_file_contents_seed_dataset(
         _file_contents_seed_batch_to_dataframe,
         fn_kwargs={"root_path": str(context.root_path), "encoding": source.encoding},
         batch_format="pandas",
+        udf_modifying_row_count=False,
     )
     return _apply_ordered_seed_selection_and_cycling(
         ray=ray,
@@ -203,6 +204,7 @@ def create_ray_filesystem_seed_dataset(
             "output_columns": output_columns,
         },
         batch_format="pandas",
+        udf_modifying_row_count=True,
     ).limit(num_records)
 
 
@@ -286,6 +288,7 @@ def _select_seed_dataset_range(
     ordinal_dataset = ray.data.range(seed_dataset_size).map_batches(
         _rename_range_id_to_seed_ordinal,
         batch_format="pandas",
+        udf_modifying_row_count=False,
     )
     return (
         dataset.zip(ordinal_dataset)

--- a/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
@@ -9,7 +9,7 @@ import os
 import pickle
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
@@ -27,7 +27,11 @@ from data_designer.engine.resources.person_reader import PersonReader
 from data_designer.engine.resources.seed_reader import SeedReader
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
-from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
+from data_designer.integrations.ray.errors import (
+    RayBackendConfigurationError,
+    RayBackendRowCountError,
+    RayDatasetGenerationError,
+)
 from data_designer.integrations.ray.metrics import RayWorkerMetrics
 from data_designer.integrations.ray.observability import RayTraceEvent
 from data_designer.integrations.ray.observability_collection import (
@@ -71,6 +75,8 @@ class _RayExecutionPayload:
     seed_window: ray_seed_planning.RaySeedWindow | None = None
     seed_config: SeedConfig | None = None
     hidden_order_column: str | None = None
+    preserve_output_row_count: bool = False
+    output_chunk_rows: int | None = None
 
 
 @dataclass(frozen=True)
@@ -143,6 +149,11 @@ class _RayWorkerGenerationPipeline:
         try:
             batch_observer.record_generation_started(worker_batch)
             generation_result = self.generate_rows(worker_batch)
+            if self._execution_payload.preserve_output_row_count:
+                _validate_output_row_count(
+                    input_rows=worker_batch.num_records,
+                    output_rows=len(generation_result.dataframe),
+                )
             return self.complete_successful_batch(worker_batch, generation_result, batch_observer)
         except _RayWorkerAllRowsDroppedError as exc:
             batch_observer.record_all_rows_dropped(worker_batch, exc.block_result)
@@ -472,6 +483,8 @@ def _compile_ray_execution_payload(
     use_input_dataset: bool,
     seed_window: ray_seed_planning.RaySeedWindow | None = None,
     hidden_order_column: str | None = None,
+    preserve_output_row_count: bool = False,
+    output_chunk_rows: int | None = None,
 ) -> _RayExecutionPayload:
     data_designer_config = config_builder.build()
     payload_seed_config = data_designer_config.seed_config if seed_window is not None else None
@@ -487,6 +500,8 @@ def _compile_ray_execution_payload(
         seed_window=seed_window,
         seed_config=payload_seed_config,
         hidden_order_column=hidden_order_column,
+        preserve_output_row_count=preserve_output_row_count,
+        output_chunk_rows=output_chunk_rows,
     )
     _validate_worker_payload_serializable(payload)
     return payload
@@ -550,6 +565,24 @@ def _append_hidden_order_column(
     output = output.copy()
     output[hidden_order_column] = order_values
     return output
+
+
+def _iter_dataframe_chunks(dataframe: Any, *, rows_per_chunk: int) -> Iterator[Any]:
+    if len(dataframe) == 0:
+        yield dataframe
+        return
+    for start in range(0, len(dataframe), rows_per_chunk):
+        yield dataframe.iloc[start : start + rows_per_chunk].copy()
+
+
+def _validate_output_row_count(*, input_rows: int, output_rows: int) -> None:
+    if output_rows == input_rows:
+        return
+    raise RayBackendRowCountError(
+        "RayBackend marked this map_batches transform as row-count preserving, but a worker returned "
+        f"{output_rows} row(s) for {input_rows} input row(s). Disable row-count-changing processors or "
+        "allow_resize columns before using the row-preserving Ray map optimization."
+    )
 
 
 def _metrics_from_block_result(

--- a/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import copy
 import sys
 import types
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from glob import glob
 from pathlib import Path
-from typing import Any, ClassVar, Iterator
+from typing import Any, ClassVar
 
 import pytest
 
@@ -163,7 +164,10 @@ class FakeRayDataset:
             self.data_module.validate_map_batches_kwargs(kwargs)
         self.map_batches_kwargs = kwargs
         self.map_batches_fn = fn
-        self.map_batches_calls.append(FakeMapBatchesCall(fn=fn, kwargs=dict(kwargs)))
+        call = FakeMapBatchesCall(fn=fn, kwargs=dict(kwargs))
+        self.map_batches_calls.append(call)
+        if self.data_module is not None:
+            self.data_module.map_batches_calls.append(call)
         blocks = map_batches_blocks(fn, self.blocks, kwargs, data_context=self.data_context)
         if self.reverse_mapped_blocks:
             blocks.reverse()
@@ -341,6 +345,7 @@ class FakeRayDataModule:
         self.DataContext = FakeDataContext
         self.ExecutionResources = FakeExecutionResources
         self.latest_dataset_context: FakeDataContext | None = None
+        self.map_batches_calls: list[FakeMapBatchesCall] = []
 
     def dataset(
         self,
@@ -524,7 +529,11 @@ def map_batches_blocks(
     max_errored_blocks = data_context.max_errored_blocks if data_context is not None else 0
     for block in blocks:
         try:
-            mapped_blocks.append(coerce_pandas_dataframe(map_fn(coerce_pandas_dataframe(block), **fn_kwargs)))
+            result = map_fn(coerce_pandas_dataframe(block), **fn_kwargs)
+            if isinstance(result, Iterator):
+                mapped_blocks.extend(coerce_pandas_dataframe(chunk) for chunk in result)
+            else:
+                mapped_blocks.append(coerce_pandas_dataframe(result))
         except Exception:
             failed_blocks += 1
             if max_errored_blocks < 0 or failed_blocks <= max_errored_blocks:

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -8,11 +8,13 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from fake_ray_harness import FakeRayDataset, install_fake_ray
+from fake_ray_harness import FakeMapBatchesCall, FakeRayDataset, install_fake_ray
 
 import data_designer.lazy_heavy_imports as lazy
-from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextColumnConfig
+from data_designer.config.base import ProcessorConfig
+from data_designer.config.column_configs import CustomColumnConfig, ExpressionColumnConfig, LLMTextColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.custom_column import custom_column_generator
 from data_designer.config.processors import SchemaTransformProcessorConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import IndexRange, SamplingStrategy
@@ -25,6 +27,7 @@ from data_designer.engine.testing.seed_readers import LineFanoutDirectorySeedRea
 from data_designer.integrations.ray import (
     RayBackend,
     RayBackendConfigurationError,
+    RayBackendRowCountError,
     RayBlockPlanning,
     RayDataCheckpointConfig,
     RayDataContextOptions,
@@ -89,6 +92,33 @@ def _block_result(*, dataframe: Any, input_rows: int) -> BlockExecutionResult:
     )
 
 
+def _map_batches_call_for(fake_ray: Any, fn: Any) -> FakeMapBatchesCall:
+    for call in fake_ray.data.map_batches_calls:
+        if call.fn is fn:
+            return call
+    raise AssertionError(f"fake Ray did not record map_batches call for {fn!r}")
+
+
+@custom_column_generator(required_columns=["x"])
+def _expand_x(row: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {**row, "expanded": f"{row['x']}-a"},
+        {**row, "expanded": f"{row['x']}-b"},
+    ]
+
+
+class UnknownProcessorConfig(ProcessorConfig):
+    processor_type: str = "unknown_plugin_processor"
+
+
+class RecordingRayDataset(FakeRayDataset):
+    def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
+        del fn
+        self.map_batches_kwargs = kwargs
+        self.map_batches_fn = None
+        return FakeRayDataset([], data_module=self.data_module)
+
+
 def test_ray_backend_uses_input_dataset_as_in_memory_seed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -113,13 +143,147 @@ def test_ray_backend_uses_input_dataset_as_in_memory_seed(
 
     assert input_dataset.map_batches_kwargs is not None
     assert input_dataset.map_batches_kwargs["num_cpus"] == 0.5
+    assert input_dataset.map_batches_kwargs["udf_modifying_row_count"] is False
     assert "fn_kwargs" not in input_dataset.map_batches_kwargs
-    assert input_dataset.map_batches_kwargs["fn_constructor_kwargs"]["execution_payload"].use_input_dataset is True
+    execution_payload = input_dataset.map_batches_kwargs["fn_constructor_kwargs"]["execution_payload"]
+    assert execution_payload.use_input_dataset is True
+    assert execution_payload.preserve_output_row_count is True
     assert "ray_remote_args" not in input_dataset.map_batches_kwargs
     assert output_df.to_dict(orient="records") == [
         {"x": 1, "label": "a", "x_label": "1-a"},
         {"x": 2, "label": "b", "x_label": "2-b"},
     ]
+
+
+def test_ray_backend_does_not_mark_allow_resize_configs_as_row_preserving(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = RecordingRayDataset([lazy.pd.DataFrame({"x": [1, 2]})])
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(
+        CustomColumnConfig(
+            name="expanded",
+            generator_function=_expand_x,
+            allow_resize=True,
+        )
+    )
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_kwargs["udf_modifying_row_count"] is True
+    execution_payload = input_dataset.map_batches_kwargs["fn_constructor_kwargs"]["execution_payload"]
+    assert execution_payload.preserve_output_row_count is False
+    assert isinstance(results, RayDatasetCreationResults)
+
+
+def test_ray_row_count_predicate_fails_closed_for_unknown_processors() -> None:
+    class FakeConfigBuilder:
+        def get_column_configs(self) -> list[Any]:
+            return []
+
+        def get_processor_configs(self) -> list[UnknownProcessorConfig]:
+            return [UnknownProcessorConfig(name="plugin_processor")]
+
+    assert ray_backend_module._is_row_count_preserving_config(FakeConfigBuilder()) is False
+
+
+def test_ray_backend_validates_row_count_when_marked_preserving(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+
+    def execute_short_block(**kwargs: Any) -> BlockExecutionResult:
+        input_frame = kwargs["input_frame"]
+        dataframe = input_frame.iloc[:1].copy()
+        return BlockExecutionResult(
+            dataframe=dataframe,
+            raw_dataframe=dataframe.copy(),
+            task_traces=[],
+            model_usage_stats={},
+            model_usage_deltas={},
+            processor_artifacts={},
+            input_rows=len(input_frame),
+            output_rows=len(dataframe),
+            dropped_rows=len(input_frame) - len(dataframe),
+            all_rows_dropped=False,
+            partial_rows_dropped=True,
+        )
+
+    monkeypatch.setattr(ray_backend_module, "execute_dataset_block", execute_short_block)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2),
+    )
+
+    with pytest.raises(RayBackendRowCountError, match="row-count preserving"):
+        designer.create(config_builder, input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_kwargs["udf_modifying_row_count"] is False
+
+
+def test_ray_backend_can_yield_output_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"x": [1, 2, 3, 4, 5], "label": ["a", "b", "c", "d", "e"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=5, output_chunk_rows=2),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset)
+    output_dataset = results.load_dataset()
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_kwargs["udf_modifying_row_count"] is False
+    execution_payload = input_dataset.map_batches_kwargs["fn_constructor_kwargs"]["execution_payload"]
+    assert execution_payload.output_chunk_rows == 2
+    assert [len(block) for block in output_dataset.blocks] == [2, 2, 1]
+    assert output_dataset.to_pandas().to_dict(orient="records") == [
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+        {"x": 3, "label": "c", "x_label": "3-c"},
+        {"x": 4, "label": "d", "x_label": "4-d"},
+        {"x": 5, "label": "e", "x_label": "5-e"},
+    ]
+
+
+def test_ray_backend_rejects_invalid_output_chunk_rows() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="output_chunk_rows"):
+        RayBackend(output_chunk_rows=0)
+
+
+def test_ray_backend_rejects_row_count_hint_remote_override() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="udf_modifying_row_count"):
+        RayBackend(ray_remote_args={"udf_modifying_row_count": False})
 
 
 def test_ray_backend_uses_override_num_blocks_for_from_scratch_dataset(
@@ -599,6 +763,8 @@ def test_ray_driver_planner_captures_from_scratch_plan(
     assert fake_ray.data.range_kwargs == {"override_num_blocks": 3}
     assert plan.worker_payload is plan.map_batches_kwargs["fn_constructor_kwargs"]["execution_payload"]
     assert plan.map_batches_kwargs["batch_size"] == 2
+    assert plan.map_batches_kwargs["udf_modifying_row_count"] is False
+    assert plan.worker_payload.preserve_output_row_count is True
     assert plan.output == "arrow_refs"
     assert plan.input_blocks == 3
     assert plan.metrics_collector is None
@@ -637,6 +803,8 @@ def test_ray_driver_planner_captures_preserve_order_input_resolution(
     assert plan.ordering_mode.hidden_order_column == ray_backend_module._RAY_INTERNAL_ROW_ID_COLUMN
     assert plan.worker_payload.hidden_order_column == ray_backend_module._RAY_INTERNAL_ROW_ID_COLUMN
     assert ray_backend_module._RAY_INTERNAL_ROW_ID_COLUMN in plan.dataset_source.dataset.to_pandas().columns
+    order_call = _map_batches_call_for(fake_ray, ray_backend_module._rename_range_id_column)
+    assert order_call.kwargs["udf_modifying_row_count"] is False
     assert plan.block_plan is None
 
 
@@ -1230,6 +1398,10 @@ def test_ray_backend_hydrates_filesystem_seed_reader_fanout_with_ray_data(
         {"relative_path": "b.txt"},
     ]
     assert fake_ray.data.range_kwargs is None
+    hydrate_call = _map_batches_call_for(fake_ray, ray_seed_planning._hydrate_filesystem_seed_manifest_batch)
+    assert hydrate_call.kwargs["udf_modifying_row_count"] is True
+    main_call = _map_batches_call_for(fake_ray, ray_backend_module._RayBatchWorker)
+    assert main_call.kwargs["udf_modifying_row_count"] is False
     assert output_df.to_dict(orient="records") == [
         {"relative_path": "a.txt", "line_index": 0, "line": "alpha", "line_label": "a.txt:0:alpha"},
         {"relative_path": "a.txt", "line_index": 1, "line": "beta", "line_label": "a.txt:1:beta"},
@@ -1303,6 +1475,8 @@ def test_ray_backend_applies_local_file_seed_range_without_leaking_ordinal(
     assert fake_ray.data.read_json_input == str(seed_path)
     assert fake_ray.data.read_json_kwargs == {"lines": True, "partitioning": None}
     assert fake_ray.data.from_pandas_input is None
+    ordinal_call = _map_batches_call_for(fake_ray, ray_seed_planning._rename_range_id_to_seed_ordinal)
+    assert ordinal_call.kwargs["udf_modifying_row_count"] is False
     assert "__data_designer_ray_seed_ordinal" not in output_df.columns
     assert output_df.to_dict(orient="records") == [
         {"value": 20, "label": "b", "value_label": "20:b"},
@@ -1370,6 +1544,8 @@ def test_ray_backend_reads_file_contents_seed_with_ray_data(
     ]
     assert fake_ray.data.read_binary_files_kwargs == {"include_paths": True, "partitioning": None}
     assert fake_ray.data.from_pandas_input is None
+    contents_call = _map_batches_call_for(fake_ray, ray_seed_planning._file_contents_seed_batch_to_dataframe)
+    assert contents_call.kwargs["udf_modifying_row_count"] is False
     assert output_df.to_dict(orient="records") == [
         {
             "source_kind": "file_contents",

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -14,6 +14,7 @@ def test_ray_package_root_exports_stable_public_api() -> None:
     expected_public_api = {
         "RayBackend",
         "RayBackendConfigurationError",
+        "RayBackendRowCountError",
         "RayBlockPlanning",
         "RayDataCheckpointConfig",
         "RayDataContextOptions",


### PR DESCRIPTION
## 📋 Summary

This PR sets Ray `map_batches` row-count hints only where the DataDesigner transform is known to preserve cardinality, then validates that contract inside Ray workers. It also adds an opt-in generator-style output path that chunks large Ray batch outputs without changing metrics or ordering semantics.

Rebased onto the current fork `feat/ray-backend` tip `a254496`, which includes merge-train tip `2603f41` from PR #115.

## 🔗 Related Issue

Closes #50
Closes #51
Follow-up: #116

## 🔄 Changes

- Mark the main Ray generation `map_batches` with `udf_modifying_row_count=False` only when no column has `allow_resize` and configured processors are known row-preserving; otherwise mark it as row-count modifying.
- Carry the row-preserving contract through `_RayExecutionPayload` and raise `RayBackendRowCountError` if a worker returns a different row count while opted into the Ray optimization.
- Add `output_chunk_rows` to `RayBackend` so `_RayBatchWorker` can return an iterator of pandas chunks for large generated rows.
- Set row-count hints on Ray seed/order helper `map_batches` calls, including `udf_modifying_row_count=True` for filesystem seed fanout hydration.
- Extend the fake-Ray harness to record all `map_batches` calls and flatten iterator-style UDF output, with focused tests for safe hints, unsafe hints, validation, seed fanout hints, and chunked output.

## 🧪 Testing

- [ ] `make test` passes (not run; focused slice only)
- [x] Unit tests added/updated
- [x] `uv run --all-packages pytest packages/data-designer/tests/integrations/ray/test_backend.py -q` passes (`73 passed`)
- [x] `uv run --all-packages ruff check packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/errors.py packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/seed_planning.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_backend.py` passes
- [x] `uv run --all-packages ruff format --check packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/errors.py packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/src/data_designer/integrations/ray/seed_planning.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_backend.py` passes
- [ ] E2E tests added/updated (N/A; fake-Ray integration coverage only)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A; no architecture docs changed)