### PR TITLE
fix(ray): expose referenced range ids to workers

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -667,6 +667,10 @@ class RayDriverPlanner:
             worker_options=worker_options,
             use_input_dataset=use_input_dataset,
             seed_window=seed_window,
+            range_input_columns=_range_input_columns_for_config(
+                config_builder,
+                dataset_source_kind=dataset_source_kind,
+            ),
             hidden_order_column=ordering_mode.hidden_order_column,
             preserve_output_row_count=row_count_preserving,
             output_chunk_rows=self._backend.output_chunk_rows,
@@ -727,6 +731,32 @@ def _initial_dataset_source_kind(input_dataset: Any | None) -> RayDatasetSourceK
     if hasattr(input_dataset, "map_batches"):
         return "input_dataset"
     return "object_refs"
+
+
+def _range_input_columns_for_config(
+    config_builder: DataDesignerConfigBuilder,
+    *,
+    dataset_source_kind: RayDatasetSourceKind,
+) -> list[str] | None:
+    if dataset_source_kind != "range":
+        return None
+    if not _config_references_missing_ray_range_id(config_builder):
+        return None
+    return [ray_seed_planning.RAY_RANGE_ID_COLUMN]
+
+
+def _config_references_missing_ray_range_id(config_builder: DataDesignerConfigBuilder) -> bool:
+    range_id_column = ray_seed_planning.RAY_RANGE_ID_COLUMN
+    column_configs = config_builder.get_column_configs()
+    referenceable_columns: set[str] = set()
+    required_columns: set[str] = set()
+    for column_config in column_configs:
+        referenceable_columns.add(column_config.name)
+        referenceable_columns.update(column_config.side_effect_columns)
+        required_columns.update(column_config.required_columns)
+        if column_config.skip is not None:
+            required_columns.update(column_config.skip.columns)
+    return range_id_column in required_columns and range_id_column not in referenceable_columns
 
 
 def _ray_data_context_scope(ray: Any, data_context: Any) -> Any:
