### PR TITLE
feat(ray): persist dataset diagnostics

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -23,6 +23,7 @@ from data_designer.integrations.ray.metrics import (
 )
 from data_designer.integrations.ray.observability import (
     RayDatasetAnalysis,
+    RayDatasetStats,
     RayThrottleSnapshot,
     RayTraceEvent,
     RayWorkerProfile,
@@ -46,6 +47,7 @@ __all__ = [
     "RayDatasetCreationResults",
     "RayDatasetGenerationError",
     "RayDatasetMetrics",
+    "RayDatasetStats",
     "RayExecutionOptions",
     "RayExecutionResources",
     "RayInputRepartition",

--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -12,12 +12,14 @@ from typing import Any, TypeAlias
 
 from data_designer.integrations.ray._telemetry_normalization import (
     ModelUsageSummary,
+    coerce_bool_field,
     coerce_float_field,
     coerce_int_field,
     coerce_model_usage,
     coerce_optional_int_field,
     coerce_optional_string_field,
     coerce_string_field,
+    validate_bool_field,
     validate_failed_blocks_not_greater_than_blocks,
     validate_non_empty_string_field,
     validate_non_negative_float_field,
@@ -28,12 +30,17 @@ from data_designer.integrations.ray.errors import RayMetricsError
 RayTraceEventPayload: TypeAlias = "RayTraceEvent | Mapping[str, Any]"
 RayWorkerProfilePayload: TypeAlias = "RayWorkerProfile | Mapping[str, Any]"
 RayThrottleSnapshotPayload: TypeAlias = "RayThrottleSnapshot | Mapping[str, Any]"
+RayDatasetStatsPayload: TypeAlias = "RayDatasetStats | Mapping[str, Any]"
 _OBSERVABILITY_FIELD_LABEL = "Ray observability field"
 _OBSERVABILITY_TELEMETRY_LABEL = "Ray observability"
 _MODEL_USAGE_FIELD_LABEL = "Ray observability model_usage"
 _RAY_REPORT_SECTION_ALIASES = {
+    "dataset_stats": "ray_dataset_stats",
+    "diagnostics": "ray_dataset_stats",
     "overview": "summary",
+    "ray_dataset_stats": "ray_dataset_stats",
     "summary": "summary",
+    "stats": "ray_dataset_stats",
     "worker_profiles": "worker_profiles",
     "profiles": "worker_profiles",
     "trace_events": "trace_events",
@@ -168,6 +175,75 @@ class RayThrottleSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class RayDatasetStats:
+    """Bounded Ray Dataset stats text and extracted operator diagnostics."""
+
+    stats_text: str | None = None
+    stats_text_truncated: bool = False
+    stats_text_char_count: int = 0
+    operator_diagnostics: list[str] = field(default_factory=list)
+    operator_diagnostics_dropped: int = 0
+    backpressure_diagnostics: list[str] = field(default_factory=list)
+    backpressure_diagnostics_dropped: int = 0
+    object_store_diagnostics: list[str] = field(default_factory=list)
+    object_store_diagnostics_dropped: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        coerce_optional_string_field(
+            self.stats_text,
+            "stats_text",
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_bool_field(
+            "stats_text_truncated",
+            self.stats_text_truncated,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "stats_text_char_count",
+            self.stats_text_char_count,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "operator_diagnostics_dropped",
+            self.operator_diagnostics_dropped,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "backpressure_diagnostics_dropped",
+            self.backpressure_diagnostics_dropped,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "object_store_diagnostics_dropped",
+            self.object_store_diagnostics_dropped,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        for field_name, values in (
+            ("operator_diagnostics", self.operator_diagnostics),
+            ("backpressure_diagnostics", self.backpressure_diagnostics),
+            ("object_store_diagnostics", self.object_store_diagnostics),
+            ("warnings", self.warnings),
+        ):
+            for value in values:
+                validate_non_empty_string_field(
+                    f"{field_name} item",
+                    value,
+                    field_label=_OBSERVABILITY_FIELD_LABEL,
+                )
+
+    @property
+    def has_stats_text(self) -> bool:
+        """Return whether Ray returned non-empty Dataset.stats() text."""
+        return bool(self.stats_text)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
 class RayDatasetAnalysis:
     """Ray-native analysis artifact composed from bounded worker summaries."""
 
@@ -180,6 +256,8 @@ class RayDatasetAnalysis:
     trace_events_dropped: int = 0
     throttle_snapshots: list[RayThrottleSnapshot] = field(default_factory=list)
     throttle_snapshots_dropped: int = 0
+    ray_dataset_stats: RayDatasetStats | None = None
+    diagnostic_warnings: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         validate_non_negative_int_field("total_rows", self.total_rows, field_label=_OBSERVABILITY_FIELD_LABEL)
@@ -205,6 +283,14 @@ class RayDatasetAnalysis:
             self.throttle_snapshots_dropped,
             field_label=_OBSERVABILITY_FIELD_LABEL,
         )
+        if self.ray_dataset_stats is not None and not isinstance(self.ray_dataset_stats, RayDatasetStats):
+            raise RayMetricsError("RayDatasetAnalysis ray_dataset_stats must be RayDatasetStats when provided.")
+        for warning in self.diagnostic_warnings:
+            validate_non_empty_string_field(
+                "diagnostic_warnings item",
+                warning,
+                field_label=_OBSERVABILITY_FIELD_LABEL,
+            )
 
     @property
     def successful_blocks(self) -> int:
@@ -226,7 +312,7 @@ class RayDatasetAnalysis:
         Ray-native reports are bounded worker summaries, not the standard local
         dataset profiler report. include_sections filters top-level Ray report
         sections and accepts ``summary``/``overview``, ``worker_profiles``,
-        ``trace_events``, and ``throttle_snapshots``.
+        ``trace_events``, ``throttle_snapshots``, and ``ray_dataset_stats``.
         """
         sections = _normalize_include_sections(include_sections)
         if save_path is None:
@@ -263,7 +349,59 @@ class RayDatasetAnalysis:
         if "throttle_snapshots" in sections:
             payload["throttle_snapshots"] = [snapshot.to_dict() for snapshot in self.throttle_snapshots]
             payload["throttle_snapshots_dropped"] = self.throttle_snapshots_dropped
+        if "ray_dataset_stats" in sections:
+            payload["ray_dataset_stats"] = None if self.ray_dataset_stats is None else self.ray_dataset_stats.to_dict()
+            payload["diagnostic_warnings"] = list(self.diagnostic_warnings)
         return payload
+
+
+def normalize_ray_dataset_stats(payload: RayDatasetStatsPayload) -> RayDatasetStats:
+    """Normalize a Ray Dataset stats dataclass or mapping payload."""
+    if isinstance(payload, RayDatasetStats):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise RayMetricsError(f"Ray Dataset stats payload must be a mapping, got {type(payload)!r}.")
+    return RayDatasetStats(
+        stats_text=coerce_optional_string_field(
+            payload.get("stats_text"),
+            "stats_text",
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        stats_text_truncated=coerce_bool_field(
+            payload,
+            "stats_text_truncated",
+            default=False,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        stats_text_char_count=coerce_int_field(
+            payload,
+            "stats_text_char_count",
+            default=0,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        operator_diagnostics=_coerce_str_list(payload.get("operator_diagnostics")),
+        operator_diagnostics_dropped=coerce_int_field(
+            payload,
+            "operator_diagnostics_dropped",
+            default=0,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        backpressure_diagnostics=_coerce_str_list(payload.get("backpressure_diagnostics")),
+        backpressure_diagnostics_dropped=coerce_int_field(
+            payload,
+            "backpressure_diagnostics_dropped",
+            default=0,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        object_store_diagnostics=_coerce_str_list(payload.get("object_store_diagnostics")),
+        object_store_diagnostics_dropped=coerce_int_field(
+            payload,
+            "object_store_diagnostics_dropped",
+            default=0,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        warnings=_coerce_str_list(payload.get("warnings")),
+    )
 
 
 def normalize_ray_trace_event(payload: RayTraceEventPayload) -> RayTraceEvent:

--- a/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
@@ -4,22 +4,72 @@
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import socket
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics
 from data_designer.integrations.ray.observability import (
     RayDatasetAnalysis,
+    RayDatasetStats,
     RayThrottleSnapshot,
     RayTraceEvent,
     RayWorkerProfile,
+    normalize_ray_dataset_stats,
     normalize_ray_throttle_snapshot,
     normalize_ray_trace_event,
     normalize_ray_worker_profile,
+)
+
+_MAX_RAY_DATASET_STATS_CHARS = 65_536
+_MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINES = 100
+_MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINE_CHARS = 500
+_MAX_RAY_DIAGNOSTIC_WARNINGS = 20
+_RAY_OPERATOR_DIAGNOSTIC_MARKERS = (
+    "operator",
+    "map",
+    "read",
+    "write",
+    "repartition",
+    "sort",
+    "filter",
+    "limit",
+    "union",
+    "zip",
+    "join",
+    "block",
+    "rows",
+    "task",
+    "wall time",
+    "cpu time",
+    "udf",
+)
+_RAY_BACKPRESSURE_DIAGNOSTIC_MARKERS = (
+    "backpressure",
+    "backpressured",
+    "queue",
+    "queued",
+    "pending",
+    "blocked",
+    "wait",
+    "stall",
+    "throttle",
+)
+_RAY_OBJECT_STORE_DIAGNOSTIC_MARKERS = (
+    "object store",
+    "object_store",
+    "objectref",
+    "plasma",
+    "spill",
+    "spilled",
+    "memory",
+    "bytes",
+    "mib",
+    "gib",
 )
 
 
@@ -108,24 +158,51 @@ def _create_metrics_collector(
 def assemble_ray_dataset_analysis(
     metrics: RayDatasetMetrics,
     payload: Mapping[str, Any],
+    *,
+    ray_dataset_stats: RayDatasetStats | Mapping[str, Any] | None = None,
+    diagnostic_warnings: list[str] | None = None,
 ) -> RayDatasetAnalysis | None:
-    if not _has_observability_payload(payload):
+    warnings = _bounded_warnings(diagnostic_warnings or [])
+    _extend_payload_warnings(payload.get("diagnostic_warnings"), warnings)
+    dataset_stats = _normalize_dataset_stats(
+        ray_dataset_stats if ray_dataset_stats is not None else payload.get("ray_dataset_stats"),
+        warnings,
+    )
+    if not _has_observability_payload(payload) and dataset_stats is None and not warnings:
         return None
-    worker_profiles = [normalize_ray_worker_profile(profile) for profile in payload.get("worker_profiles", []) or []]
-    trace_events = [normalize_ray_trace_event(event) for event in payload.get("trace_events", []) or []]
-    throttle_snapshots = [
-        normalize_ray_throttle_snapshot(snapshot) for snapshot in payload.get("throttle_snapshots", []) or []
-    ]
+    worker_profiles, invalid_worker_profiles = _normalize_observability_items(
+        payload.get("worker_profiles"),
+        normalize_ray_worker_profile,
+        "worker profile",
+        warnings,
+    )
+    trace_events, invalid_trace_events = _normalize_observability_items(
+        payload.get("trace_events"),
+        normalize_ray_trace_event,
+        "trace event",
+        warnings,
+    )
+    throttle_snapshots, invalid_throttle_snapshots = _normalize_observability_items(
+        payload.get("throttle_snapshots"),
+        normalize_ray_throttle_snapshot,
+        "throttle snapshot",
+        warnings,
+    )
     return RayDatasetAnalysis(
         total_rows=metrics.total_rows,
         blocks=metrics.blocks,
         failed_blocks=metrics.failed_blocks,
         worker_profiles=worker_profiles,
-        worker_profiles_dropped=int(payload.get("worker_profiles_dropped", 0) or 0),
+        worker_profiles_dropped=_safe_non_negative_payload_int(payload, "worker_profiles_dropped", warnings)
+        + invalid_worker_profiles,
         trace_events=trace_events,
-        trace_events_dropped=int(payload.get("trace_events_dropped", 0) or 0),
+        trace_events_dropped=_safe_non_negative_payload_int(payload, "trace_events_dropped", warnings)
+        + invalid_trace_events,
         throttle_snapshots=throttle_snapshots,
-        throttle_snapshots_dropped=int(payload.get("throttle_snapshots_dropped", 0) or 0),
+        throttle_snapshots_dropped=_safe_non_negative_payload_int(payload, "throttle_snapshots_dropped", warnings)
+        + invalid_throttle_snapshots,
+        ray_dataset_stats=dataset_stats,
+        diagnostic_warnings=warnings,
     )
 
 
@@ -137,7 +214,194 @@ def _has_observability_payload(payload: Mapping[str, Any]) -> bool:
         or payload.get("trace_events_dropped")
         or payload.get("throttle_snapshots")
         or payload.get("throttle_snapshots_dropped")
+        or payload.get("ray_dataset_stats")
+        or payload.get("diagnostic_warnings")
     )
+
+
+def collect_ray_dataset_stats(dataset: Any | None) -> RayDatasetStats | None:
+    """Collect bounded Ray Dataset.stats() output without materializing rows on the driver."""
+    if dataset is None:
+        return None
+    stats = getattr(dataset, "stats", None)
+    if not callable(stats):
+        return None
+
+    try:
+        raw_stats = stats()
+    except Exception as exc:
+        return RayDatasetStats(warnings=[_format_collection_warning("Ray Dataset.stats() failed", exc)])
+
+    stats_text, warnings = _coerce_ray_dataset_stats_text(raw_stats)
+    if stats_text is None:
+        return RayDatasetStats(warnings=warnings) if warnings else None
+
+    bounded_stats_text = stats_text[:_MAX_RAY_DATASET_STATS_CHARS]
+    stats_text_truncated = len(stats_text) > _MAX_RAY_DATASET_STATS_CHARS
+    operator_diagnostics, operator_diagnostics_dropped = _extract_ray_dataset_stats_diagnostics(
+        stats_text,
+        _RAY_OPERATOR_DIAGNOSTIC_MARKERS,
+    )
+    backpressure_diagnostics, backpressure_diagnostics_dropped = _extract_ray_dataset_stats_diagnostics(
+        stats_text,
+        _RAY_BACKPRESSURE_DIAGNOSTIC_MARKERS,
+    )
+    object_store_diagnostics, object_store_diagnostics_dropped = _extract_ray_dataset_stats_diagnostics(
+        stats_text,
+        _RAY_OBJECT_STORE_DIAGNOSTIC_MARKERS,
+    )
+    return RayDatasetStats(
+        stats_text=bounded_stats_text,
+        stats_text_truncated=stats_text_truncated,
+        stats_text_char_count=len(stats_text),
+        operator_diagnostics=operator_diagnostics,
+        operator_diagnostics_dropped=operator_diagnostics_dropped,
+        backpressure_diagnostics=backpressure_diagnostics,
+        backpressure_diagnostics_dropped=backpressure_diagnostics_dropped,
+        object_store_diagnostics=object_store_diagnostics,
+        object_store_diagnostics_dropped=object_store_diagnostics_dropped,
+        warnings=warnings,
+    )
+
+
+def _normalize_dataset_stats(
+    payload: Any,
+    warnings: list[str],
+) -> RayDatasetStats | None:
+    if payload is None:
+        return None
+    try:
+        return normalize_ray_dataset_stats(payload)
+    except Exception as exc:
+        _append_warning(warnings, _format_collection_warning("Ray Dataset stats payload normalization failed", exc))
+        return None
+
+
+def _normalize_observability_items(
+    raw_items: Any,
+    normalizer: Callable[[Any], Any],
+    item_label: str,
+    warnings: list[str],
+) -> tuple[list[Any], int]:
+    if raw_items is None:
+        return [], 0
+    if not isinstance(raw_items, list):
+        _append_warning(warnings, f"Ray observability {item_label} payload must be a list when provided.")
+        return [], 1
+
+    items: list[Any] = []
+    invalid_items = 0
+    for index, raw_item in enumerate(raw_items):
+        try:
+            items.append(normalizer(raw_item))
+        except Exception as exc:
+            invalid_items += 1
+            _append_warning(
+                warnings,
+                _format_collection_warning(f"Skipped Ray observability {item_label} at index {index}", exc),
+            )
+    return items, invalid_items
+
+
+def _safe_non_negative_payload_int(payload: Mapping[str, Any], field_name: str, warnings: list[str]) -> int:
+    value = payload.get(field_name, 0) or 0
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        _append_warning(warnings, f"Ray observability field {field_name!r} must be a non-negative integer.")
+        return 0
+    return value
+
+
+def _extend_payload_warnings(raw_warnings: Any, warnings: list[str]) -> None:
+    if raw_warnings is None:
+        return
+    if not isinstance(raw_warnings, list):
+        _append_warning(warnings, "Ray observability diagnostic_warnings payload must be a list when provided.")
+        return
+    for warning in raw_warnings:
+        if isinstance(warning, str) and warning:
+            _append_warning(warnings, warning)
+        else:
+            _append_warning(warnings, "Ray observability diagnostic_warnings entries must be non-empty strings.")
+
+
+def _coerce_ray_dataset_stats_text(raw_stats: Any) -> tuple[str | None, list[str]]:
+    warnings: list[str] = []
+    if raw_stats is None:
+        return None, ["Ray Dataset.stats() returned None."]
+    if isinstance(raw_stats, str):
+        return raw_stats, warnings
+    if isinstance(raw_stats, bytes):
+        return raw_stats.decode("utf-8", errors="replace"), [
+            "Ray Dataset.stats() returned bytes; decoded it as UTF-8 with replacement."
+        ]
+    if isinstance(raw_stats, Mapping) or isinstance(raw_stats, (list, tuple)):
+        return json.dumps(raw_stats, sort_keys=True, default=str), [
+            f"Ray Dataset.stats() returned {type(raw_stats).__name__}; serialized it as JSON text."
+        ]
+
+    for method_name in ("to_string", "to_summary"):
+        method = getattr(raw_stats, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            converted = method()
+        except Exception as exc:
+            _append_warning(
+                warnings,
+                _format_collection_warning(f"Ray Dataset.stats() {method_name} conversion failed", exc),
+            )
+            continue
+        if converted is raw_stats:
+            continue
+        converted_text, converted_warnings = _coerce_ray_dataset_stats_text(converted)
+        return converted_text, _bounded_warnings([*warnings, *converted_warnings])
+
+    _append_warning(
+        warnings,
+        f"Ray Dataset.stats() returned {type(raw_stats).__name__}; converted it with str().",
+    )
+    return str(raw_stats), warnings
+
+
+def _extract_ray_dataset_stats_diagnostics(
+    stats_text: str,
+    markers: tuple[str, ...],
+) -> tuple[list[str], int]:
+    diagnostics: list[str] = []
+    dropped = 0
+    for raw_line in stats_text.splitlines():
+        line = " ".join(raw_line.strip().split())
+        if line == "":
+            continue
+        normalized_line = line.lower()
+        if not any(marker in normalized_line for marker in markers):
+            continue
+        bounded_line = _bound_diagnostic_line(line)
+        if len(diagnostics) >= _MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINES:
+            dropped += 1
+            continue
+        diagnostics.append(bounded_line)
+    return diagnostics, dropped
+
+
+def _bound_diagnostic_line(line: str) -> str:
+    if len(line) <= _MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINE_CHARS:
+        return line
+    return f"{line[:_MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINE_CHARS]}... [truncated]"
+
+
+def _append_warning(warnings: list[str], warning: str) -> None:
+    if len(warnings) >= _MAX_RAY_DIAGNOSTIC_WARNINGS:
+        return
+    warnings.append(warning)
+
+
+def _bounded_warnings(warnings: list[str]) -> list[str]:
+    return [warning for warning in warnings if warning][:_MAX_RAY_DIAGNOSTIC_WARNINGS]
+
+
+def _format_collection_warning(message: str, exc: Exception) -> str:
+    return f"{message}: {type(exc).__name__}: {exc}"
 
 
 def _record_worker_observability(

--- a/packages/data-designer/src/data_designer/integrations/ray/results.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/results.py
@@ -17,6 +17,7 @@ from data_designer.integrations.ray.observability import RayDatasetAnalysis
 from data_designer.integrations.ray.observability_collection import (
     _has_observability_payload,
     assemble_ray_dataset_analysis,
+    collect_ray_dataset_stats,
 )
 
 
@@ -46,6 +47,7 @@ class RayResultArtifacts:
             ray=ray,
             metrics_collector=metrics_collector,
             metrics_loader=self._metrics_loader,
+            dataset_getter=lambda: self._dataset,
         )
 
     @property
@@ -171,6 +173,11 @@ class RayMetricsLoader:
             return None
         return snapshot()
 
+    @property
+    def driver_metrics(self) -> RayDatasetMetrics:
+        """Return driver-only metrics captured before optional worker aggregation."""
+        return self._driver_metrics
+
 
 class RayAnalysisLoader:
     """Load and normalize Ray observability artifacts without the public result wrapper."""
@@ -181,27 +188,57 @@ class RayAnalysisLoader:
         ray: Any | None = None,
         metrics_collector: Any | None = None,
         metrics_loader: RayMetricsLoader,
+        dataset_getter: Callable[[], Any] | None = None,
     ) -> None:
         self._ray = ray
         self._metrics_collector = metrics_collector
         self._metrics_loader = metrics_loader
+        self._dataset_getter = dataset_getter
         self._analysis_cache: RayDatasetAnalysis | None = None
 
     def load_observability(self) -> RayDatasetAnalysis | None:
         """Return bounded Ray-native profiles, traces, and worker-local throttle snapshots."""
         if self._analysis_cache is not None:
             return self._analysis_cache
-        if self._ray is None or self._metrics_collector is None:
-            return None
-        try:
-            payload = self._load_observability_payload()
-        except Exception as exc:
-            raise RayDatasetGenerationError("RayBackend failed to load Ray observability artifacts.") from exc
-        if not _has_observability_payload(payload):
+        diagnostic_warnings: list[str] = []
+        payload = self._load_observability_payload_or_warning(diagnostic_warnings)
+        metrics = self._load_metrics_for_analysis(diagnostic_warnings)
+        ray_dataset_stats = self._load_ray_dataset_stats(diagnostic_warnings)
+        if not _has_observability_payload(payload) and ray_dataset_stats is None and not diagnostic_warnings:
             return None
 
-        self._analysis_cache = assemble_ray_dataset_analysis(self._metrics_loader.load_metrics(), payload)
+        self._analysis_cache = assemble_ray_dataset_analysis(
+            metrics,
+            payload,
+            ray_dataset_stats=ray_dataset_stats,
+            diagnostic_warnings=diagnostic_warnings,
+        )
         return self._analysis_cache
+
+    def _load_observability_payload_or_warning(self, diagnostic_warnings: list[str]) -> dict[str, Any]:
+        if self._ray is None or self._metrics_collector is None:
+            return {}
+        try:
+            return self._load_observability_payload()
+        except Exception as exc:
+            diagnostic_warnings.append(_diagnostic_collection_warning("load Ray observability artifacts", exc))
+            return {}
+
+    def _load_metrics_for_analysis(self, diagnostic_warnings: list[str]) -> RayDatasetMetrics:
+        try:
+            return self._metrics_loader.load_metrics()
+        except Exception as exc:
+            diagnostic_warnings.append(_diagnostic_collection_warning("load Ray metrics for analysis", exc))
+            return self._metrics_loader.driver_metrics
+
+    def _load_ray_dataset_stats(self, diagnostic_warnings: list[str]) -> Any | None:
+        if self._dataset_getter is None:
+            return None
+        try:
+            return collect_ray_dataset_stats(self._dataset_getter())
+        except Exception as exc:
+            diagnostic_warnings.append(_diagnostic_collection_warning("collect Ray Dataset stats", exc))
+            return None
 
     def _load_observability_payload(self) -> dict[str, Any]:
         observability_snapshot = getattr(self._metrics_collector, "observability_snapshot", None)
@@ -212,6 +249,10 @@ class RayAnalysisLoader:
             self._metrics_loader.load_worker_metrics()
             payload = self._ray.get(observability_snapshot.remote())
         return dict(payload)
+
+
+def _diagnostic_collection_warning(action: str, exc: Exception) -> str:
+    return f"RayBackend failed to {action}: {type(exc).__name__}: {exc}"
 
 
 def _merge_driver_and_worker_metrics(

--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 import data_designer.lazy_heavy_imports as lazy
+from data_designer.integrations.ray import RayDatasetAnalysis, RayDatasetStats, RayTraceEvent
 
 pytestmark = pytest.mark.ray_benchmark
 
@@ -123,6 +124,49 @@ def test_result_payload_reports_validity_and_provider_counters(tmp_path: Path) -
     assert payload["throughput"]["tokens_per_second"] == 20
     assert payload["throughput"]["retry_count"] == 4
     assert payload["throughput"]["throttle_count"] == 1
+
+
+def test_ray_diagnostics_payload_summarizes_dataset_stats_without_raw_text() -> None:
+    benchmark_common = _load_common_module()
+
+    analysis = RayDatasetAnalysis(
+        total_rows=2,
+        blocks=1,
+        trace_events=[RayTraceEvent(block_id="block-a", event_type="block_completed", timestamp_seconds=1.0)],
+        trace_events_dropped=2,
+        ray_dataset_stats=RayDatasetStats(
+            stats_text="Operator 1 MapBatches: detailed stats text",
+            stats_text_char_count=43,
+            operator_diagnostics=["Operator 1 MapBatches: detailed stats text"],
+            backpressure_diagnostics=["Backpressure: queued task wait time 0.1s"],
+            object_store_diagnostics=["Object store memory: 1 MiB used"],
+        ),
+        diagnostic_warnings=["some Ray stats were unavailable"],
+    )
+
+    payload = benchmark_common.ray_diagnostics_payload(analysis)
+
+    assert payload == {
+        "diagnostic_warnings": ["some Ray stats were unavailable"],
+        "ray_dataset_stats": {
+            "backpressure_diagnostics": ["Backpressure: queued task wait time 0.1s"],
+            "backpressure_diagnostics_dropped": 0,
+            "object_store_diagnostics": ["Object store memory: 1 MiB used"],
+            "object_store_diagnostics_dropped": 0,
+            "operator_diagnostics": ["Operator 1 MapBatches: detailed stats text"],
+            "operator_diagnostics_dropped": 0,
+            "stats_text_available": True,
+            "stats_text_char_count": 43,
+            "stats_text_truncated": False,
+            "warnings": [],
+        },
+        "throttle_snapshots": 0,
+        "throttle_snapshots_dropped": 0,
+        "trace_events": 1,
+        "trace_events_dropped": 2,
+        "worker_profiles": 0,
+        "worker_profiles_dropped": 0,
+    }
 
 
 def test_failure_payload_preserves_result_shape() -> None:

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -16,6 +16,7 @@ from data_designer.integrations.ray import (
     RayDatasetAnalysis,
     RayDatasetCreationResults,
     RayDatasetMetrics,
+    RayDatasetStats,
     RayMetricsError,
     RayThrottleSnapshot,
     RayTraceEvent,
@@ -101,6 +102,116 @@ def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
     assert report["worker_profiles"][0]["block_id"] == "block-a"
     assert report["worker_profiles_dropped"] == 0
     assert report["throttle_snapshots_dropped"] == 0
+
+
+def test_ray_results_load_analysis_collects_dataset_stats_without_metrics_actor(
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    class StatsDataset:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def stats(self) -> str:
+            self.calls += 1
+            return "\n".join(
+                [
+                    "Operator 1 MapBatches(_RayBatchWorker): 2 tasks executed, 2 blocks produced",
+                    "Backpressure: queued task wait time 0.25s",
+                    "Object store memory: 10 MiB used, 0 bytes spilled",
+                ]
+            )
+
+    dataset = StatsDataset()
+    results = RayDatasetCreationResults(
+        dataset=dataset,
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(total_rows=4, blocks=2),
+    )
+
+    analysis = results.load_analysis()
+
+    assert analysis is not None
+    assert analysis.total_rows == 4
+    assert analysis.blocks == 2
+    assert analysis.ray_dataset_stats is not None
+    assert analysis.ray_dataset_stats.stats_text_char_count > 0
+    assert (
+        "Operator 1 MapBatches(_RayBatchWorker): 2 tasks executed, 2 blocks produced"
+        in analysis.ray_dataset_stats.operator_diagnostics
+    )
+    assert analysis.ray_dataset_stats.backpressure_diagnostics == ["Backpressure: queued task wait time 0.25s"]
+    assert analysis.ray_dataset_stats.object_store_diagnostics == ["Object store memory: 10 MiB used, 0 bytes spilled"]
+    assert results.load_analysis() is analysis
+    assert dataset.calls == 1
+
+
+def test_ray_results_load_analysis_preserves_dataset_stats_failure_as_warning(
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    class FailingStatsDataset:
+        def stats(self) -> str:
+            raise RuntimeError("stats unavailable")
+
+    results = RayDatasetCreationResults(
+        dataset=FailingStatsDataset(),
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(total_rows=1, blocks=1),
+    )
+
+    analysis = results.load_analysis()
+
+    assert analysis is not None
+    assert analysis.ray_dataset_stats is not None
+    assert analysis.ray_dataset_stats.stats_text is None
+    assert analysis.ray_dataset_stats.warnings == ["Ray Dataset.stats() failed: RuntimeError: stats unavailable"]
+
+
+def test_collect_ray_dataset_stats_bounds_raw_text_and_diagnostics() -> None:
+    class LongStatsDataset:
+        def stats(self) -> str:
+            long_operator_line = f"Operator {'x' * 600}"
+            return "\n".join([long_operator_line for _ in range(105)] + ["tail" * 1000])
+
+    dataset_stats = ray_observability_collection.collect_ray_dataset_stats(LongStatsDataset())
+
+    assert dataset_stats is not None
+    assert dataset_stats.stats_text_truncated is True
+    assert dataset_stats.stats_text is not None
+    assert len(dataset_stats.stats_text) == 65_536
+    assert len(dataset_stats.operator_diagnostics) == 100
+    assert dataset_stats.operator_diagnostics_dropped == 5
+    assert dataset_stats.operator_diagnostics[0].endswith("... [truncated]")
+
+
+def test_assemble_ray_dataset_analysis_skips_malformed_diagnostics() -> None:
+    analysis = ray_observability_collection.assemble_ray_dataset_analysis(
+        RayDatasetMetrics(total_rows=1, blocks=1),
+        {
+            "worker_profiles": [{"block_id": "block-a", "total_rows": 1}, {"total_rows": 1}],
+            "trace_events": "not-a-list",
+            "throttle_snapshots": [
+                {
+                    "provider_name": "provider",
+                    "model_id": "model",
+                    "domain": "chat",
+                    "current_limit": 1,
+                },
+                {"provider_name": 7},
+            ],
+            "trace_events_dropped": "bad-count",
+        },
+    )
+
+    assert analysis is not None
+    assert [profile.block_id for profile in analysis.worker_profiles] == ["block-a"]
+    assert analysis.worker_profiles_dropped == 1
+    assert analysis.trace_events == []
+    assert analysis.trace_events_dropped == 1
+    assert [snapshot.domain for snapshot in analysis.throttle_snapshots] == ["chat"]
+    assert analysis.throttle_snapshots_dropped == 1
+    assert any("Skipped Ray observability worker profile" in warning for warning in analysis.diagnostic_warnings)
+    assert any("trace event payload must be a list" in warning for warning in analysis.diagnostic_warnings)
+    assert any("trace_events_dropped" in warning for warning in analysis.diagnostic_warnings)
 
 
 def test_ray_metrics_collector_bounds_profiles_and_throttle_snapshots() -> None:
@@ -292,6 +403,39 @@ def test_ray_dataset_analysis_to_report_filters_html_sections(tmp_path: Path) ->
     assert "&quot;worker_profiles&quot;" in report
     assert "&quot;summary&quot;" not in report
     assert "&quot;trace_events&quot;" not in report
+
+
+def test_ray_dataset_analysis_to_report_filters_dataset_stats_section(tmp_path: Path) -> None:
+    analysis = RayDatasetAnalysis(
+        total_rows=1,
+        blocks=1,
+        ray_dataset_stats=RayDatasetStats(
+            stats_text="Operator 1 MapBatches: 1 blocks",
+            stats_text_char_count=31,
+            operator_diagnostics=["Operator 1 MapBatches: 1 blocks"],
+        ),
+        diagnostic_warnings=["stats partially unavailable"],
+    )
+    report_path = tmp_path / "ray-analysis.json"
+
+    analysis.to_report(report_path, include_sections=["ray_dataset_stats"])
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report == {
+        "diagnostic_warnings": ["stats partially unavailable"],
+        "ray_dataset_stats": {
+            "backpressure_diagnostics": [],
+            "backpressure_diagnostics_dropped": 0,
+            "object_store_diagnostics": [],
+            "object_store_diagnostics_dropped": 0,
+            "operator_diagnostics": ["Operator 1 MapBatches: 1 blocks"],
+            "operator_diagnostics_dropped": 0,
+            "stats_text": "Operator 1 MapBatches: 1 blocks",
+            "stats_text_char_count": 31,
+            "stats_text_truncated": False,
+            "warnings": [],
+        },
+    }
 
 
 def test_ray_dataset_analysis_to_report_rejects_unknown_include_section(tmp_path: Path) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -21,6 +21,7 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayDatasetCreationResults",
         "RayDatasetGenerationError",
         "RayDatasetMetrics",
+        "RayDatasetStats",
         "RayExecutionOptions",
         "RayExecutionResources",
         "RayInputRepartition",

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -155,6 +155,8 @@ def test_real_ray_streaming_out_of_core_parquet_smoke(
     assert analysis.total_rows == num_records
     assert analysis.worker_profiles
     assert analysis.trace_events
+    assert analysis.ray_dataset_stats is not None
+    assert analysis.ray_dataset_stats.stats_text is not None or analysis.ray_dataset_stats.warnings
     assert sample["ticket_key"].notna().all()
     assert sample["routing_key"].str.contains("::").all()
     assert list(parquet_dir.glob("*.parquet"))

--- a/scripts/benchmarks/ray_benchmark_common.py
+++ b/scripts/benchmarks/ray_benchmark_common.py
@@ -173,6 +173,7 @@ def run_ray_backend_benchmark(
         results = designer.create(config_builder, num_records=num_records)
         output = results.load_dataset().to_pandas()
         metrics = results.load_metrics().to_dict()
+        ray_diagnostics = load_ray_diagnostics_payload(results)
         elapsed_seconds = time.perf_counter() - start
         payload = result_payload(
             backend=backend,
@@ -191,6 +192,7 @@ def run_ray_backend_benchmark(
         )
         if ray_output == "arrow_refs":
             payload["arrow_ref_count"] = len(results.output)
+        payload["ray_diagnostics"] = ray_diagnostics
         return payload
 
 
@@ -289,6 +291,47 @@ def result_payload(
         "output_mode": output_mode,
         "batch_size": batch_size,
         "max_parallel_requests": max_parallel_requests,
+    }
+
+
+def load_ray_diagnostics_payload(results: Any) -> dict[str, Any] | None:
+    try:
+        analysis = results.load_analysis()
+    except Exception as exc:
+        return {
+            "ray_dataset_stats": None,
+            "diagnostic_warnings": [f"Ray analysis collection failed: {type(exc).__name__}: {exc}"],
+        }
+    return ray_diagnostics_payload(analysis)
+
+
+def ray_diagnostics_payload(analysis: Any | None) -> dict[str, Any] | None:
+    if analysis is None:
+        return None
+    dataset_stats = getattr(analysis, "ray_dataset_stats", None)
+    stats_payload = None
+    if dataset_stats is not None:
+        stats_payload = {
+            "stats_text_available": bool(getattr(dataset_stats, "has_stats_text", False)),
+            "stats_text_truncated": bool(getattr(dataset_stats, "stats_text_truncated", False)),
+            "stats_text_char_count": int(getattr(dataset_stats, "stats_text_char_count", 0) or 0),
+            "operator_diagnostics": list(getattr(dataset_stats, "operator_diagnostics", []) or []),
+            "operator_diagnostics_dropped": int(getattr(dataset_stats, "operator_diagnostics_dropped", 0) or 0),
+            "backpressure_diagnostics": list(getattr(dataset_stats, "backpressure_diagnostics", []) or []),
+            "backpressure_diagnostics_dropped": int(getattr(dataset_stats, "backpressure_diagnostics_dropped", 0) or 0),
+            "object_store_diagnostics": list(getattr(dataset_stats, "object_store_diagnostics", []) or []),
+            "object_store_diagnostics_dropped": int(getattr(dataset_stats, "object_store_diagnostics_dropped", 0) or 0),
+            "warnings": list(getattr(dataset_stats, "warnings", []) or []),
+        }
+    return {
+        "worker_profiles": len(getattr(analysis, "worker_profiles", []) or []),
+        "worker_profiles_dropped": int(getattr(analysis, "worker_profiles_dropped", 0) or 0),
+        "trace_events": len(getattr(analysis, "trace_events", []) or []),
+        "trace_events_dropped": int(getattr(analysis, "trace_events_dropped", 0) or 0),
+        "throttle_snapshots": len(getattr(analysis, "throttle_snapshots", []) or []),
+        "throttle_snapshots_dropped": int(getattr(analysis, "throttle_snapshots_dropped", 0) or 0),
+        "ray_dataset_stats": stats_payload,
+        "diagnostic_warnings": list(getattr(analysis, "diagnostic_warnings", []) or []),
     }
 
 


### PR DESCRIPTION
## 📋 Summary

Adds bounded Ray-native Dataset stats capture to the Ray analysis surface so users can inspect execution stats, operator/backpressure lines, and object-store signals without collecting result rows on the driver. Diagnostic collection now degrades to analysis warnings when Ray stats or observability payloads are absent, malformed, or fail at runtime.

## 🔗 Related Issue

Fixes #47

## 🔄 Changes

- Add `RayDatasetStats` to `RayDatasetAnalysis` and expose it from the Ray package root.
- Collect bounded `Dataset.stats()` text plus extracted operator, backpressure, and object-store diagnostic lines from `RayResultArtifacts.load_observability()`.
- Preserve dataset creation and analysis loading when Ray diagnostic APIs fail by converting collection and normalization failures into bounded warnings.
- Include compact Ray diagnostics summaries in benchmark payloads alongside existing DataDesigner metrics.
- Extend fake-Ray, benchmark-helper, public API, and real-Ray smoke coverage for the new diagnostics surface.

## 🔍 Attention Areas

- [observability_collection.py](https://github.com/eric-tramel/DataDesigner/blob/worker-e-ray-diagnostics-47/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py) — contains the bounded stats extraction and malformed-payload degradation logic.
- [observability.py](https://github.com/eric-tramel/DataDesigner/blob/worker-e-ray-diagnostics-47/packages/data-designer/src/data_designer/integrations/ray/observability.py) — adds the public `RayDatasetStats` analysis type.

## 🧪 Testing

- [ ] `make test` passes (not run; focused Ray integration suite run)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated (N/A for this diagnostics-only change)

Focused verification run:

- `uv run pytest packages/data-designer/tests/integrations/ray -q` — 231 passed, 7 skipped
- `uv run ruff check packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/observability_collection.py packages/data-designer/src/data_designer/integrations/ray/results.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_public_api.py packages/data-designer/tests/integrations/ray/test_real_smoke.py scripts/benchmarks/ray_benchmark_common.py` — passed
- `uv run ruff format --check packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/observability_collection.py packages/data-designer/src/data_designer/integrations/ray/results.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_public_api.py packages/data-designer/tests/integrations/ray/test_real_smoke.py scripts/benchmarks/ray_benchmark_common.py` — 9 files already formatted

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A; no architecture docs changed)