### PR TITLE
feat: add Ray artifact datasink

### DIFF
--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -63,6 +63,7 @@ Users declare what their data should look like through config objects (columns, 
 - [Config Layer](config.md) — builder API, column types, model configs, plugin system
 - [Engine Layer](engine.md) — compilation, generators, registries
 - [Models](models.md) — model facade, adapters, retry/throttle
+- [Ray Data LLM](ray-data-llm.md) — evaluation of Ray Data LLM/vLLM placement
 - [Dataset Builders](dataset-builders.md) — sync/async orchestration, DAG, batching
 - [MCP](mcp.md) — tool execution, session pooling
 - [Sampling](sampling.md) — statistical generators, person/entity data

--- a/architecture/ray-data-llm.md
+++ b/architecture/ray-data-llm.md
@@ -1,0 +1,74 @@
+# Ray Data LLM / vLLM Integration Evaluation
+
+Issue: [#52](https://github.com/eric-tramel/DataDesigner/issues/52)  
+Date: 2026-04-25  
+Status: recommended path documented; execution integration deferred
+
+## Decision
+
+Ray Data LLM/vLLM should not be added as a first-class `ModelProvider` yet. Keep external provider behavior on the existing `ModelFacade` and HTTP client adapters. Treat Ray Data LLM as a future RayBackend-only stage optimization for local GPU inference after the Ray planner can prove a column stage is eligible.
+
+The safe slice is a capability probe: `probe_ray_data_llm_capabilities()` detects the optional `ray.data.llm` surface at runtime, and `assess_ray_data_llm_integration()` returns the current placement recommendation without importing Ray during package import.
+
+## Sources Reviewed
+
+- Ray Data LLM docs: `ray.data.llm` is a Ray Dataset batch inference pipeline that can run vLLM/SGLang engines directly or call hosted endpoints through processor configs. Current docs reviewed: Ray 2.55.1, while this repository's Ray extra requires `ray[data]>=2.54.0,<3`. See <https://docs.ray.io/en/latest/data/working-with-llms.html>.
+- `vLLMEngineProcessorConfig` exposes stage-level knobs such as `model_source`, `batch_size`, `concurrency`, `engine_kwargs`, `task_type`, and `dynamic_lora_loading_path`. See <https://docs.ray.io/en/latest/data/api/doc/ray.data.llm.vLLMEngineProcessorConfig.html>.
+- vLLM engine arguments own GPU execution details such as tensor/pipeline parallelism and distributed executor backend selection. See <https://docs.vllm.ai/en/latest/configuration/engine_args/>.
+- vLLM and Ray Serve can expose OpenAI-compatible HTTP APIs; those already fit DataDesigner through `ModelProvider(provider_type="openai")`. See <https://docs.vllm.ai/en/latest/serving/openai_compatible_server/>.
+
+Local package introspection for this evaluation found `ray` and `vllm` were not installed in the worker environment, so no live GPU benchmark was run.
+
+## Fit Analysis
+
+### Provider Abstraction
+
+DataDesigner generators obtain models through `ModelRegistry` and `ModelFacade`. That path owns request construction, retry behavior, adaptive throttling, health checks, parser correction, MCP/tool loops, and usage stats.
+
+Ray Data LLM is not only a request adapter. It is a Ray Dataset processor stage with preprocess/postprocess functions and its own batching and resource controls. Modeling that as `ModelProvider(provider_type="ray-vllm")` would either bypass `ModelFacade` semantics or force a provider adapter to orchestrate Ray Dataset transforms from inside per-cell model calls, which would violate the current layering and execution model.
+
+### Recommended Placement
+
+The idiomatic path is a RayBackend optimization:
+
+1. The interface still receives declarative model and column configs.
+2. The Ray backend planner identifies eligible stages.
+3. Eligible Ray Dataset blocks flow through a Ray Data LLM processor.
+4. Ineligible columns continue through the existing engine block executor and `ModelFacade`.
+
+This preserves the declarative config contract and avoids changing external provider behavior.
+
+### Batching and Concurrency
+
+DataDesigner currently controls model concurrency with `max_parallel_requests`, async task scheduling, worker batch size, and optional Ray-level provider throttling. Ray Data LLM controls throughput with processor `batch_size`, stage `concurrency`, vLLM engine kwargs, and GPU placement. A future implementation needs an explicit mapping rather than reusing provider fields implicitly.
+
+### LoRA
+
+Ray Data LLM exposes dynamic LoRA loading at the processor level. DataDesigner does not currently model per-row or per-column LoRA adapter selection in `ModelConfig`, so LoRA should remain a future opt-in Ray integration field rather than a hidden provider behavior.
+
+### Embeddings, Classification, and Multimodal
+
+Ray Data LLM supports generation, embedding, classification, and scoring task types. That is promising for chat/text and embedding columns, but multimodal support needs extra care because DataDesigner image context resolution, generated artifact paths, and response parsing currently live around the model facade.
+
+## Initial Eligibility
+
+A narrow future prototype should only consider columns that meet all of these conditions:
+
+- RayBackend is active and `probe_ray_data_llm_capabilities().supports_local_vllm` is true.
+- The model is local vLLM-capable and explicitly opted in through a Ray integration option.
+- The column is an LLM text or embedding stage with no MCP tool config.
+- The stage does not require parser correction loops, custom retry semantics, or per-cell provider extras that Ray Data LLM cannot preserve.
+- The surrounding column dependency graph allows a whole Ray Dataset stage boundary.
+
+All other model-generated columns should keep using the existing `ModelFacade`.
+
+## Non-Goals For This Slice
+
+- No new `ModelProvider.provider_type`.
+- No required `vllm` dependency.
+- No changes to existing external OpenAI-compatible provider behavior.
+- No planner rewrite or GPU benchmark in this PR.
+
+## Follow-Up Recommendation
+
+[Issue #118](https://github.com/eric-tramel/DataDesigner/issues/118) tracks a RayBackend-only proof of concept and benchmark. The POC should compare the existing RayBackend plus OpenAI-compatible vLLM server path against a Ray Data LLM processor stage for a single independent text column, then expand only if the result preserves usage stats, errors, ordering, dropped-row behavior, and observability.

--- a/docs/concepts/ray-backend.md
+++ b/docs/concepts/ray-backend.md
@@ -1,0 +1,37 @@
+# Ray Backend
+
+`RayBackend` runs Data Designer generation over Ray Data blocks and returns a Ray Dataset by default. To persist Data Designer artifacts through Ray Data instead of collecting records on the driver, construct the backend with `write_artifacts=True`.
+
+```python
+from data_designer import DataDesigner
+from data_designer.integrations.ray import RayBackend
+
+data_designer = DataDesigner(
+    artifact_path="artifacts",
+    backend=RayBackend(batch_size=1024, write_artifacts=True),
+)
+results = data_designer.create(config_builder, num_records=1_000_000, dataset_name="ray-run")
+```
+
+When artifact writing is enabled, Ray writes generated blocks through the Data Designer Ray datasink. The returned `results.load_dataset()` is a Ray Dataset read from the persisted final parquet folder.
+
+The artifact layout matches the local backend where practical:
+
+```text
+artifacts/
+  ray-run/
+    builder_config.json
+    metadata.json
+    parquet-files/
+      batch_00000.parquet
+      batch_00001.parquet
+    dropped-columns-parquet-files/
+      batch_00000.parquet
+    processors-files/
+      processor_name/
+        batch_00000.parquet
+```
+
+`metadata.json` records target and actual row counts, batch size, completed batch count, schema, and relative paths for final parquet files. When present, dropped-column and processor artifact paths are included under `dropped-columns-parquet-files` and `processor-files`.
+
+`distributed_artifact_writes=True` is the default. Use a cluster-visible artifact path when running Ray workers on multiple nodes, or set `distributed_artifact_writes=False` to force Ray Data write tasks onto the driver node.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Custom Columns: concepts/custom_columns.md
       - Validators: concepts/validators.md
       - Processors: concepts/processors.md
+      - Ray Backend: concepts/ray-backend.md
       - Person Sampling: concepts/person_sampling.md
       - Traces: concepts/traces.md
       - Tool Use & MCP:

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -18,6 +18,12 @@ from data_designer.integrations.ray.errors import (
     RayIntegrationError,
     RayMetricsError,
 )
+from data_designer.integrations.ray.llm import (
+    RayDataLLMCapabilities,
+    RayDataLLMIntegrationAssessment,
+    assess_ray_data_llm_integration,
+    probe_ray_data_llm_capabilities,
+)
 from data_designer.integrations.ray.metrics import (
     RayDatasetMetrics,
     RayWorkerMetrics,
@@ -44,6 +50,8 @@ __all__ = [
     "RayBlockPlanning",
     "RayDataCheckpointConfig",
     "RayDataContextOptions",
+    "RayDataLLMCapabilities",
+    "RayDataLLMIntegrationAssessment",
     "RayDatasetAnalysis",
     "RayDatasetCreationResults",
     "RayDatasetGenerationError",
@@ -57,4 +65,6 @@ __all__ = [
     "RayTraceEvent",
     "RayWorkerMetrics",
     "RayWorkerProfile",
+    "assess_ray_data_llm_integration",
+    "probe_ray_data_llm_capabilities",
 ]

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -10,6 +10,7 @@ debugging, but they are intentionally excluded from the package root surface.
 
 from __future__ import annotations
 
+from data_designer.integrations.ray.artifact_output import DataDesignerRayDatasink
 from data_designer.integrations.ray.backend import RayBackend, RayDatasetCreationResults
 from data_designer.integrations.ray.errors import (
     RayBackendConfigurationError,
@@ -34,6 +35,7 @@ from data_designer.integrations.ray.options import (
 )
 
 __all__ = [
+    "DataDesignerRayDatasink",
     "RayBackend",
     "RayBackendConfigurationError",
     "RayBlockPlanning",

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -23,6 +23,7 @@ from data_designer.integrations.ray.metrics import (
 )
 from data_designer.integrations.ray.observability import (
     RayDatasetAnalysis,
+    RayDatasetStats,
     RayThrottleSnapshot,
     RayTraceEvent,
     RayWorkerProfile,
@@ -46,6 +47,7 @@ __all__ = [
     "RayDatasetCreationResults",
     "RayDatasetGenerationError",
     "RayDatasetMetrics",
+    "RayDatasetStats",
     "RayExecutionOptions",
     "RayExecutionResources",
     "RayInputRepartition",

--- a/packages/data-designer/src/data_designer/integrations/ray/artifact_output.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/artifact_output.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import data_designer.lazy_heavy_imports as lazy
+from data_designer.engine.dataset_builders.block_execution import BlockExecutionResult
+from data_designer.engine.storage.artifact_storage import (
+    BATCH_FILE_NAME_FORMAT,
+    FINAL_DATASET_FOLDER_NAME,
+    METADATA_FILENAME,
+    PROCESSORS_OUTPUTS_FOLDER_NAME,
+    ArtifactStorage,
+)
+
+_ARTIFACT_COLUMN_PREFIX = "__data_designer_ray_artifact__"
+_DROPPED_ARTIFACT_KIND = "dropped"
+_PROCESSOR_ARTIFACT_KIND = "processor"
+_DROPPED_COLUMNS_FOLDER_NAME = "dropped-columns-parquet-files"
+
+
+class DataDesignerRayDatasink:
+    """Datasink-compatible writer for Data Designer Ray artifacts."""
+
+    def __init__(
+        self,
+        *,
+        base_dataset_path: Path,
+        dataset_name: str,
+        target_num_records: int,
+        buffer_size: int,
+        min_rows_per_write: int | None,
+        supports_distributed_writes: bool,
+    ) -> None:
+        self.base_dataset_path = Path(base_dataset_path)
+        self.dataset_name = dataset_name
+        self.target_num_records = target_num_records
+        self.buffer_size = buffer_size
+        self._min_rows_per_write = min_rows_per_write
+        self._supports_distributed_writes = supports_distributed_writes
+
+    def get_name(self) -> str:
+        return "DataDesignerRayDatasink"
+
+    @property
+    def min_rows_per_write(self) -> int | None:
+        return self._min_rows_per_write
+
+    @property
+    def supports_distributed_writes(self) -> bool:
+        return self._supports_distributed_writes
+
+    @property
+    def final_dataset_path(self) -> Path:
+        return self.base_dataset_path / FINAL_DATASET_FOLDER_NAME
+
+    @property
+    def dropped_columns_dataset_path(self) -> Path:
+        return self.base_dataset_path / _DROPPED_COLUMNS_FOLDER_NAME
+
+    @property
+    def processors_outputs_path(self) -> Path:
+        return self.base_dataset_path / PROCESSORS_OUTPUTS_FOLDER_NAME
+
+    @property
+    def metadata_file_path(self) -> Path:
+        return self.base_dataset_path / METADATA_FILENAME
+
+    def on_write_start(self, schema: Any | None = None) -> None:
+        del schema
+        ArtifactStorage.mkdir_if_needed(self.final_dataset_path)
+
+    def write(self, blocks: Iterable[Any], ctx: Any) -> dict[str, Any] | None:
+        dataframe = _blocks_to_pandas_dataframe(blocks)
+        if len(dataframe) == 0:
+            return None
+
+        batch_number = int(getattr(ctx, "task_idx", 0))
+        parquet_file_name = BATCH_FILE_NAME_FORMAT.format(batch_number=batch_number)
+        final_dataframe, dropped_dataframe, processor_dataframes = split_ray_artifact_columns(dataframe)
+        file_paths: dict[str, Any] = {FINAL_DATASET_FOLDER_NAME: []}
+
+        ArtifactStorage.mkdir_if_needed(self.final_dataset_path)
+        final_path = self.final_dataset_path / parquet_file_name
+        final_dataframe.to_parquet(final_path, index=False)
+        file_paths[FINAL_DATASET_FOLDER_NAME].append(str(final_path.relative_to(self.base_dataset_path)))
+
+        if len(dropped_dataframe.columns) > 0:
+            ArtifactStorage.mkdir_if_needed(self.dropped_columns_dataset_path)
+            dropped_path = self.dropped_columns_dataset_path / parquet_file_name
+            dropped_dataframe.to_parquet(dropped_path, index=False)
+            file_paths[_DROPPED_COLUMNS_FOLDER_NAME] = [str(dropped_path.relative_to(self.base_dataset_path))]
+
+        processor_file_paths: dict[str, list[str]] = {}
+        for processor_name, processor_dataframe in processor_dataframes.items():
+            processor_path = self.processors_outputs_path / processor_name / parquet_file_name
+            ArtifactStorage.mkdir_if_needed(processor_path.parent)
+            processor_dataframe.to_parquet(processor_path, index=False)
+            processor_file_paths[processor_name] = [str(processor_path.relative_to(self.base_dataset_path))]
+        if processor_file_paths:
+            file_paths["processor-files"] = processor_file_paths
+
+        return {
+            "num_rows": len(final_dataframe),
+            "schema": _dataframe_schema(final_dataframe),
+            "file_paths": file_paths,
+        }
+
+    def on_write_complete(self, write_result: Any) -> None:
+        write_returns = [item for item in _write_result_returns(write_result) if item is not None]
+        actual_num_records = sum(int(item["num_rows"]) for item in write_returns)
+        metadata: dict[str, Any] = {
+            "target_num_records": self.target_num_records,
+            "actual_num_records": actual_num_records,
+            "total_num_batches": len(write_returns),
+            "buffer_size": self.buffer_size,
+            "dataset_name": self.dataset_name,
+            "file_paths": _combine_file_paths(item["file_paths"] for item in write_returns),
+            "num_completed_batches": len(write_returns),
+        }
+        if write_returns:
+            metadata["schema"] = write_returns[0]["schema"]
+
+        ArtifactStorage.mkdir_if_needed(self.base_dataset_path)
+        with open(self.metadata_file_path, "w", encoding="utf-8") as file:
+            json.dump(metadata, file, indent=2, sort_keys=True)
+
+    def on_write_failed(self, exception: Exception) -> None:
+        del exception
+
+
+def append_ray_artifact_columns(dataframe: Any, block_result: BlockExecutionResult) -> Any:
+    """Append internal artifact columns that the Ray datasink can split back out."""
+    output = dataframe.copy()
+    dropped_dataframe = _dropped_columns_dataframe(
+        raw_dataframe=block_result.raw_dataframe,
+        final_dataframe=block_result.dataframe,
+    )
+    if len(dropped_dataframe.columns) > 0:
+        output = _append_prefixed_dataframe_columns(output, dropped_dataframe, (_DROPPED_ARTIFACT_KIND,))
+
+    for processor_name, processor_dataframe in block_result.processor_artifacts.items():
+        output = _append_prefixed_dataframe_columns(
+            output,
+            processor_dataframe.reset_index(drop=True),
+            (_PROCESSOR_ARTIFACT_KIND, processor_name),
+        )
+    return output
+
+
+def split_ray_artifact_columns(dataframe: Any) -> tuple[Any, Any, dict[str, Any]]:
+    final_columns = [column for column in dataframe.columns if not str(column).startswith(_ARTIFACT_COLUMN_PREFIX)]
+    dropped_columns: dict[str, Any] = {}
+    processor_columns: dict[str, dict[str, Any]] = {}
+
+    for column in dataframe.columns:
+        column_name = str(column)
+        if not column_name.startswith(_ARTIFACT_COLUMN_PREFIX):
+            continue
+        kind, parts = _parse_artifact_column_name(column_name)
+        if kind == _DROPPED_ARTIFACT_KIND:
+            dropped_columns[parts[0]] = dataframe[column]
+        elif kind == _PROCESSOR_ARTIFACT_KIND:
+            processor_name, processor_column = parts
+            processor_columns.setdefault(processor_name, {})[processor_column] = dataframe[column]
+
+    processor_dataframes = {
+        processor_name: lazy.pd.DataFrame(columns) for processor_name, columns in processor_columns.items()
+    }
+    return lazy.pd.DataFrame(dataframe[final_columns]), lazy.pd.DataFrame(dropped_columns), processor_dataframes
+
+
+def _dropped_columns_dataframe(*, raw_dataframe: Any, final_dataframe: Any) -> Any:
+    dropped_column_names = [column for column in raw_dataframe.columns if column not in final_dataframe.columns]
+    if not dropped_column_names:
+        return lazy.pd.DataFrame(index=range(len(final_dataframe)))
+    if len(raw_dataframe) == len(final_dataframe):
+        return raw_dataframe[dropped_column_names].reset_index(drop=True)
+    if final_dataframe.index.isin(raw_dataframe.index).all():
+        return raw_dataframe.loc[final_dataframe.index, dropped_column_names].reset_index(drop=True)
+    raise ValueError("Ray artifact dropped-column outputs must preserve row identity.")
+
+
+def _append_prefixed_dataframe_columns(dataframe: Any, artifact_dataframe: Any, path_parts: tuple[str, ...]) -> Any:
+    if len(dataframe) != len(artifact_dataframe):
+        raise ValueError("Ray artifact processor outputs must preserve row counts.")
+    for column_name in artifact_dataframe.columns:
+        dataframe[_artifact_column_name(*path_parts, str(column_name))] = artifact_dataframe[column_name].to_list()
+    return dataframe
+
+
+def _artifact_column_name(kind: str, *parts: str) -> str:
+    encoded_parts = "__".join(_encode_artifact_part(part) for part in parts)
+    return f"{_ARTIFACT_COLUMN_PREFIX}{kind}__{encoded_parts}"
+
+
+def _encode_artifact_part(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _decode_artifact_part(value: str) -> str:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(f"{value}{padding}".encode("ascii")).decode("utf-8")
+
+
+def _parse_artifact_column_name(column_name: str) -> tuple[str, tuple[str, ...]]:
+    suffix = column_name.removeprefix(_ARTIFACT_COLUMN_PREFIX)
+    kind, _, encoded_parts = suffix.partition("__")
+    return kind, tuple(_decode_artifact_part(part) for part in encoded_parts.split("__") if part)
+
+
+def _blocks_to_pandas_dataframe(blocks: Iterable[Any]) -> Any:
+    dataframes = [_coerce_block_to_pandas_dataframe(block) for block in blocks]
+    if not dataframes:
+        return lazy.pd.DataFrame()
+    if len(dataframes) == 1:
+        return dataframes[0]
+    return lazy.pd.concat(dataframes, ignore_index=True)
+
+
+def _coerce_block_to_pandas_dataframe(block: Any) -> Any:
+    if isinstance(block, lazy.pd.DataFrame):
+        return block
+    to_pandas = getattr(block, "to_pandas", None)
+    if callable(to_pandas):
+        return to_pandas()
+    return lazy.pd.DataFrame(block)
+
+
+def _dataframe_schema(dataframe: Any) -> dict[str, str]:
+    schema = lazy.pa.Table.from_pandas(dataframe, preserve_index=False).schema
+    return {field.name: str(field.type) for field in schema}
+
+
+def _write_result_returns(write_result: Any) -> list[Any]:
+    if isinstance(write_result, list):
+        return write_result
+    write_returns = getattr(write_result, "write_returns", None)
+    if write_returns is None:
+        return []
+    return list(write_returns)
+
+
+def _combine_file_paths(file_paths_items: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    combined: dict[str, Any] = {FINAL_DATASET_FOLDER_NAME: []}
+    processor_files: dict[str, list[str]] = {}
+    dropped_files: list[str] = []
+
+    for file_paths in file_paths_items:
+        combined[FINAL_DATASET_FOLDER_NAME].extend(file_paths.get(FINAL_DATASET_FOLDER_NAME, []))
+        dropped_files.extend(file_paths.get(_DROPPED_COLUMNS_FOLDER_NAME, []))
+        for processor_name, paths in file_paths.get("processor-files", {}).items():
+            processor_files.setdefault(processor_name, []).extend(paths)
+
+    combined[FINAL_DATASET_FOLDER_NAME] = sorted(combined[FINAL_DATASET_FOLDER_NAME])
+    if dropped_files:
+        combined[_DROPPED_COLUMNS_FOLDER_NAME] = sorted(dropped_files)
+    if processor_files:
+        combined["processor-files"] = {name: sorted(paths) for name, paths in sorted(processor_files.items())}
+    return combined

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -17,8 +17,9 @@ from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.engine.column_generators.utils.generator_classification import column_type_is_model_generated
 from data_designer.engine.dataset_builders.block_execution import execute_dataset_block
-from data_designer.engine.storage.artifact_storage import ArtifactStorage
+from data_designer.engine.storage.artifact_storage import SDG_CONFIG_FILENAME, ArtifactStorage
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
+from data_designer.integrations.ray.artifact_output import DataDesignerRayDatasink
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics
 from data_designer.integrations.ray.observability import RayDatasetAnalysis
@@ -132,10 +133,12 @@ class RayDatasetCreationResults:
         ray: Any | None = None,
         metrics_collector: Any | None = None,
         throttle_manager: Any | None = None,
+        artifact_storage: ArtifactStorage | None = None,
         output: Any | None = None,
         observability_options: _RayObservabilityOptions | None = None,
     ) -> None:
         del config_builder, observability_options
+        self.artifact_storage = artifact_storage
         self._artifacts = RayResultArtifacts(
             dataset=dataset,
             metrics=metrics,
@@ -222,14 +225,23 @@ class RayDatasetCreationResults:
         """
         return self._artifacts.output
 
+    def load_processor_dataset(self, processor_name: str) -> Any:
+        """Load a persisted processor output dataset as pandas."""
+        if self.artifact_storage is None:
+            raise RuntimeError("RayBackend was not configured to write artifacts.")
+        return self.artifact_storage.load_processor_dataset(processor_name)
+
 
 class RayBackend:
     """Ray Data execution backend for in-memory Data Designer jobs.
 
     The backend maps Data Designer generation over Ray Data blocks and returns
-    Ray-resident outputs. Ray is imported lazily so base Data Designer installs
-    do not require the optional dependency. input_dataset may be a Ray Dataset
-    or a sequence of ObjectRefs containing Arrow tables or pandas DataFrames.
+    Ray-resident outputs. When ``write_artifacts`` is enabled, the mapped Ray
+    Dataset is also written through a Ray Datasink-compatible artifact writer
+    using the standard Data Designer artifact layout. Ray is imported lazily so
+    base Data Designer installs do not require the optional dependency.
+    input_dataset may be a Ray Dataset or a sequence of ObjectRefs containing
+    Arrow tables or pandas DataFrames.
 
     Prefer ``block_planning=RayBlockPlanning(...)`` and
     ``execution_options=RayExecutionOptions(...)`` for Ray-specific controls.
@@ -267,6 +279,10 @@ class RayBackend:
         max_trace_events: int = 1000,
         max_worker_profiles: int = 1000,
         max_throttle_snapshots: int = 1000,
+        write_artifacts: bool = False,
+        artifact_write_concurrency: int | None = None,
+        artifact_write_ray_remote_args: dict[str, Any] | None = None,
+        distributed_artifact_writes: bool = True,
         **legacy_options: Any,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
@@ -307,6 +323,10 @@ class RayBackend:
         self.max_trace_events = max_trace_events
         self.max_worker_profiles = max_worker_profiles
         self.max_throttle_snapshots = max_throttle_snapshots
+        self.write_artifacts = write_artifacts
+        self.artifact_write_concurrency = artifact_write_concurrency
+        self.artifact_write_ray_remote_args = artifact_write_ray_remote_args
+        self.distributed_artifact_writes = distributed_artifact_writes
 
     def create(
         self,
@@ -317,7 +337,6 @@ class RayBackend:
         dataset_name: str,
         input_dataset: Any | None = None,
     ) -> RayDatasetCreationResults:
-        del dataset_name
         start_time = time.perf_counter()
         ray = _import_ray()
         if not ray.is_initialized():
@@ -334,7 +353,20 @@ class RayBackend:
             num_records=num_records,
             input_dataset=input_dataset,
         )
-        result_dataset, mapped, output = self._execute_plan(ray, plan)
+        result_dataset, mapped, output = self._execute_plan(ray, plan, materialize_output=not self.write_artifacts)
+        artifact_storage = None
+        if self.write_artifacts:
+            artifact_storage = self._write_artifacts(
+                ray=ray,
+                mapped=mapped,
+                runtime_context=runtime_context,
+                config_builder=config_builder,
+                num_records=num_records,
+                dataset_name=dataset_name,
+                batch_size=int(plan.map_batches_kwargs["batch_size"]),
+            )
+            result_dataset = ray.data.read_parquet(str(artifact_storage.final_dataset_path))
+            output = result_dataset.to_arrow_refs() if plan.output == "arrow_refs" else None
         metrics = _create_driver_metrics(
             plan,
             mapped=mapped,
@@ -348,11 +380,14 @@ class RayBackend:
             ray=ray,
             metrics_collector=plan.metrics_collector,
             throttle_manager=plan.throttle_manager,
+            artifact_storage=artifact_storage,
             output=output,
             observability_options=plan.observability_options,
         )
 
-    def _execute_plan(self, ray: Any, plan: RayJobPlan) -> tuple[Any, Any, Any | None]:
+    def _execute_plan(
+        self, ray: Any, plan: RayJobPlan, *, materialize_output: bool = True
+    ) -> tuple[Any, Any, Any | None]:
         try:
             mapped = plan.dataset_source.dataset.map_batches(_RayBatchWorker, **plan.map_batches_kwargs)
         except RayDatasetGenerationError:
@@ -369,6 +404,9 @@ class RayBackend:
         except Exception as exc:
             raise RayDatasetGenerationError("RayBackend failed while applying Ray output ordering.") from exc
 
+        if not materialize_output:
+            return mapped, mapped, None
+
         try:
             output = mapped.to_arrow_refs() if plan.output == "arrow_refs" else None
             result_dataset = _dataset_from_arrow_refs(ray, output) if output is not None else mapped
@@ -379,6 +417,43 @@ class RayBackend:
                 "RayBackend failed while materializing Ray output blocks for output='arrow_refs'."
             ) from exc
         return result_dataset, mapped, output
+
+    def _write_artifacts(
+        self,
+        *,
+        ray: Any,
+        mapped: Any,
+        runtime_context: BackendRuntimeContext,
+        config_builder: DataDesignerConfigBuilder,
+        num_records: int,
+        dataset_name: str,
+        batch_size: int,
+    ) -> ArtifactStorage:
+        del ray
+        ArtifactStorage.mkdir_if_needed(runtime_context.artifact_path)
+        artifact_storage = ArtifactStorage(artifact_path=runtime_context.artifact_path, dataset_name=dataset_name)
+        ArtifactStorage.mkdir_if_needed(artifact_storage.base_dataset_path)
+        config_builder.get_builder_config().to_json(artifact_storage.base_dataset_path / SDG_CONFIG_FILENAME)
+
+        datasink = DataDesignerRayDatasink(
+            base_dataset_path=artifact_storage.base_dataset_path,
+            dataset_name=artifact_storage.resolved_dataset_name,
+            target_num_records=num_records,
+            buffer_size=batch_size,
+            min_rows_per_write=batch_size,
+            supports_distributed_writes=self.distributed_artifact_writes,
+        )
+        try:
+            mapped.write_datasink(
+                datasink,
+                ray_remote_args=self.artifact_write_ray_remote_args,
+                concurrency=self.artifact_write_concurrency,
+            )
+        except RayDatasetGenerationError:
+            raise
+        except Exception as exc:
+            raise RayDatasetGenerationError("RayBackend failed while writing Data Designer artifacts.") from exc
+        return artifact_storage
 
     def _resolve_input_dataset(
         self,
@@ -461,7 +536,7 @@ class RayDriverPlanner:
 
         validate_no_ray_after_generation_processors(config_builder)
         if not self._backend.allow_unsafe_processors:
-            validate_ray_safe_processors(config_builder)
+            validate_ray_safe_processors(config_builder, allow_dataset_artifacts=self._backend.write_artifacts)
 
         model_aliases = _model_health_check_aliases(config_builder)
         if self._backend.preflight_model_health_check:
@@ -532,6 +607,7 @@ class RayDriverPlanner:
             use_input_dataset=use_input_dataset,
             seed_window=seed_window,
             hidden_order_column=ordering_mode.hidden_order_column,
+            capture_artifacts=self._backend.write_artifacts,
         )
 
         map_batches_kwargs: dict[str, Any] = {
@@ -811,6 +887,7 @@ def _generate_batch(
     use_input_dataset: bool | None = None,
     seed_window: ray_seed_planning.RaySeedWindow | None = None,
     hidden_order_column: str | None = None,
+    capture_artifacts: bool = False,
     metrics_collector: Any | None = None,
     observability_options: _RayObservabilityOptions | None = None,
 ) -> Any:
@@ -824,6 +901,7 @@ def _generate_batch(
         use_input_dataset=use_input_dataset,
         seed_window=seed_window,
         hidden_order_column=hidden_order_column,
+        capture_artifacts=capture_artifacts,
     )
     return _RayBatchWorker(
         execution_payload=execution_payload,

--- a/packages/data-designer/src/data_designer/integrations/ray/llm.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/llm.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from typing import Literal
+
+RayDataLLMPlacement = Literal["ray-backend-stage-optimization"]
+
+_REQUIRED_RAY_DATA_LLM_SYMBOLS = ("build_processor", "vLLMEngineProcessorConfig")
+_SUPPORTED_TASK_TYPES = ("generate", "embed", "classify", "score")
+_RECOMMENDED_PLACEMENT: RayDataLLMPlacement = "ray-backend-stage-optimization"
+_RECOMMENDATION = (
+    "Keep Ray Data LLM/vLLM behind the Ray integration as an optional stage optimization. "
+    "Do not model it as a general ModelProvider until DataDesigner can preserve ModelFacade semantics "
+    "for retries, MCP/tool loops, correction loops, usage accounting, and provider throttling."
+)
+_BLOCKING_GAPS = (
+    "Ray Data LLM is a Ray Dataset processor stage, while DataDesigner generators call the ModelFacade "
+    "per generated cell inside the engine execution plan.",
+    "A direct provider adapter would bypass existing ModelFacade contracts for retries, usage stats, "
+    "MCP/tool calls, parser correction, and health checks.",
+    "Stage-level execution needs planner support to select only eligible LLM columns and to preserve column "
+    "dependencies, validation, dropped-row handling, and artifact semantics.",
+)
+_SAFE_FIRST_SLICE = (
+    "Detect Ray Data LLM availability and keep external providers on the existing OpenAI-compatible facade. "
+    "A future prototype can add a RayBackend-only stage for eligible chat or embedding columns."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RayDataLLMCapabilities:
+    """Runtime availability of Ray Data LLM APIs needed for local vLLM execution."""
+
+    available: bool
+    ray_version: str | None
+    missing_symbols: tuple[str, ...]
+    has_build_processor: bool
+    has_vllm_engine_processor: bool
+    has_http_request_processor: bool
+    has_serve_deployment_processor: bool
+    supported_task_types: tuple[str, ...] = _SUPPORTED_TASK_TYPES
+    import_error: str | None = None
+
+    @property
+    def supports_local_vllm(self) -> bool:
+        """Return whether Ray Data LLM has the local vLLM processor API."""
+        return self.available and self.has_build_processor and self.has_vllm_engine_processor
+
+    @property
+    def supports_openai_compatible_endpoint(self) -> bool:
+        """Return whether Ray Data LLM exposes an HTTP processor API."""
+        return self.available and self.has_http_request_processor
+
+
+@dataclass(frozen=True, slots=True)
+class RayDataLLMIntegrationAssessment:
+    """Recommendation for how Ray Data LLM should fit into DataDesigner."""
+
+    capabilities: RayDataLLMCapabilities
+    recommended_placement: RayDataLLMPlacement
+    recommendation: str
+    broad_integration_ready: bool
+    safe_first_slice: str
+    blocking_gaps: tuple[str, ...]
+
+
+def probe_ray_data_llm_capabilities() -> RayDataLLMCapabilities:
+    """Probe optional Ray Data LLM symbols without importing Ray at module import time."""
+    ray_version = _package_version("ray")
+    try:
+        ray_data_llm = importlib.import_module("ray.data.llm")
+    except Exception as exc:
+        return RayDataLLMCapabilities(
+            available=False,
+            ray_version=ray_version,
+            missing_symbols=_REQUIRED_RAY_DATA_LLM_SYMBOLS,
+            has_build_processor=False,
+            has_vllm_engine_processor=False,
+            has_http_request_processor=False,
+            has_serve_deployment_processor=False,
+            import_error=f"{type(exc).__name__}: {exc}",
+        )
+
+    missing_symbols = tuple(symbol for symbol in _REQUIRED_RAY_DATA_LLM_SYMBOLS if not hasattr(ray_data_llm, symbol))
+    has_build_processor = hasattr(ray_data_llm, "build_processor")
+    has_vllm_engine_processor = hasattr(ray_data_llm, "vLLMEngineProcessorConfig")
+    return RayDataLLMCapabilities(
+        available=not missing_symbols,
+        ray_version=ray_version,
+        missing_symbols=missing_symbols,
+        has_build_processor=has_build_processor,
+        has_vllm_engine_processor=has_vllm_engine_processor,
+        has_http_request_processor=hasattr(ray_data_llm, "HttpRequestProcessorConfig"),
+        has_serve_deployment_processor=hasattr(ray_data_llm, "ServeDeploymentProcessorConfig"),
+    )
+
+
+def assess_ray_data_llm_integration(
+    capabilities: RayDataLLMCapabilities | None = None,
+) -> RayDataLLMIntegrationAssessment:
+    """Return the current integration recommendation for Ray Data LLM/vLLM."""
+    resolved_capabilities = capabilities or probe_ray_data_llm_capabilities()
+    return RayDataLLMIntegrationAssessment(
+        capabilities=resolved_capabilities,
+        recommended_placement=_RECOMMENDED_PLACEMENT,
+        recommendation=_RECOMMENDATION,
+        broad_integration_ready=False,
+        safe_first_slice=_SAFE_FIRST_SLICE,
+        blocking_gaps=_BLOCKING_GAPS,
+    )
+
+
+def _package_version(package_name: str) -> str | None:
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return None

--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -12,12 +12,14 @@ from typing import Any, TypeAlias
 
 from data_designer.integrations.ray._telemetry_normalization import (
     ModelUsageSummary,
+    coerce_bool_field,
     coerce_float_field,
     coerce_int_field,
     coerce_model_usage,
     coerce_optional_int_field,
     coerce_optional_string_field,
     coerce_string_field,
+    validate_bool_field,
     validate_failed_blocks_not_greater_than_blocks,
     validate_non_empty_string_field,
     validate_non_negative_float_field,
@@ -28,12 +30,17 @@ from data_designer.integrations.ray.errors import RayMetricsError
 RayTraceEventPayload: TypeAlias = "RayTraceEvent | Mapping[str, Any]"
 RayWorkerProfilePayload: TypeAlias = "RayWorkerProfile | Mapping[str, Any]"
 RayThrottleSnapshotPayload: TypeAlias = "RayThrottleSnapshot | Mapping[str, Any]"
+RayDatasetStatsPayload: TypeAlias = "RayDatasetStats | Mapping[str, Any]"
 _OBSERVABILITY_FIELD_LABEL = "Ray observability field"
 _OBSERVABILITY_TELEMETRY_LABEL = "Ray observability"
 _MODEL_USAGE_FIELD_LABEL = "Ray observability model_usage"
 _RAY_REPORT_SECTION_ALIASES = {
+    "dataset_stats": "ray_dataset_stats",
+    "diagnostics": "ray_dataset_stats",
     "overview": "summary",
+    "ray_dataset_stats": "ray_dataset_stats",
     "summary": "summary",
+    "stats": "ray_dataset_stats",
     "worker_profiles": "worker_profiles",
     "profiles": "worker_profiles",
     "trace_events": "trace_events",
@@ -168,6 +175,75 @@ class RayThrottleSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class RayDatasetStats:
+    """Bounded Ray Dataset stats text and extracted operator diagnostics."""
+
+    stats_text: str | None = None
+    stats_text_truncated: bool = False
+    stats_text_char_count: int = 0
+    operator_diagnostics: list[str] = field(default_factory=list)
+    operator_diagnostics_dropped: int = 0
+    backpressure_diagnostics: list[str] = field(default_factory=list)
+    backpressure_diagnostics_dropped: int = 0
+    object_store_diagnostics: list[str] = field(default_factory=list)
+    object_store_diagnostics_dropped: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        coerce_optional_string_field(
+            self.stats_text,
+            "stats_text",
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_bool_field(
+            "stats_text_truncated",
+            self.stats_text_truncated,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "stats_text_char_count",
+            self.stats_text_char_count,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "operator_diagnostics_dropped",
+            self.operator_diagnostics_dropped,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "backpressure_diagnostics_dropped",
+            self.backpressure_diagnostics_dropped,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        validate_non_negative_int_field(
+            "object_store_diagnostics_dropped",
+            self.object_store_diagnostics_dropped,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        )
+        for field_name, values in (
+            ("operator_diagnostics", self.operator_diagnostics),
+            ("backpressure_diagnostics", self.backpressure_diagnostics),
+            ("object_store_diagnostics", self.object_store_diagnostics),
+            ("warnings", self.warnings),
+        ):
+            for value in values:
+                validate_non_empty_string_field(
+                    f"{field_name} item",
+                    value,
+                    field_label=_OBSERVABILITY_FIELD_LABEL,
+                )
+
+    @property
+    def has_stats_text(self) -> bool:
+        """Return whether Ray returned non-empty Dataset.stats() text."""
+        return bool(self.stats_text)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
 class RayDatasetAnalysis:
     """Ray-native analysis artifact composed from bounded worker summaries."""
 
@@ -180,6 +256,8 @@ class RayDatasetAnalysis:
     trace_events_dropped: int = 0
     throttle_snapshots: list[RayThrottleSnapshot] = field(default_factory=list)
     throttle_snapshots_dropped: int = 0
+    ray_dataset_stats: RayDatasetStats | None = None
+    diagnostic_warnings: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         validate_non_negative_int_field("total_rows", self.total_rows, field_label=_OBSERVABILITY_FIELD_LABEL)
@@ -205,6 +283,14 @@ class RayDatasetAnalysis:
             self.throttle_snapshots_dropped,
             field_label=_OBSERVABILITY_FIELD_LABEL,
         )
+        if self.ray_dataset_stats is not None and not isinstance(self.ray_dataset_stats, RayDatasetStats):
+            raise RayMetricsError("RayDatasetAnalysis ray_dataset_stats must be RayDatasetStats when provided.")
+        for warning in self.diagnostic_warnings:
+            validate_non_empty_string_field(
+                "diagnostic_warnings item",
+                warning,
+                field_label=_OBSERVABILITY_FIELD_LABEL,
+            )
 
     @property
     def successful_blocks(self) -> int:
@@ -226,7 +312,7 @@ class RayDatasetAnalysis:
         Ray-native reports are bounded worker summaries, not the standard local
         dataset profiler report. include_sections filters top-level Ray report
         sections and accepts ``summary``/``overview``, ``worker_profiles``,
-        ``trace_events``, and ``throttle_snapshots``.
+        ``trace_events``, ``throttle_snapshots``, and ``ray_dataset_stats``.
         """
         sections = _normalize_include_sections(include_sections)
         if save_path is None:
@@ -263,7 +349,59 @@ class RayDatasetAnalysis:
         if "throttle_snapshots" in sections:
             payload["throttle_snapshots"] = [snapshot.to_dict() for snapshot in self.throttle_snapshots]
             payload["throttle_snapshots_dropped"] = self.throttle_snapshots_dropped
+        if "ray_dataset_stats" in sections:
+            payload["ray_dataset_stats"] = None if self.ray_dataset_stats is None else self.ray_dataset_stats.to_dict()
+            payload["diagnostic_warnings"] = list(self.diagnostic_warnings)
         return payload
+
+
+def normalize_ray_dataset_stats(payload: RayDatasetStatsPayload) -> RayDatasetStats:
+    """Normalize a Ray Dataset stats dataclass or mapping payload."""
+    if isinstance(payload, RayDatasetStats):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise RayMetricsError(f"Ray Dataset stats payload must be a mapping, got {type(payload)!r}.")
+    return RayDatasetStats(
+        stats_text=coerce_optional_string_field(
+            payload.get("stats_text"),
+            "stats_text",
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        stats_text_truncated=coerce_bool_field(
+            payload,
+            "stats_text_truncated",
+            default=False,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        stats_text_char_count=coerce_int_field(
+            payload,
+            "stats_text_char_count",
+            default=0,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        operator_diagnostics=_coerce_str_list(payload.get("operator_diagnostics")),
+        operator_diagnostics_dropped=coerce_int_field(
+            payload,
+            "operator_diagnostics_dropped",
+            default=0,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        backpressure_diagnostics=_coerce_str_list(payload.get("backpressure_diagnostics")),
+        backpressure_diagnostics_dropped=coerce_int_field(
+            payload,
+            "backpressure_diagnostics_dropped",
+            default=0,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        object_store_diagnostics=_coerce_str_list(payload.get("object_store_diagnostics")),
+        object_store_diagnostics_dropped=coerce_int_field(
+            payload,
+            "object_store_diagnostics_dropped",
+            default=0,
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        warnings=_coerce_str_list(payload.get("warnings")),
+    )
 
 
 def normalize_ray_trace_event(payload: RayTraceEventPayload) -> RayTraceEvent:

--- a/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
@@ -4,22 +4,72 @@
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import socket
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics
 from data_designer.integrations.ray.observability import (
     RayDatasetAnalysis,
+    RayDatasetStats,
     RayThrottleSnapshot,
     RayTraceEvent,
     RayWorkerProfile,
+    normalize_ray_dataset_stats,
     normalize_ray_throttle_snapshot,
     normalize_ray_trace_event,
     normalize_ray_worker_profile,
+)
+
+_MAX_RAY_DATASET_STATS_CHARS = 65_536
+_MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINES = 100
+_MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINE_CHARS = 500
+_MAX_RAY_DIAGNOSTIC_WARNINGS = 20
+_RAY_OPERATOR_DIAGNOSTIC_MARKERS = (
+    "operator",
+    "map",
+    "read",
+    "write",
+    "repartition",
+    "sort",
+    "filter",
+    "limit",
+    "union",
+    "zip",
+    "join",
+    "block",
+    "rows",
+    "task",
+    "wall time",
+    "cpu time",
+    "udf",
+)
+_RAY_BACKPRESSURE_DIAGNOSTIC_MARKERS = (
+    "backpressure",
+    "backpressured",
+    "queue",
+    "queued",
+    "pending",
+    "blocked",
+    "wait",
+    "stall",
+    "throttle",
+)
+_RAY_OBJECT_STORE_DIAGNOSTIC_MARKERS = (
+    "object store",
+    "object_store",
+    "objectref",
+    "plasma",
+    "spill",
+    "spilled",
+    "memory",
+    "bytes",
+    "mib",
+    "gib",
 )
 
 
@@ -108,24 +158,51 @@ def _create_metrics_collector(
 def assemble_ray_dataset_analysis(
     metrics: RayDatasetMetrics,
     payload: Mapping[str, Any],
+    *,
+    ray_dataset_stats: RayDatasetStats | Mapping[str, Any] | None = None,
+    diagnostic_warnings: list[str] | None = None,
 ) -> RayDatasetAnalysis | None:
-    if not _has_observability_payload(payload):
+    warnings = _bounded_warnings(diagnostic_warnings or [])
+    _extend_payload_warnings(payload.get("diagnostic_warnings"), warnings)
+    dataset_stats = _normalize_dataset_stats(
+        ray_dataset_stats if ray_dataset_stats is not None else payload.get("ray_dataset_stats"),
+        warnings,
+    )
+    if not _has_observability_payload(payload) and dataset_stats is None and not warnings:
         return None
-    worker_profiles = [normalize_ray_worker_profile(profile) for profile in payload.get("worker_profiles", []) or []]
-    trace_events = [normalize_ray_trace_event(event) for event in payload.get("trace_events", []) or []]
-    throttle_snapshots = [
-        normalize_ray_throttle_snapshot(snapshot) for snapshot in payload.get("throttle_snapshots", []) or []
-    ]
+    worker_profiles, invalid_worker_profiles = _normalize_observability_items(
+        payload.get("worker_profiles"),
+        normalize_ray_worker_profile,
+        "worker profile",
+        warnings,
+    )
+    trace_events, invalid_trace_events = _normalize_observability_items(
+        payload.get("trace_events"),
+        normalize_ray_trace_event,
+        "trace event",
+        warnings,
+    )
+    throttle_snapshots, invalid_throttle_snapshots = _normalize_observability_items(
+        payload.get("throttle_snapshots"),
+        normalize_ray_throttle_snapshot,
+        "throttle snapshot",
+        warnings,
+    )
     return RayDatasetAnalysis(
         total_rows=metrics.total_rows,
         blocks=metrics.blocks,
         failed_blocks=metrics.failed_blocks,
         worker_profiles=worker_profiles,
-        worker_profiles_dropped=int(payload.get("worker_profiles_dropped", 0) or 0),
+        worker_profiles_dropped=_safe_non_negative_payload_int(payload, "worker_profiles_dropped", warnings)
+        + invalid_worker_profiles,
         trace_events=trace_events,
-        trace_events_dropped=int(payload.get("trace_events_dropped", 0) or 0),
+        trace_events_dropped=_safe_non_negative_payload_int(payload, "trace_events_dropped", warnings)
+        + invalid_trace_events,
         throttle_snapshots=throttle_snapshots,
-        throttle_snapshots_dropped=int(payload.get("throttle_snapshots_dropped", 0) or 0),
+        throttle_snapshots_dropped=_safe_non_negative_payload_int(payload, "throttle_snapshots_dropped", warnings)
+        + invalid_throttle_snapshots,
+        ray_dataset_stats=dataset_stats,
+        diagnostic_warnings=warnings,
     )
 
 
@@ -137,7 +214,194 @@ def _has_observability_payload(payload: Mapping[str, Any]) -> bool:
         or payload.get("trace_events_dropped")
         or payload.get("throttle_snapshots")
         or payload.get("throttle_snapshots_dropped")
+        or payload.get("ray_dataset_stats")
+        or payload.get("diagnostic_warnings")
     )
+
+
+def collect_ray_dataset_stats(dataset: Any | None) -> RayDatasetStats | None:
+    """Collect bounded Ray Dataset.stats() output without materializing rows on the driver."""
+    if dataset is None:
+        return None
+    stats = getattr(dataset, "stats", None)
+    if not callable(stats):
+        return None
+
+    try:
+        raw_stats = stats()
+    except Exception as exc:
+        return RayDatasetStats(warnings=[_format_collection_warning("Ray Dataset.stats() failed", exc)])
+
+    stats_text, warnings = _coerce_ray_dataset_stats_text(raw_stats)
+    if stats_text is None:
+        return RayDatasetStats(warnings=warnings) if warnings else None
+
+    bounded_stats_text = stats_text[:_MAX_RAY_DATASET_STATS_CHARS]
+    stats_text_truncated = len(stats_text) > _MAX_RAY_DATASET_STATS_CHARS
+    operator_diagnostics, operator_diagnostics_dropped = _extract_ray_dataset_stats_diagnostics(
+        stats_text,
+        _RAY_OPERATOR_DIAGNOSTIC_MARKERS,
+    )
+    backpressure_diagnostics, backpressure_diagnostics_dropped = _extract_ray_dataset_stats_diagnostics(
+        stats_text,
+        _RAY_BACKPRESSURE_DIAGNOSTIC_MARKERS,
+    )
+    object_store_diagnostics, object_store_diagnostics_dropped = _extract_ray_dataset_stats_diagnostics(
+        stats_text,
+        _RAY_OBJECT_STORE_DIAGNOSTIC_MARKERS,
+    )
+    return RayDatasetStats(
+        stats_text=bounded_stats_text,
+        stats_text_truncated=stats_text_truncated,
+        stats_text_char_count=len(stats_text),
+        operator_diagnostics=operator_diagnostics,
+        operator_diagnostics_dropped=operator_diagnostics_dropped,
+        backpressure_diagnostics=backpressure_diagnostics,
+        backpressure_diagnostics_dropped=backpressure_diagnostics_dropped,
+        object_store_diagnostics=object_store_diagnostics,
+        object_store_diagnostics_dropped=object_store_diagnostics_dropped,
+        warnings=warnings,
+    )
+
+
+def _normalize_dataset_stats(
+    payload: Any,
+    warnings: list[str],
+) -> RayDatasetStats | None:
+    if payload is None:
+        return None
+    try:
+        return normalize_ray_dataset_stats(payload)
+    except Exception as exc:
+        _append_warning(warnings, _format_collection_warning("Ray Dataset stats payload normalization failed", exc))
+        return None
+
+
+def _normalize_observability_items(
+    raw_items: Any,
+    normalizer: Callable[[Any], Any],
+    item_label: str,
+    warnings: list[str],
+) -> tuple[list[Any], int]:
+    if raw_items is None:
+        return [], 0
+    if not isinstance(raw_items, list):
+        _append_warning(warnings, f"Ray observability {item_label} payload must be a list when provided.")
+        return [], 1
+
+    items: list[Any] = []
+    invalid_items = 0
+    for index, raw_item in enumerate(raw_items):
+        try:
+            items.append(normalizer(raw_item))
+        except Exception as exc:
+            invalid_items += 1
+            _append_warning(
+                warnings,
+                _format_collection_warning(f"Skipped Ray observability {item_label} at index {index}", exc),
+            )
+    return items, invalid_items
+
+
+def _safe_non_negative_payload_int(payload: Mapping[str, Any], field_name: str, warnings: list[str]) -> int:
+    value = payload.get(field_name, 0) or 0
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        _append_warning(warnings, f"Ray observability field {field_name!r} must be a non-negative integer.")
+        return 0
+    return value
+
+
+def _extend_payload_warnings(raw_warnings: Any, warnings: list[str]) -> None:
+    if raw_warnings is None:
+        return
+    if not isinstance(raw_warnings, list):
+        _append_warning(warnings, "Ray observability diagnostic_warnings payload must be a list when provided.")
+        return
+    for warning in raw_warnings:
+        if isinstance(warning, str) and warning:
+            _append_warning(warnings, warning)
+        else:
+            _append_warning(warnings, "Ray observability diagnostic_warnings entries must be non-empty strings.")
+
+
+def _coerce_ray_dataset_stats_text(raw_stats: Any) -> tuple[str | None, list[str]]:
+    warnings: list[str] = []
+    if raw_stats is None:
+        return None, ["Ray Dataset.stats() returned None."]
+    if isinstance(raw_stats, str):
+        return raw_stats, warnings
+    if isinstance(raw_stats, bytes):
+        return raw_stats.decode("utf-8", errors="replace"), [
+            "Ray Dataset.stats() returned bytes; decoded it as UTF-8 with replacement."
+        ]
+    if isinstance(raw_stats, Mapping) or isinstance(raw_stats, (list, tuple)):
+        return json.dumps(raw_stats, sort_keys=True, default=str), [
+            f"Ray Dataset.stats() returned {type(raw_stats).__name__}; serialized it as JSON text."
+        ]
+
+    for method_name in ("to_string", "to_summary"):
+        method = getattr(raw_stats, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            converted = method()
+        except Exception as exc:
+            _append_warning(
+                warnings,
+                _format_collection_warning(f"Ray Dataset.stats() {method_name} conversion failed", exc),
+            )
+            continue
+        if converted is raw_stats:
+            continue
+        converted_text, converted_warnings = _coerce_ray_dataset_stats_text(converted)
+        return converted_text, _bounded_warnings([*warnings, *converted_warnings])
+
+    _append_warning(
+        warnings,
+        f"Ray Dataset.stats() returned {type(raw_stats).__name__}; converted it with str().",
+    )
+    return str(raw_stats), warnings
+
+
+def _extract_ray_dataset_stats_diagnostics(
+    stats_text: str,
+    markers: tuple[str, ...],
+) -> tuple[list[str], int]:
+    diagnostics: list[str] = []
+    dropped = 0
+    for raw_line in stats_text.splitlines():
+        line = " ".join(raw_line.strip().split())
+        if line == "":
+            continue
+        normalized_line = line.lower()
+        if not any(marker in normalized_line for marker in markers):
+            continue
+        bounded_line = _bound_diagnostic_line(line)
+        if len(diagnostics) >= _MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINES:
+            dropped += 1
+            continue
+        diagnostics.append(bounded_line)
+    return diagnostics, dropped
+
+
+def _bound_diagnostic_line(line: str) -> str:
+    if len(line) <= _MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINE_CHARS:
+        return line
+    return f"{line[:_MAX_RAY_DATASET_STATS_DIAGNOSTIC_LINE_CHARS]}... [truncated]"
+
+
+def _append_warning(warnings: list[str], warning: str) -> None:
+    if len(warnings) >= _MAX_RAY_DIAGNOSTIC_WARNINGS:
+        return
+    warnings.append(warning)
+
+
+def _bounded_warnings(warnings: list[str]) -> list[str]:
+    return [warning for warning in warnings if warning][:_MAX_RAY_DIAGNOSTIC_WARNINGS]
+
+
+def _format_collection_warning(message: str, exc: Exception) -> str:
+    return f"{message}: {type(exc).__name__}: {exc}"
 
 
 def _record_worker_observability(

--- a/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/processor_policy.py
@@ -10,7 +10,7 @@ from data_designer.engine.processing.processors.base import Processor
 from data_designer.engine.registry.data_designer_registry import DataDesignerRegistry
 from data_designer.integrations.ray.errors import RayBackendConfigurationError
 
-_RAY_SUPPORTED_SIDE_EFFECTS = frozenset(
+_RAY_ALWAYS_SUPPORTED_SIDE_EFFECTS = frozenset(
     {
         ProcessorSideEffect.NONE.value,
         ProcessorSideEffect.BATCH_ARTIFACT.value,
@@ -18,13 +18,19 @@ _RAY_SUPPORTED_SIDE_EFFECTS = frozenset(
 )
 
 
-def validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> None:
+def validate_ray_safe_processors(
+    config_builder: DataDesignerConfigBuilder,
+    *,
+    allow_dataset_artifacts: bool = False,
+) -> None:
     """Validate configured processor capabilities against Ray execution constraints."""
     unsupported: list[str] = []
     for processor in config_builder.get_processor_configs():
         safety = _get_distributed_safety(processor)
-        if safety is None or not _is_supported_by_ray(safety):
-            unsupported.append(_format_processor_violation(processor, safety))
+        if safety is None or not _is_supported_by_ray(safety, allow_dataset_artifacts=allow_dataset_artifacts):
+            unsupported.append(
+                _format_processor_violation(processor, safety, allow_dataset_artifacts=allow_dataset_artifacts)
+            )
 
     if not unsupported:
         return
@@ -33,8 +39,8 @@ def validate_ray_safe_processors(config_builder: DataDesignerConfigBuilder) -> N
         "RayBackend supports only processors whose distributed_safety metadata is compatible "
         "with partitioned execution. "
         f"Unsupported processor(s): {'; '.join(unsupported)}. "
-        "Review the processor's partition safety and side-effect metadata, or pass "
-        "allow_unsafe_processors=True to bypass this experimental guard."
+        "Enable write_artifacts=True for dataset artifact processors, review the processor's partition safety "
+        "and side-effect metadata, or pass allow_unsafe_processors=True to bypass this experimental guard."
     )
 
 
@@ -75,15 +81,30 @@ def _get_distributed_safety(processor: ProcessorConfig) -> ProcessorDistributedS
     return None
 
 
-def _is_supported_by_ray(safety: ProcessorDistributedSafety) -> bool:
+def _is_supported_by_ray(
+    safety: ProcessorDistributedSafety,
+    *,
+    allow_dataset_artifacts: bool,
+) -> bool:
     return (
         safety.partition_safe
         and not safety.requires_global_order
-        and safety.side_effects in _RAY_SUPPORTED_SIDE_EFFECTS
+        and _side_effect_is_supported(safety.side_effects, allow_dataset_artifacts=allow_dataset_artifacts)
     )
 
 
-def _format_processor_violation(processor: ProcessorConfig, safety: ProcessorDistributedSafety | None) -> str:
+def _side_effect_is_supported(side_effect: ProcessorSideEffect, *, allow_dataset_artifacts: bool) -> bool:
+    if side_effect in _RAY_ALWAYS_SUPPORTED_SIDE_EFFECTS:
+        return True
+    return allow_dataset_artifacts and side_effect == ProcessorSideEffect.DATASET_ARTIFACT.value
+
+
+def _format_processor_violation(
+    processor: ProcessorConfig,
+    safety: ProcessorDistributedSafety | None,
+    *,
+    allow_dataset_artifacts: bool,
+) -> str:
     label = _format_processor_label(processor)
     if safety is None:
         return f"{label}: missing distributed_safety metadata"
@@ -93,7 +114,7 @@ def _format_processor_violation(processor: ProcessorConfig, safety: ProcessorDis
         reasons.append("partition_safe=False")
     if safety.requires_global_order:
         reasons.append("requires_global_order=True")
-    if safety.side_effects in _RAY_SUPPORTED_SIDE_EFFECTS:
+    if _side_effect_is_supported(safety.side_effects, allow_dataset_artifacts=allow_dataset_artifacts):
         reasons.append(f"side_effects={safety.side_effects}")
     else:
         reasons.append(f"side_effects={safety.side_effects} unsupported by RayBackend")

--- a/packages/data-designer/src/data_designer/integrations/ray/results.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/results.py
@@ -17,6 +17,7 @@ from data_designer.integrations.ray.observability import RayDatasetAnalysis
 from data_designer.integrations.ray.observability_collection import (
     _has_observability_payload,
     assemble_ray_dataset_analysis,
+    collect_ray_dataset_stats,
 )
 
 
@@ -46,6 +47,7 @@ class RayResultArtifacts:
             ray=ray,
             metrics_collector=metrics_collector,
             metrics_loader=self._metrics_loader,
+            dataset_getter=lambda: self._dataset,
         )
 
     @property
@@ -171,6 +173,11 @@ class RayMetricsLoader:
             return None
         return snapshot()
 
+    @property
+    def driver_metrics(self) -> RayDatasetMetrics:
+        """Return driver-only metrics captured before optional worker aggregation."""
+        return self._driver_metrics
+
 
 class RayAnalysisLoader:
     """Load and normalize Ray observability artifacts without the public result wrapper."""
@@ -181,27 +188,57 @@ class RayAnalysisLoader:
         ray: Any | None = None,
         metrics_collector: Any | None = None,
         metrics_loader: RayMetricsLoader,
+        dataset_getter: Callable[[], Any] | None = None,
     ) -> None:
         self._ray = ray
         self._metrics_collector = metrics_collector
         self._metrics_loader = metrics_loader
+        self._dataset_getter = dataset_getter
         self._analysis_cache: RayDatasetAnalysis | None = None
 
     def load_observability(self) -> RayDatasetAnalysis | None:
         """Return bounded Ray-native profiles, traces, and worker-local throttle snapshots."""
         if self._analysis_cache is not None:
             return self._analysis_cache
-        if self._ray is None or self._metrics_collector is None:
-            return None
-        try:
-            payload = self._load_observability_payload()
-        except Exception as exc:
-            raise RayDatasetGenerationError("RayBackend failed to load Ray observability artifacts.") from exc
-        if not _has_observability_payload(payload):
+        diagnostic_warnings: list[str] = []
+        payload = self._load_observability_payload_or_warning(diagnostic_warnings)
+        metrics = self._load_metrics_for_analysis(diagnostic_warnings)
+        ray_dataset_stats = self._load_ray_dataset_stats(diagnostic_warnings)
+        if not _has_observability_payload(payload) and ray_dataset_stats is None and not diagnostic_warnings:
             return None
 
-        self._analysis_cache = assemble_ray_dataset_analysis(self._metrics_loader.load_metrics(), payload)
+        self._analysis_cache = assemble_ray_dataset_analysis(
+            metrics,
+            payload,
+            ray_dataset_stats=ray_dataset_stats,
+            diagnostic_warnings=diagnostic_warnings,
+        )
         return self._analysis_cache
+
+    def _load_observability_payload_or_warning(self, diagnostic_warnings: list[str]) -> dict[str, Any]:
+        if self._ray is None or self._metrics_collector is None:
+            return {}
+        try:
+            return self._load_observability_payload()
+        except Exception as exc:
+            diagnostic_warnings.append(_diagnostic_collection_warning("load Ray observability artifacts", exc))
+            return {}
+
+    def _load_metrics_for_analysis(self, diagnostic_warnings: list[str]) -> RayDatasetMetrics:
+        try:
+            return self._metrics_loader.load_metrics()
+        except Exception as exc:
+            diagnostic_warnings.append(_diagnostic_collection_warning("load Ray metrics for analysis", exc))
+            return self._metrics_loader.driver_metrics
+
+    def _load_ray_dataset_stats(self, diagnostic_warnings: list[str]) -> Any | None:
+        if self._dataset_getter is None:
+            return None
+        try:
+            return collect_ray_dataset_stats(self._dataset_getter())
+        except Exception as exc:
+            diagnostic_warnings.append(_diagnostic_collection_warning("collect Ray Dataset stats", exc))
+            return None
 
     def _load_observability_payload(self) -> dict[str, Any]:
         observability_snapshot = getattr(self._metrics_collector, "observability_snapshot", None)
@@ -212,6 +249,10 @@ class RayAnalysisLoader:
             self._metrics_loader.load_worker_metrics()
             payload = self._ray.get(observability_snapshot.remote())
         return dict(payload)
+
+
+def _diagnostic_collection_warning(action: str, exc: Exception) -> str:
+    return f"RayBackend failed to {action}: {type(exc).__name__}: {exc}"
 
 
 def _merge_driver_and_worker_metrics(

--- a/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
@@ -27,6 +27,7 @@ from data_designer.engine.resources.person_reader import PersonReader
 from data_designer.engine.resources.seed_reader import SeedReader
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
+from data_designer.integrations.ray.artifact_output import append_ray_artifact_columns
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayWorkerMetrics
 from data_designer.integrations.ray.observability import RayTraceEvent
@@ -71,6 +72,7 @@ class _RayExecutionPayload:
     seed_window: ray_seed_planning.RaySeedWindow | None = None
     seed_config: SeedConfig | None = None
     hidden_order_column: str | None = None
+    capture_artifacts: bool = False
 
 
 @dataclass(frozen=True)
@@ -214,6 +216,8 @@ class _RayWorkerGenerationPipeline:
             generation_result,
             throttle_manager=self._worker_options.throttle_manager,
         )
+        if self._execution_payload.capture_artifacts:
+            return append_ray_artifact_columns(generation_result.dataframe, generation_result.block_result)
         return generation_result.dataframe
 
     def create_block_config(self, dataframe: Any) -> DataDesignerConfig:
@@ -472,6 +476,7 @@ def _compile_ray_execution_payload(
     use_input_dataset: bool,
     seed_window: ray_seed_planning.RaySeedWindow | None = None,
     hidden_order_column: str | None = None,
+    capture_artifacts: bool = False,
 ) -> _RayExecutionPayload:
     data_designer_config = config_builder.build()
     payload_seed_config = data_designer_config.seed_config if seed_window is not None else None
@@ -487,6 +492,7 @@ def _compile_ray_execution_payload(
         seed_window=seed_window,
         seed_config=payload_seed_config,
         hidden_order_column=hidden_order_column,
+        capture_artifacts=capture_artifacts,
     )
     _validate_worker_payload_serializable(payload)
     return payload

--- a/packages/data-designer/src/data_designer/interface/backends.py
+++ b/packages/data-designer/src/data_designer/interface/backends.py
@@ -50,6 +50,9 @@ class BackendRuntimeContext(Protocol):
     def managed_assets_path(self) -> Path: ...
 
     @property
+    def artifact_path(self) -> Path: ...
+
+    @property
     def person_reader(self) -> PersonReader | None: ...
 
     @property
@@ -94,6 +97,7 @@ class DataDesignerRuntimeContext:
     secret_resolver: SecretResolver
     seed_readers: tuple[SeedReader, ...]
     managed_assets_path: Path
+    artifact_path: Path
     person_reader: PersonReader | None
     mcp_providers: tuple[MCPProviderT, ...]
     run_config: RunConfig

--- a/packages/data-designer/src/data_designer/interface/data_designer.py
+++ b/packages/data-designer/src/data_designer/interface/data_designer.py
@@ -512,6 +512,7 @@ class DataDesigner(DataDesignerInterface[DatasetCreationResults]):
             secret_resolver=self._secret_resolver,
             seed_readers=tuple(self._seed_reader_registry._readers.values()),
             managed_assets_path=self._managed_assets_path,
+            artifact_path=self._artifact_path,
             person_reader=self._person_reader,
             mcp_providers=tuple(self._mcp_providers),
             run_config=self._run_config,

--- a/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
@@ -44,6 +44,7 @@ class FakeRayDataset:
         self.map_batches_fn: Any | None = None
         self.map_batches_calls: list[FakeMapBatchesCall] = []
         self.repartition_calls: list[dict[str, Any]] = []
+        self.write_datasink_kwargs: dict[str, Any] | None = None
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         if self.data_module is not None:
@@ -61,6 +62,24 @@ class FakeRayDataset:
         )
         mapped.repartition_calls = list(self.repartition_calls)
         return mapped
+
+    def write_datasink(
+        self,
+        datasink: Any,
+        *,
+        ray_remote_args: dict[str, Any] | None = None,
+        concurrency: int | None = None,
+    ) -> None:
+        self.write_datasink_kwargs = {"ray_remote_args": ray_remote_args, "concurrency": concurrency}
+        if self.data_module is not None:
+            self.data_module.write_datasink_kwargs = dict(self.write_datasink_kwargs)
+        datasink.on_write_start(schema=None)
+        write_returns = []
+        for task_idx, block in enumerate(self.blocks):
+            write_return = datasink.write([coerce_pandas_dataframe(block)], types.SimpleNamespace(task_idx=task_idx))
+            if write_return is not None:
+                write_returns.append(write_return)
+        datasink.on_write_complete(types.SimpleNamespace(write_returns=write_returns))
 
     def repartition(
         self,
@@ -213,6 +232,7 @@ class FakeRayDataModule:
         self.read_json_kwargs: dict[str, Any] | None = None
         self.read_parquet_input: Any | None = None
         self.read_parquet_kwargs: dict[str, Any] | None = None
+        self.write_datasink_kwargs: dict[str, Any] | None = None
         self.range_blocks = range_blocks
         self.reverse_mapped_blocks = reverse_mapped_blocks
         self.range_kwargs: dict[str, Any] | None = None

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -13,13 +13,14 @@ from fake_ray_harness import FakeRayDataset, install_fake_ray
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.processors import SchemaTransformProcessorConfig
+from data_designer.config.processors import DropColumnsProcessorConfig, SchemaTransformProcessorConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import IndexRange, SamplingStrategy
 from data_designer.config.seed_source import DirectorySeedSource, FileContentsSeedSource, LocalFileSeedSource
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.engine.storage.artifact_storage import SDG_CONFIG_FILENAME, BatchStage
 from data_designer.engine.testing.seed_readers import LineFanoutDirectorySeedReader
 from data_designer.integrations.ray import (
     RayBackend,
@@ -98,6 +99,106 @@ def test_ray_backend_uses_input_dataset_as_in_memory_seed(
         {"x": 1, "label": "a", "x_label": "1-a"},
         {"x": 2, "label": "b", "x_label": "2-b"},
     ]
+
+
+def test_ray_backend_writes_data_designer_artifacts_with_fake_ray(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    input_dataset = fake_ray.data.dataset([lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=2,
+            write_artifacts=True,
+            artifact_write_concurrency=3,
+            artifact_write_ray_remote_args={"num_cpus": 0.25},
+        ),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset, num_records=2, dataset_name="ray-output")
+    artifact_storage = results.artifact_storage
+
+    assert artifact_storage is not None
+    assert (artifact_storage.base_dataset_path / SDG_CONFIG_FILENAME).is_file()
+    assert artifact_storage.metadata_file_path.is_file()
+    assert fake_ray.data.write_datasink_kwargs == {"ray_remote_args": {"num_cpus": 0.25}, "concurrency": 3}
+    assert fake_ray.data.read_parquet_input == str(artifact_storage.final_dataset_path)
+    assert results.load_dataset().to_pandas().to_dict(orient="records") == [
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+    ]
+    assert artifact_storage.load_dataset().to_dict(orient="records") == [
+        {"x": 1, "label": "a", "x_label": "1-a"},
+        {"x": 2, "label": "b", "x_label": "2-b"},
+    ]
+
+    metadata = artifact_storage.read_metadata()
+    assert metadata["dataset_name"] == "ray-output"
+    assert metadata["target_num_records"] == 2
+    assert metadata["actual_num_records"] == 2
+    assert metadata["num_completed_batches"] == 1
+    assert metadata["file_paths"]["parquet-files"] == ["parquet-files/batch_00000.parquet"]
+    assert metadata["schema"] == {"label": "string", "x": "int64", "x_label": "string"}
+
+
+def test_ray_backend_writes_dropped_columns_and_processor_artifacts_with_fake_ray(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    input_dataset = fake_ray.data.dataset([lazy.pd.DataFrame({"x": [1, 2], "label": ["a", "b"]})])
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="kept_label", expr="{{ label }}"))
+    config_builder.add_processor(
+        SchemaTransformProcessorConfig(
+            name="schema-transform",
+            template={"combined": "{{ x_label }}"},
+        )
+    )
+    config_builder.add_processor(DropColumnsProcessorConfig(name="drop-x-label", column_names=["x_label"]))
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=2, write_artifacts=True),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset, num_records=2, dataset_name="ray-output")
+    artifact_storage = results.artifact_storage
+
+    assert artifact_storage is not None
+    assert results.load_dataset().to_pandas().to_dict(orient="records") == [
+        {"x": 1, "label": "a", "kept_label": "a"},
+        {"x": 2, "label": "b", "kept_label": "b"},
+    ]
+    assert artifact_storage.load_dataset(batch_stage=BatchStage.DROPPED_COLUMNS).to_dict(orient="records") == [
+        {"x_label": "1-a"},
+        {"x_label": "2-b"},
+    ]
+    assert results.load_processor_dataset("schema-transform").to_dict(orient="records") == [
+        {"combined": "1-a"},
+        {"combined": "2-b"},
+    ]
+
+    metadata = artifact_storage.read_metadata()
+    assert metadata["file_paths"]["dropped-columns-parquet-files"] == [
+        "dropped-columns-parquet-files/batch_00000.parquet"
+    ]
+    assert metadata["file_paths"]["processor-files"] == {
+        "schema-transform": ["processors-files/schema-transform/batch_00000.parquet"]
+    }
 
 
 def test_ray_backend_uses_override_num_blocks_for_from_scratch_dataset(

--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 import data_designer.lazy_heavy_imports as lazy
+from data_designer.integrations.ray import RayDatasetAnalysis, RayDatasetStats, RayTraceEvent
 
 pytestmark = pytest.mark.ray_benchmark
 
@@ -123,6 +124,49 @@ def test_result_payload_reports_validity_and_provider_counters(tmp_path: Path) -
     assert payload["throughput"]["tokens_per_second"] == 20
     assert payload["throughput"]["retry_count"] == 4
     assert payload["throughput"]["throttle_count"] == 1
+
+
+def test_ray_diagnostics_payload_summarizes_dataset_stats_without_raw_text() -> None:
+    benchmark_common = _load_common_module()
+
+    analysis = RayDatasetAnalysis(
+        total_rows=2,
+        blocks=1,
+        trace_events=[RayTraceEvent(block_id="block-a", event_type="block_completed", timestamp_seconds=1.0)],
+        trace_events_dropped=2,
+        ray_dataset_stats=RayDatasetStats(
+            stats_text="Operator 1 MapBatches: detailed stats text",
+            stats_text_char_count=43,
+            operator_diagnostics=["Operator 1 MapBatches: detailed stats text"],
+            backpressure_diagnostics=["Backpressure: queued task wait time 0.1s"],
+            object_store_diagnostics=["Object store memory: 1 MiB used"],
+        ),
+        diagnostic_warnings=["some Ray stats were unavailable"],
+    )
+
+    payload = benchmark_common.ray_diagnostics_payload(analysis)
+
+    assert payload == {
+        "diagnostic_warnings": ["some Ray stats were unavailable"],
+        "ray_dataset_stats": {
+            "backpressure_diagnostics": ["Backpressure: queued task wait time 0.1s"],
+            "backpressure_diagnostics_dropped": 0,
+            "object_store_diagnostics": ["Object store memory: 1 MiB used"],
+            "object_store_diagnostics_dropped": 0,
+            "operator_diagnostics": ["Operator 1 MapBatches: detailed stats text"],
+            "operator_diagnostics_dropped": 0,
+            "stats_text_available": True,
+            "stats_text_char_count": 43,
+            "stats_text_truncated": False,
+            "warnings": [],
+        },
+        "throttle_snapshots": 0,
+        "throttle_snapshots_dropped": 0,
+        "trace_events": 1,
+        "trace_events_dropped": 2,
+        "worker_profiles": 0,
+        "worker_profiles_dropped": 0,
+    }
 
 
 def test_failure_payload_preserves_result_shape() -> None:

--- a/packages/data-designer/tests/integrations/ray/test_llm.py
+++ b/packages/data-designer/tests/integrations/ray/test_llm.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from data_designer.integrations.ray import llm as ray_llm
+
+pytestmark = pytest.mark.ray_fake
+
+
+def test_probe_ray_data_llm_capabilities_reports_missing_optional_surface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_import_module(name: str) -> Any:
+        assert name == "ray.data.llm"
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(ray_llm.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(ray_llm, "_package_version", lambda package_name: None)
+
+    capabilities = ray_llm.probe_ray_data_llm_capabilities()
+
+    assert capabilities.available is False
+    assert capabilities.ray_version is None
+    assert capabilities.missing_symbols == ("build_processor", "vLLMEngineProcessorConfig")
+    assert capabilities.supports_local_vllm is False
+    assert capabilities.import_error is not None
+
+
+def test_probe_ray_data_llm_capabilities_detects_vllm_processor_symbols(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_module = SimpleNamespace(
+        build_processor=object(),
+        vLLMEngineProcessorConfig=object(),
+        HttpRequestProcessorConfig=object(),
+        ServeDeploymentProcessorConfig=object(),
+    )
+
+    def fake_import_module(name: str) -> Any:
+        assert name == "ray.data.llm"
+        return fake_module
+
+    monkeypatch.setattr(ray_llm.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(ray_llm, "_package_version", lambda package_name: "2.54.0")
+
+    capabilities = ray_llm.probe_ray_data_llm_capabilities()
+
+    assert capabilities.available is True
+    assert capabilities.ray_version == "2.54.0"
+    assert capabilities.missing_symbols == ()
+    assert capabilities.supports_local_vllm is True
+    assert capabilities.supports_openai_compatible_endpoint is True
+    assert capabilities.supported_task_types == ("generate", "embed", "classify", "score")
+
+
+def test_assess_ray_data_llm_integration_keeps_vllm_out_of_provider_abstraction() -> None:
+    capabilities = ray_llm.RayDataLLMCapabilities(
+        available=True,
+        ray_version="2.54.0",
+        missing_symbols=(),
+        has_build_processor=True,
+        has_vllm_engine_processor=True,
+        has_http_request_processor=False,
+        has_serve_deployment_processor=False,
+    )
+
+    assessment = ray_llm.assess_ray_data_llm_integration(capabilities)
+
+    assert assessment.capabilities is capabilities
+    assert assessment.recommended_placement == "ray-backend-stage-optimization"
+    assert assessment.broad_integration_ready is False
+    assert "Do not model it as a general ModelProvider" in assessment.recommendation
+    assert any("ModelFacade contracts" in gap for gap in assessment.blocking_gaps)

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -16,6 +16,7 @@ from data_designer.integrations.ray import (
     RayDatasetAnalysis,
     RayDatasetCreationResults,
     RayDatasetMetrics,
+    RayDatasetStats,
     RayMetricsError,
     RayThrottleSnapshot,
     RayTraceEvent,
@@ -101,6 +102,116 @@ def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
     assert report["worker_profiles"][0]["block_id"] == "block-a"
     assert report["worker_profiles_dropped"] == 0
     assert report["throttle_snapshots_dropped"] == 0
+
+
+def test_ray_results_load_analysis_collects_dataset_stats_without_metrics_actor(
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    class StatsDataset:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def stats(self) -> str:
+            self.calls += 1
+            return "\n".join(
+                [
+                    "Operator 1 MapBatches(_RayBatchWorker): 2 tasks executed, 2 blocks produced",
+                    "Backpressure: queued task wait time 0.25s",
+                    "Object store memory: 10 MiB used, 0 bytes spilled",
+                ]
+            )
+
+    dataset = StatsDataset()
+    results = RayDatasetCreationResults(
+        dataset=dataset,
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(total_rows=4, blocks=2),
+    )
+
+    analysis = results.load_analysis()
+
+    assert analysis is not None
+    assert analysis.total_rows == 4
+    assert analysis.blocks == 2
+    assert analysis.ray_dataset_stats is not None
+    assert analysis.ray_dataset_stats.stats_text_char_count > 0
+    assert (
+        "Operator 1 MapBatches(_RayBatchWorker): 2 tasks executed, 2 blocks produced"
+        in analysis.ray_dataset_stats.operator_diagnostics
+    )
+    assert analysis.ray_dataset_stats.backpressure_diagnostics == ["Backpressure: queued task wait time 0.25s"]
+    assert analysis.ray_dataset_stats.object_store_diagnostics == ["Object store memory: 10 MiB used, 0 bytes spilled"]
+    assert results.load_analysis() is analysis
+    assert dataset.calls == 1
+
+
+def test_ray_results_load_analysis_preserves_dataset_stats_failure_as_warning(
+    stub_sampler_only_config_builder: DataDesignerConfigBuilder,
+) -> None:
+    class FailingStatsDataset:
+        def stats(self) -> str:
+            raise RuntimeError("stats unavailable")
+
+    results = RayDatasetCreationResults(
+        dataset=FailingStatsDataset(),
+        config_builder=stub_sampler_only_config_builder,
+        metrics=RayDatasetMetrics(total_rows=1, blocks=1),
+    )
+
+    analysis = results.load_analysis()
+
+    assert analysis is not None
+    assert analysis.ray_dataset_stats is not None
+    assert analysis.ray_dataset_stats.stats_text is None
+    assert analysis.ray_dataset_stats.warnings == ["Ray Dataset.stats() failed: RuntimeError: stats unavailable"]
+
+
+def test_collect_ray_dataset_stats_bounds_raw_text_and_diagnostics() -> None:
+    class LongStatsDataset:
+        def stats(self) -> str:
+            long_operator_line = f"Operator {'x' * 600}"
+            return "\n".join([long_operator_line for _ in range(105)] + ["tail" * 1000])
+
+    dataset_stats = ray_observability_collection.collect_ray_dataset_stats(LongStatsDataset())
+
+    assert dataset_stats is not None
+    assert dataset_stats.stats_text_truncated is True
+    assert dataset_stats.stats_text is not None
+    assert len(dataset_stats.stats_text) == 65_536
+    assert len(dataset_stats.operator_diagnostics) == 100
+    assert dataset_stats.operator_diagnostics_dropped == 5
+    assert dataset_stats.operator_diagnostics[0].endswith("... [truncated]")
+
+
+def test_assemble_ray_dataset_analysis_skips_malformed_diagnostics() -> None:
+    analysis = ray_observability_collection.assemble_ray_dataset_analysis(
+        RayDatasetMetrics(total_rows=1, blocks=1),
+        {
+            "worker_profiles": [{"block_id": "block-a", "total_rows": 1}, {"total_rows": 1}],
+            "trace_events": "not-a-list",
+            "throttle_snapshots": [
+                {
+                    "provider_name": "provider",
+                    "model_id": "model",
+                    "domain": "chat",
+                    "current_limit": 1,
+                },
+                {"provider_name": 7},
+            ],
+            "trace_events_dropped": "bad-count",
+        },
+    )
+
+    assert analysis is not None
+    assert [profile.block_id for profile in analysis.worker_profiles] == ["block-a"]
+    assert analysis.worker_profiles_dropped == 1
+    assert analysis.trace_events == []
+    assert analysis.trace_events_dropped == 1
+    assert [snapshot.domain for snapshot in analysis.throttle_snapshots] == ["chat"]
+    assert analysis.throttle_snapshots_dropped == 1
+    assert any("Skipped Ray observability worker profile" in warning for warning in analysis.diagnostic_warnings)
+    assert any("trace event payload must be a list" in warning for warning in analysis.diagnostic_warnings)
+    assert any("trace_events_dropped" in warning for warning in analysis.diagnostic_warnings)
 
 
 def test_ray_metrics_collector_bounds_profiles_and_throttle_snapshots() -> None:
@@ -292,6 +403,39 @@ def test_ray_dataset_analysis_to_report_filters_html_sections(tmp_path: Path) ->
     assert "&quot;worker_profiles&quot;" in report
     assert "&quot;summary&quot;" not in report
     assert "&quot;trace_events&quot;" not in report
+
+
+def test_ray_dataset_analysis_to_report_filters_dataset_stats_section(tmp_path: Path) -> None:
+    analysis = RayDatasetAnalysis(
+        total_rows=1,
+        blocks=1,
+        ray_dataset_stats=RayDatasetStats(
+            stats_text="Operator 1 MapBatches: 1 blocks",
+            stats_text_char_count=31,
+            operator_diagnostics=["Operator 1 MapBatches: 1 blocks"],
+        ),
+        diagnostic_warnings=["stats partially unavailable"],
+    )
+    report_path = tmp_path / "ray-analysis.json"
+
+    analysis.to_report(report_path, include_sections=["ray_dataset_stats"])
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report == {
+        "diagnostic_warnings": ["stats partially unavailable"],
+        "ray_dataset_stats": {
+            "backpressure_diagnostics": [],
+            "backpressure_diagnostics_dropped": 0,
+            "object_store_diagnostics": [],
+            "object_store_diagnostics_dropped": 0,
+            "operator_diagnostics": ["Operator 1 MapBatches: 1 blocks"],
+            "operator_diagnostics_dropped": 0,
+            "stats_text": "Operator 1 MapBatches: 1 blocks",
+            "stats_text_char_count": 31,
+            "stats_text_truncated": False,
+            "warnings": [],
+        },
+    }
 
 
 def test_ray_dataset_analysis_to_report_rejects_unknown_include_section(tmp_path: Path) -> None:

--- a/packages/data-designer/tests/integrations/ray/test_processor_policy.py
+++ b/packages/data-designer/tests/integrations/ray/test_processor_policy.py
@@ -238,6 +238,20 @@ def test_ray_processor_policy_accepts_legacy_ray_safe_metadata(stub_model_config
     validate_ray_safe_processors(config_builder)
 
 
+def test_ray_processor_policy_allows_dataset_artifact_processors_when_artifact_writes_enabled(
+    stub_model_configs: Any,
+) -> None:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_processor(
+        SchemaTransformProcessorConfig(
+            name="schema-transform",
+            template={"combined": "{{ x_label }}"},
+        )
+    )
+
+    validate_ray_safe_processors(config_builder, allow_dataset_artifacts=True)
+
+
 def test_ray_processor_policy_rejects_after_generation_processor_implementation(stub_model_configs: Any) -> None:
     config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
     config_builder.add_processor(AfterGenerationProcessorConfig(name="global-processor"))

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -12,6 +12,7 @@ pytestmark = pytest.mark.ray_fake
 
 def test_ray_package_root_exports_stable_public_api() -> None:
     expected_public_api = {
+        "DataDesignerRayDatasink",
         "RayBackend",
         "RayBackendConfigurationError",
         "RayBlockPlanning",

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -18,6 +18,8 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayBlockPlanning",
         "RayDataCheckpointConfig",
         "RayDataContextOptions",
+        "RayDataLLMCapabilities",
+        "RayDataLLMIntegrationAssessment",
         "RayDatasetAnalysis",
         "RayDatasetCreationResults",
         "RayDatasetGenerationError",
@@ -31,6 +33,8 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayTraceEvent",
         "RayWorkerMetrics",
         "RayWorkerProfile",
+        "assess_ray_data_llm_integration",
+        "probe_ray_data_llm_capabilities",
     }
 
     assert set(ray.__all__) == expected_public_api

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -21,6 +21,7 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayDatasetCreationResults",
         "RayDatasetGenerationError",
         "RayDatasetMetrics",
+        "RayDatasetStats",
         "RayExecutionOptions",
         "RayExecutionResources",
         "RayInputRepartition",

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -155,6 +155,8 @@ def test_real_ray_streaming_out_of_core_parquet_smoke(
     assert analysis.total_rows == num_records
     assert analysis.worker_profiles
     assert analysis.trace_events
+    assert analysis.ray_dataset_stats is not None
+    assert analysis.ray_dataset_stats.stats_text is not None or analysis.ray_dataset_stats.warnings
     assert sample["ticket_key"].notna().all()
     assert sample["routing_key"].str.contains("::").all()
     assert list(parquet_dir.glob("*.parquet"))

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -160,6 +160,38 @@ def test_real_ray_streaming_out_of_core_parquet_smoke(
     assert list(parquet_dir.glob("*.parquet"))
 
 
+def test_real_ray_data_designer_artifact_write_smoke(
+    local_ray: Any,
+    real_ray_smoke_paths: Any,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    input_dataset = local_ray.data.from_pandas(
+        [
+            lazy.pd.DataFrame({"x": [1], "label": ["a"]}),
+            lazy.pd.DataFrame({"x": [2], "label": ["b"]}),
+        ]
+    )
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="x_label", expr="{{ x }}-{{ label }}"))
+    designer = DataDesigner(
+        artifact_path=real_ray_smoke_paths.artifact_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=real_ray_smoke_paths.managed_assets_path,
+        backend=RayBackend(batch_size=1, write_artifacts=True),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset, num_records=2, dataset_name="ray-artifacts")
+    artifact_storage = results.artifact_storage
+
+    assert artifact_storage is not None
+    assert artifact_storage.metadata_file_path.is_file()
+    assert artifact_storage.read_metadata()["actual_num_records"] == 2
+    assert results.load_dataset().count() == 2
+    assert sorted(artifact_storage.final_dataset_path.glob("*.parquet"))
+
+
 def test_real_ray_input_dataset_repartition_smoke(
     local_ray: Any,
     real_ray_smoke_paths: Any,

--- a/scripts/benchmarks/ray_benchmark_common.py
+++ b/scripts/benchmarks/ray_benchmark_common.py
@@ -173,6 +173,7 @@ def run_ray_backend_benchmark(
         results = designer.create(config_builder, num_records=num_records)
         output = results.load_dataset().to_pandas()
         metrics = results.load_metrics().to_dict()
+        ray_diagnostics = load_ray_diagnostics_payload(results)
         elapsed_seconds = time.perf_counter() - start
         payload = result_payload(
             backend=backend,
@@ -191,6 +192,7 @@ def run_ray_backend_benchmark(
         )
         if ray_output == "arrow_refs":
             payload["arrow_ref_count"] = len(results.output)
+        payload["ray_diagnostics"] = ray_diagnostics
         return payload
 
 
@@ -289,6 +291,47 @@ def result_payload(
         "output_mode": output_mode,
         "batch_size": batch_size,
         "max_parallel_requests": max_parallel_requests,
+    }
+
+
+def load_ray_diagnostics_payload(results: Any) -> dict[str, Any] | None:
+    try:
+        analysis = results.load_analysis()
+    except Exception as exc:
+        return {
+            "ray_dataset_stats": None,
+            "diagnostic_warnings": [f"Ray analysis collection failed: {type(exc).__name__}: {exc}"],
+        }
+    return ray_diagnostics_payload(analysis)
+
+
+def ray_diagnostics_payload(analysis: Any | None) -> dict[str, Any] | None:
+    if analysis is None:
+        return None
+    dataset_stats = getattr(analysis, "ray_dataset_stats", None)
+    stats_payload = None
+    if dataset_stats is not None:
+        stats_payload = {
+            "stats_text_available": bool(getattr(dataset_stats, "has_stats_text", False)),
+            "stats_text_truncated": bool(getattr(dataset_stats, "stats_text_truncated", False)),
+            "stats_text_char_count": int(getattr(dataset_stats, "stats_text_char_count", 0) or 0),
+            "operator_diagnostics": list(getattr(dataset_stats, "operator_diagnostics", []) or []),
+            "operator_diagnostics_dropped": int(getattr(dataset_stats, "operator_diagnostics_dropped", 0) or 0),
+            "backpressure_diagnostics": list(getattr(dataset_stats, "backpressure_diagnostics", []) or []),
+            "backpressure_diagnostics_dropped": int(getattr(dataset_stats, "backpressure_diagnostics_dropped", 0) or 0),
+            "object_store_diagnostics": list(getattr(dataset_stats, "object_store_diagnostics", []) or []),
+            "object_store_diagnostics_dropped": int(getattr(dataset_stats, "object_store_diagnostics_dropped", 0) or 0),
+            "warnings": list(getattr(dataset_stats, "warnings", []) or []),
+        }
+    return {
+        "worker_profiles": len(getattr(analysis, "worker_profiles", []) or []),
+        "worker_profiles_dropped": int(getattr(analysis, "worker_profiles_dropped", 0) or 0),
+        "trace_events": len(getattr(analysis, "trace_events", []) or []),
+        "trace_events_dropped": int(getattr(analysis, "trace_events_dropped", 0) or 0),
+        "throttle_snapshots": len(getattr(analysis, "throttle_snapshots", []) or []),
+        "throttle_snapshots_dropped": int(getattr(analysis, "throttle_snapshots_dropped", 0) or 0),
+        "ray_dataset_stats": stats_payload,
+        "diagnostic_warnings": list(getattr(analysis, "diagnostic_warnings", []) or []),
     }
 
 


### PR DESCRIPTION
## 📋 Summary
Adds an opt-in Ray artifact write path so `RayBackend(write_artifacts=True)` can persist final DataDesigner outputs, metadata, dropped columns, and processor artifacts through Ray Data without collecting generated rows on the driver.

## 🔗 Related Issue
Closes #44

## 🔄 Changes
- Add `DataDesignerRayDatasink` and Ray worker artifact-column plumbing for final parquet, dropped-column parquet, processor outputs, metadata, and builder config artifacts.
- Thread the interface-owned artifact path through `BackendRuntimeContext` so the Ray backend preserves DataDesigner layering while writing artifacts.
- Allow dataset-artifact processors under Ray only when artifact writes are enabled, and expose the datasink from the Ray integration public API.
- Document the Ray artifact layout and add fake-Ray tests plus opt-in real-Ray smoke coverage under the existing fixtures.

## 🧪 Testing
- [x] `uv run --package data-designer pytest packages/data-designer/tests/integrations/ray` — 208 passed, 7 skipped, 1 warning
- [x] `uv run --package data-designer --extra ray pytest packages/data-designer/tests/integrations/ray/test_real_smoke.py::test_real_ray_data_designer_artifact_write_smoke` — 1 skipped by opt-in real-Ray fixture
- [x] `uv run --package data-designer ruff check <touched files>`
- [x] `uv run --package data-designer ruff format --check <touched files>`
- [ ] `make test` passes — not run; focused Ray integration suite used for this scoped backend change

## ✅ Checklist
- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)