@@ -988,6 +1018,7 @@ def _generate_batch(
     worker_options: _RayWorkerOptions | None = None,
     use_input_dataset: bool | None = None,
     seed_window: ray_seed_planning.RaySeedWindow | None = None,
+    range_input_columns: list[str] | None = None,
     hidden_order_column: str | None = None,
     preserve_output_row_count: bool = False,
     output_chunk_rows: int | None = None,
@@ -1004,6 +1035,7 @@ def _generate_batch(
         worker_options=worker_options,
         use_input_dataset=use_input_dataset,
         seed_window=seed_window,
+        range_input_columns=range_input_columns,
         hidden_order_column=hidden_order_column,
         preserve_output_row_count=preserve_output_row_count,
         output_chunk_rows=output_chunk_rows,

--- a/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
@@ -75,6 +75,7 @@ class _RayExecutionPayload:
     use_input_dataset: bool
     seed_window: ray_seed_planning.RaySeedWindow | None = None
     seed_config: SeedConfig | None = None
+    range_input_columns: list[str] | None = None
     hidden_order_column: str | None = None
     preserve_output_row_count: bool = False
     output_chunk_rows: int | None = None
@@ -186,8 +187,10 @@ class _RayWorkerGenerationPipeline:
             hidden_order_column=self._execution_payload.hidden_order_column,
         )
         block_config = self.create_block_config(worker_batch.dataframe)
-        input_frame = (
-            _strip_internal_columns(worker_batch.dataframe) if self._execution_payload.use_input_dataset else None
+        input_frame = _create_worker_input_frame(
+            worker_batch.dataframe,
+            use_input_dataset=self._execution_payload.use_input_dataset,
+            range_input_columns=self._execution_payload.range_input_columns,
         )
         block_result = self._execute_block(
             data_designer_config=block_config,
@@ -471,7 +474,7 @@ def _prepare_worker_options(
     if observability_options.trace_enabled:
         run_config.async_trace = True
     seed_readers = copy.deepcopy(worker_options.seed_readers)
-    if execution_payload.use_input_dataset:
+    if execution_payload.use_input_dataset or execution_payload.range_input_columns is not None:
         seed_readers = ray_seed_planning.ensure_dataframe_seed_reader(seed_readers)
     return replace(
         worker_options,
@@ -486,6 +489,7 @@ def _compile_ray_execution_payload(
     worker_options: _RayWorkerOptions,
     use_input_dataset: bool,
     seed_window: ray_seed_planning.RaySeedWindow | None = None,
+    range_input_columns: list[str] | None = None,
     hidden_order_column: str | None = None,
     preserve_output_row_count: bool = False,
     output_chunk_rows: int | None = None,
@@ -504,6 +508,7 @@ def _compile_ray_execution_payload(
         use_input_dataset=use_input_dataset,
         seed_window=seed_window,
         seed_config=payload_seed_config,
+        range_input_columns=range_input_columns,
         hidden_order_column=hidden_order_column,
         preserve_output_row_count=preserve_output_row_count,
         output_chunk_rows=output_chunk_rows,
@@ -534,6 +539,26 @@ def _validate_worker_payload_serializable(payload: _RayExecutionPayload) -> None
             "RayBackend worker payload is not serializable. Check model providers, seed readers, "
             "secret resolvers, and MCP providers for process-safe state before launching Ray workers."
         ) from exc
+
+
+def _create_worker_input_frame(
+    dataframe: Any,
+    *,
+    use_input_dataset: bool,
+    range_input_columns: list[str] | None,
+) -> Any | None:
+    if use_input_dataset:
+        return _strip_internal_columns(dataframe)
+    if range_input_columns is None:
+        return None
+
+    input_frame = _strip_internal_columns(dataframe)
+    missing_columns = [column for column in range_input_columns if column not in input_frame.columns]
+    if missing_columns:
+        raise RayDatasetGenerationError(
+            f"RayBackend expected ray.data.range() worker batches to include column(s) {missing_columns!r}."
+        )
+    return input_frame.loc[:, range_input_columns].copy()
 
 
 def _strip_internal_columns(dataframe: Any) -> Any:

--- a/packages/data-designer/tests/integrations/ray/test_semantics.py
+++ b/packages/data-designer/tests/integrations/ray/test_semantics.py
@@ -58,6 +58,12 @@ def _summary_seed_config_builder(stub_model_configs: Any, seed_df: lazy.pd.DataF
     return config_builder
 
 
+def _id_label_config_builder(stub_model_configs: Any) -> DataDesignerConfigBuilder:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="id_label", expr="row-{{ id }}"))
+    return config_builder
+
+
 @pytest.mark.parametrize(
     ("drop_order_column", "expected_columns"),
     [
@@ -237,6 +243,39 @@ def test_hidden_row_id_preserves_from_scratch_order_without_schema_pollution(
     assert len(output_df) == 5
     assert list(output_df.columns) == ["uuid", "category", "uniform"]
     assert not any(column.startswith("__data_designer_ray") for column in output_df.columns)
+
+
+def test_from_scratch_range_id_is_available_to_referenced_columns(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    fake_ray.data.range_blocks = [
+        lazy.pd.DataFrame({"id": [0, 1]}),
+        lazy.pd.DataFrame({"id": [2, 3]}),
+    ]
+    designer = _designer(
+        tmp_path=tmp_path,
+        stub_model_providers=stub_model_providers,
+        backend=RayBackend(batch_size=2),
+    )
+
+    output_df = (
+        designer.create(_id_label_config_builder(stub_model_configs), num_records=4)
+        .load_dataset()
+        .to_pandas()
+        .sort_values("id")
+        .reset_index(drop=True)
+    )
+
+    assert output_df.to_dict(orient="records") == [
+        {"id": 0, "id_label": "row-0"},
+        {"id": 1, "id_label": "row-1"},
+        {"id": 2, "id_label": "row-2"},
+        {"id": 3, "id_label": "row-3"},
+    ]
 
 
 def test_seed_config_without_input_dataset_reads_partition_offsets_once(


### PR DESCRIPTION
## 📋 Summary

Fixes Ray from-scratch range generation when a user config references Ray's synthetic `id` column. The backend now carries only the referenced range input columns into the worker block config so compiler validation and generation see `id` without leaking internal order columns into unrelated schemas.

## 🔗 Related Issue

Fixes #124

## 🔄 Changes

- Detect when a from-scratch Ray range job references the `id` column but no configured column defines it.
- Pass a minimal range input frame into worker block execution for those jobs.
- Keep non-range jobs, explicit input datasets, hidden ordering columns, and row-count validation behavior unchanged.
- Add fake-Ray semantics coverage for `id` references in from-scratch Ray generation.

## 🧪 Testing

- [ ] `make test` passes (not run; focused Ray suite used)
- [x] Unit tests added/updated
- [x] E2E tests added/updated

Verification run by Worker J:

- `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_semantics.py::test_from_scratch_range_id_is_available_to_referenced_columns packages/data-designer/tests/integrations/ray/test_semantics.py::test_hidden_row_id_preserves_from_scratch_order_without_schema_pollution -q` — passed
- `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_worker_boundary.py::test_worker_failure_includes_block_context -q` — passed
- `UV_CACHE_DIR=/tmp/uv-cache-worker-j DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_real_smoke.py::test_real_ray_data_context_controls_smoke -q` — passed
- `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_semantics.py -q` — passed
- `uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_worker_boundary.py -q` — passed
- `ruff format --check` and `ruff check` on touched files — passed

Coordinator spot-check:

- `UV_CACHE_DIR=/tmp/uv-cache-worker-j uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_semantics.py::test_from_scratch_range_id_is_available_to_referenced_columns packages/data-designer/tests/integrations/ray/test_worker_boundary.py::test_worker_failure_includes_block_context -q` — 2 passed
- `UV_CACHE_DIR=/tmp/uv-cache-worker-j uv run --group dev ruff check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py packages/data-designer/tests/integrations/ray/test_semantics.py` — passed

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A; correctness fix only)