### PR TITLE
feat(ray): add Data LLM capability probe

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -63,6 +63,7 @@ Users declare what their data should look like through config objects (columns, 
 - [Config Layer](config.md) — builder API, column types, model configs, plugin system
 - [Engine Layer](engine.md) — compilation, generators, registries
 - [Models](models.md) — model facade, adapters, retry/throttle
+- [Ray Data LLM](ray-data-llm.md) — evaluation of Ray Data LLM/vLLM placement
 - [Dataset Builders](dataset-builders.md) — sync/async orchestration, DAG, batching
 - [MCP](mcp.md) — tool execution, session pooling
 - [Sampling](sampling.md) — statistical generators, person/entity data

--- a/architecture/ray-data-llm.md
+++ b/architecture/ray-data-llm.md
@@ -1,0 +1,74 @@
+# Ray Data LLM / vLLM Integration Evaluation
+
+Issue: [#52](https://github.com/eric-tramel/DataDesigner/issues/52)  
+Date: 2026-04-25  
+Status: recommended path documented; execution integration deferred
+
+## Decision
+
+Ray Data LLM/vLLM should not be added as a first-class `ModelProvider` yet. Keep external provider behavior on the existing `ModelFacade` and HTTP client adapters. Treat Ray Data LLM as a future RayBackend-only stage optimization for local GPU inference after the Ray planner can prove a column stage is eligible.
+
+The safe slice is a capability probe: `probe_ray_data_llm_capabilities()` detects the optional `ray.data.llm` surface at runtime, and `assess_ray_data_llm_integration()` returns the current placement recommendation without importing Ray during package import.
+
+## Sources Reviewed
+
+- Ray Data LLM docs: `ray.data.llm` is a Ray Dataset batch inference pipeline that can run vLLM/SGLang engines directly or call hosted endpoints through processor configs. Current docs reviewed: Ray 2.55.1, while this repository's Ray extra requires `ray[data]>=2.54.0,<3`. See <https://docs.ray.io/en/latest/data/working-with-llms.html>.
+- `vLLMEngineProcessorConfig` exposes stage-level knobs such as `model_source`, `batch_size`, `concurrency`, `engine_kwargs`, `task_type`, and `dynamic_lora_loading_path`. See <https://docs.ray.io/en/latest/data/api/doc/ray.data.llm.vLLMEngineProcessorConfig.html>.
+- vLLM engine arguments own GPU execution details such as tensor/pipeline parallelism and distributed executor backend selection. See <https://docs.vllm.ai/en/latest/configuration/engine_args/>.
+- vLLM and Ray Serve can expose OpenAI-compatible HTTP APIs; those already fit DataDesigner through `ModelProvider(provider_type="openai")`. See <https://docs.vllm.ai/en/latest/serving/openai_compatible_server/>.
+
+Local package introspection for this evaluation found `ray` and `vllm` were not installed in the worker environment, so no live GPU benchmark was run.
+
+## Fit Analysis
+
+### Provider Abstraction
+
+DataDesigner generators obtain models through `ModelRegistry` and `ModelFacade`. That path owns request construction, retry behavior, adaptive throttling, health checks, parser correction, MCP/tool loops, and usage stats.
+
+Ray Data LLM is not only a request adapter. It is a Ray Dataset processor stage with preprocess/postprocess functions and its own batching and resource controls. Modeling that as `ModelProvider(provider_type="ray-vllm")` would either bypass `ModelFacade` semantics or force a provider adapter to orchestrate Ray Dataset transforms from inside per-cell model calls, which would violate the current layering and execution model.
+
+### Recommended Placement
+
+The idiomatic path is a RayBackend optimization:
+
+1. The interface still receives declarative model and column configs.
+2. The Ray backend planner identifies eligible stages.
+3. Eligible Ray Dataset blocks flow through a Ray Data LLM processor.
+4. Ineligible columns continue through the existing engine block executor and `ModelFacade`.
+
+This preserves the declarative config contract and avoids changing external provider behavior.
+
+### Batching and Concurrency
+
+DataDesigner currently controls model concurrency with `max_parallel_requests`, async task scheduling, worker batch size, and optional Ray-level provider throttling. Ray Data LLM controls throughput with processor `batch_size`, stage `concurrency`, vLLM engine kwargs, and GPU placement. A future implementation needs an explicit mapping rather than reusing provider fields implicitly.
+
+### LoRA
+
+Ray Data LLM exposes dynamic LoRA loading at the processor level. DataDesigner does not currently model per-row or per-column LoRA adapter selection in `ModelConfig`, so LoRA should remain a future opt-in Ray integration field rather than a hidden provider behavior.
+
+### Embeddings, Classification, and Multimodal
+
+Ray Data LLM supports generation, embedding, classification, and scoring task types. That is promising for chat/text and embedding columns, but multimodal support needs extra care because DataDesigner image context resolution, generated artifact paths, and response parsing currently live around the model facade.
+
+## Initial Eligibility
+
+A narrow future prototype should only consider columns that meet all of these conditions:
+
+- RayBackend is active and `probe_ray_data_llm_capabilities().supports_local_vllm` is true.
+- The model is local vLLM-capable and explicitly opted in through a Ray integration option.
+- The column is an LLM text or embedding stage with no MCP tool config.
+- The stage does not require parser correction loops, custom retry semantics, or per-cell provider extras that Ray Data LLM cannot preserve.
+- The surrounding column dependency graph allows a whole Ray Dataset stage boundary.
+
+All other model-generated columns should keep using the existing `ModelFacade`.
+
+## Non-Goals For This Slice
+
+- No new `ModelProvider.provider_type`.
+- No required `vllm` dependency.
+- No changes to existing external OpenAI-compatible provider behavior.
+- No planner rewrite or GPU benchmark in this PR.
+
+## Follow-Up Recommendation
+
+[Issue #118](https://github.com/eric-tramel/DataDesigner/issues/118) tracks a RayBackend-only proof of concept and benchmark. The POC should compare the existing RayBackend plus OpenAI-compatible vLLM server path against a Ray Data LLM processor stage for a single independent text column, then expand only if the result preserves usage stats, errors, ordering, dropped-row behavior, and observability.

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -18,6 +18,12 @@ from data_designer.integrations.ray.errors import (
     RayIntegrationError,
     RayMetricsError,
 )
+from data_designer.integrations.ray.llm import (
+    RayDataLLMCapabilities,
+    RayDataLLMIntegrationAssessment,
+    assess_ray_data_llm_integration,
+    probe_ray_data_llm_capabilities,
+)
 from data_designer.integrations.ray.metrics import (
     RayDatasetMetrics,
     RayWorkerMetrics,
@@ -44,6 +50,8 @@ __all__ = [
     "RayBlockPlanning",
     "RayDataCheckpointConfig",
     "RayDataContextOptions",
+    "RayDataLLMCapabilities",
+    "RayDataLLMIntegrationAssessment",
     "RayDatasetAnalysis",
     "RayDatasetCreationResults",
     "RayDatasetGenerationError",
@@ -57,4 +65,6 @@ __all__ = [
     "RayTraceEvent",
     "RayWorkerMetrics",
     "RayWorkerProfile",
+    "assess_ray_data_llm_integration",
+    "probe_ray_data_llm_capabilities",
 ]

--- a/packages/data-designer/src/data_designer/integrations/ray/llm.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/llm.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from typing import Literal
+
+RayDataLLMPlacement = Literal["ray-backend-stage-optimization"]
+
+_REQUIRED_RAY_DATA_LLM_SYMBOLS = ("build_processor", "vLLMEngineProcessorConfig")
+_SUPPORTED_TASK_TYPES = ("generate", "embed", "classify", "score")
+_RECOMMENDED_PLACEMENT: RayDataLLMPlacement = "ray-backend-stage-optimization"
+_RECOMMENDATION = (
+    "Keep Ray Data LLM/vLLM behind the Ray integration as an optional stage optimization. "
+    "Do not model it as a general ModelProvider until DataDesigner can preserve ModelFacade semantics "
+    "for retries, MCP/tool loops, correction loops, usage accounting, and provider throttling."
+)
+_BLOCKING_GAPS = (
+    "Ray Data LLM is a Ray Dataset processor stage, while DataDesigner generators call the ModelFacade "
+    "per generated cell inside the engine execution plan.",
+    "A direct provider adapter would bypass existing ModelFacade contracts for retries, usage stats, "
+    "MCP/tool calls, parser correction, and health checks.",
+    "Stage-level execution needs planner support to select only eligible LLM columns and to preserve column "
+    "dependencies, validation, dropped-row handling, and artifact semantics.",
+)
+_SAFE_FIRST_SLICE = (
+    "Detect Ray Data LLM availability and keep external providers on the existing OpenAI-compatible facade. "
+    "A future prototype can add a RayBackend-only stage for eligible chat or embedding columns."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RayDataLLMCapabilities:
+    """Runtime availability of Ray Data LLM APIs needed for local vLLM execution."""
+
+    available: bool
+    ray_version: str | None
+    missing_symbols: tuple[str, ...]
+    has_build_processor: bool
+    has_vllm_engine_processor: bool
+    has_http_request_processor: bool
+    has_serve_deployment_processor: bool
+    supported_task_types: tuple[str, ...] = _SUPPORTED_TASK_TYPES
+    import_error: str | None = None
+
+    @property
+    def supports_local_vllm(self) -> bool:
+        """Return whether Ray Data LLM has the local vLLM processor API."""
+        return self.available and self.has_build_processor and self.has_vllm_engine_processor
+
+    @property
+    def supports_openai_compatible_endpoint(self) -> bool:
+        """Return whether Ray Data LLM exposes an HTTP processor API."""
+        return self.available and self.has_http_request_processor
+
+
+@dataclass(frozen=True, slots=True)
+class RayDataLLMIntegrationAssessment:
+    """Recommendation for how Ray Data LLM should fit into DataDesigner."""
+
+    capabilities: RayDataLLMCapabilities
+    recommended_placement: RayDataLLMPlacement
+    recommendation: str
+    broad_integration_ready: bool
+    safe_first_slice: str
+    blocking_gaps: tuple[str, ...]
+
+
+def probe_ray_data_llm_capabilities() -> RayDataLLMCapabilities:
+    """Probe optional Ray Data LLM symbols without importing Ray at module import time."""
+    ray_version = _package_version("ray")
+    try:
+        ray_data_llm = importlib.import_module("ray.data.llm")
+    except Exception as exc:
+        return RayDataLLMCapabilities(
+            available=False,
+            ray_version=ray_version,
+            missing_symbols=_REQUIRED_RAY_DATA_LLM_SYMBOLS,
+            has_build_processor=False,
+            has_vllm_engine_processor=False,
+            has_http_request_processor=False,
+            has_serve_deployment_processor=False,
+            import_error=f"{type(exc).__name__}: {exc}",
+        )
+
+    missing_symbols = tuple(symbol for symbol in _REQUIRED_RAY_DATA_LLM_SYMBOLS if not hasattr(ray_data_llm, symbol))
+    has_build_processor = hasattr(ray_data_llm, "build_processor")
+    has_vllm_engine_processor = hasattr(ray_data_llm, "vLLMEngineProcessorConfig")
+    return RayDataLLMCapabilities(
+        available=not missing_symbols,
+        ray_version=ray_version,
+        missing_symbols=missing_symbols,
+        has_build_processor=has_build_processor,
+        has_vllm_engine_processor=has_vllm_engine_processor,
+        has_http_request_processor=hasattr(ray_data_llm, "HttpRequestProcessorConfig"),
+        has_serve_deployment_processor=hasattr(ray_data_llm, "ServeDeploymentProcessorConfig"),
+    )
+
+
+def assess_ray_data_llm_integration(
+    capabilities: RayDataLLMCapabilities | None = None,
+) -> RayDataLLMIntegrationAssessment:
+    """Return the current integration recommendation for Ray Data LLM/vLLM."""
+    resolved_capabilities = capabilities or probe_ray_data_llm_capabilities()
+    return RayDataLLMIntegrationAssessment(
+        capabilities=resolved_capabilities,
+        recommended_placement=_RECOMMENDED_PLACEMENT,
+        recommendation=_RECOMMENDATION,
+        broad_integration_ready=False,
+        safe_first_slice=_SAFE_FIRST_SLICE,
+        blocking_gaps=_BLOCKING_GAPS,
+    )
+
+
+def _package_version(package_name: str) -> str | None:
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return None

--- a/packages/data-designer/tests/integrations/ray/test_llm.py
+++ b/packages/data-designer/tests/integrations/ray/test_llm.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from data_designer.integrations.ray import llm as ray_llm
+
+pytestmark = pytest.mark.ray_fake
+
+
+def test_probe_ray_data_llm_capabilities_reports_missing_optional_surface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_import_module(name: str) -> Any:
+        assert name == "ray.data.llm"
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(ray_llm.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(ray_llm, "_package_version", lambda package_name: None)
+
+    capabilities = ray_llm.probe_ray_data_llm_capabilities()
+
+    assert capabilities.available is False
+    assert capabilities.ray_version is None
+    assert capabilities.missing_symbols == ("build_processor", "vLLMEngineProcessorConfig")
+    assert capabilities.supports_local_vllm is False
+    assert capabilities.import_error is not None
+
+
+def test_probe_ray_data_llm_capabilities_detects_vllm_processor_symbols(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_module = SimpleNamespace(
+        build_processor=object(),
+        vLLMEngineProcessorConfig=object(),
+        HttpRequestProcessorConfig=object(),
+        ServeDeploymentProcessorConfig=object(),
+    )
+
+    def fake_import_module(name: str) -> Any:
+        assert name == "ray.data.llm"
+        return fake_module
+
+    monkeypatch.setattr(ray_llm.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(ray_llm, "_package_version", lambda package_name: "2.54.0")
+
+    capabilities = ray_llm.probe_ray_data_llm_capabilities()
+
+    assert capabilities.available is True
+    assert capabilities.ray_version == "2.54.0"
+    assert capabilities.missing_symbols == ()
+    assert capabilities.supports_local_vllm is True
+    assert capabilities.supports_openai_compatible_endpoint is True
+    assert capabilities.supported_task_types == ("generate", "embed", "classify", "score")
+
+
+def test_assess_ray_data_llm_integration_keeps_vllm_out_of_provider_abstraction() -> None:
+    capabilities = ray_llm.RayDataLLMCapabilities(
+        available=True,
+        ray_version="2.54.0",
+        missing_symbols=(),
+        has_build_processor=True,
+        has_vllm_engine_processor=True,
+        has_http_request_processor=False,
+        has_serve_deployment_processor=False,
+    )
+
+    assessment = ray_llm.assess_ray_data_llm_integration(capabilities)
+
+    assert assessment.capabilities is capabilities
+    assert assessment.recommended_placement == "ray-backend-stage-optimization"
+    assert assessment.broad_integration_ready is False
+    assert "Do not model it as a general ModelProvider" in assessment.recommendation
+    assert any("ModelFacade contracts" in gap for gap in assessment.blocking_gaps)

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -18,6 +18,8 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayBlockPlanning",
         "RayDataCheckpointConfig",
         "RayDataContextOptions",
+        "RayDataLLMCapabilities",
+        "RayDataLLMIntegrationAssessment",
         "RayDatasetAnalysis",
         "RayDatasetCreationResults",
         "RayDatasetGenerationError",
@@ -31,6 +33,8 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayTraceEvent",
         "RayWorkerMetrics",
         "RayWorkerProfile",
+        "assess_ray_data_llm_integration",
+        "probe_ray_data_llm_capabilities",
     }
 
     assert set(ray.__all__) == expected_public_api


### PR DESCRIPTION
## 📋 Summary

Evaluates Ray Data LLM/vLLM integration for local GPU generation and records the recommended path: keep it out of `ModelProvider` for now and treat it as a future RayBackend-only stage optimization. Adds a small runtime capability probe so follow-up work can detect `ray.data.llm` without changing external provider behavior.

## 🔗 Related Issue

Closes #52
Follow-up: #118

## 🔄 Changes

- Added `probe_ray_data_llm_capabilities()` and `assess_ray_data_llm_integration()` under `data_designer.integrations.ray`.
- Exported the probe and assessment dataclasses from the experimental Ray integration package root.
- Added test coverage for missing Ray Data LLM, detected vLLM/HTTP processor symbols, and the recommendation to keep vLLM out of the provider abstraction.
- Added `architecture/ray-data-llm.md` with the placement analysis, current Ray/vLLM docs reviewed, and initial eligibility constraints.

## 🔍 Sources

- Ray Data LLM docs reviewed: https://docs.ray.io/en/latest/data/working-with-llms.html
- Ray `vLLMEngineProcessorConfig` docs reviewed: https://docs.ray.io/en/latest/data/api/doc/ray.data.llm.vLLMEngineProcessorConfig.html
- vLLM engine args docs reviewed: https://docs.vllm.ai/en/latest/configuration/engine_args/
- vLLM OpenAI-compatible server docs reviewed: https://docs.vllm.ai/en/latest/serving/openai_compatible_server/
- Local package introspection in this worker environment: `ray` and `vllm` were not installed; repository Ray extra is `ray[data]>=2.54.0,<3`.

## 🧪 Testing

- [ ] `make test` passes (not run; focused Ray integration slice only)
- [x] `uv run --package data-designer pytest packages/data-designer/tests/integrations/ray/test_llm.py`
- [x] `uv run ruff check architecture/overview.md architecture/ray-data-llm.md packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/src/data_designer/integrations/ray/llm.py packages/data-designer/tests/integrations/ray/test_llm.py`
- [x] `uv run ruff format --check --preview architecture/overview.md architecture/ray-data-llm.md packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/src/data_designer/integrations/ray/llm.py packages/data-designer/tests/integrations/ray/test_llm.py`
- [x] `git diff --check`
- [x] Unit tests added/updated
- [x] E2E tests not applicable; no execution backend behavior changed

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
