### PR TITLE
fix(ray): preserve datasink write metadata

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/artifact_output.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/artifact_output.py
@@ -114,7 +114,9 @@ class DataDesignerRayDatasink:
 
     def on_write_complete(self, write_result: Any) -> None:
         write_returns = [item for item in _write_result_returns(write_result) if item is not None]
-        actual_num_records = sum(int(item["num_rows"]) for item in write_returns)
+        actual_num_records = _write_result_num_rows(write_result)
+        if actual_num_records is None:
+            actual_num_records = sum(int(item["num_rows"]) for item in write_returns)
         metadata: dict[str, Any] = {
             "target_num_records": self.target_num_records,
             "actual_num_records": actual_num_records,
@@ -133,6 +135,42 @@ class DataDesignerRayDatasink:
 
     def on_write_failed(self, exception: Exception) -> None:
         del exception
+
+
+def create_data_designer_ray_datasink(
+    *,
+    ray: Any,
+    base_dataset_path: Path,
+    dataset_name: str,
+    target_num_records: int,
+    buffer_size: int,
+    min_rows_per_write: int | None,
+    supports_distributed_writes: bool,
+) -> DataDesignerRayDatasink:
+    """Create a datasink that real Ray recognizes without importing Ray eagerly."""
+    ray_data = getattr(ray, "data", None)
+    ray_datasink_cls = getattr(ray_data, "Datasink", None)
+    if ray_datasink_cls is None:
+        return DataDesignerRayDatasink(
+            base_dataset_path=base_dataset_path,
+            dataset_name=dataset_name,
+            target_num_records=target_num_records,
+            buffer_size=buffer_size,
+            min_rows_per_write=min_rows_per_write,
+            supports_distributed_writes=supports_distributed_writes,
+        )
+
+    class _RayDataDesignerRayDatasink(DataDesignerRayDatasink, ray_datasink_cls):  # type: ignore[misc, valid-type]
+        pass
+
+    return _RayDataDesignerRayDatasink(
+        base_dataset_path=base_dataset_path,
+        dataset_name=dataset_name,
+        target_num_records=target_num_records,
+        buffer_size=buffer_size,
+        min_rows_per_write=min_rows_per_write,
+        supports_distributed_writes=supports_distributed_writes,
+    )
 
 
 def append_ray_artifact_columns(dataframe: Any, block_result: BlockExecutionResult) -> Any:
@@ -245,6 +283,13 @@ def _write_result_returns(write_result: Any) -> list[Any]:
     if write_returns is None:
         return []
     return list(write_returns)
+
+
+def _write_result_num_rows(write_result: Any) -> int | None:
+    num_rows = getattr(write_result, "num_rows", None)
+    if num_rows is None:
+        return None
+    return int(num_rows)
 
 
 def _combine_file_paths(file_paths_items: Iterable[dict[str, Any]]) -> dict[str, Any]:

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -20,7 +20,7 @@ from data_designer.engine.column_generators.utils.generator_classification impor
 from data_designer.engine.dataset_builders.block_execution import execute_dataset_block
 from data_designer.engine.storage.artifact_storage import SDG_CONFIG_FILENAME, ArtifactStorage
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
-from data_designer.integrations.ray.artifact_output import DataDesignerRayDatasink
+from data_designer.integrations.ray.artifact_output import create_data_designer_ray_datasink
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics
 from data_designer.integrations.ray.observability import RayDatasetAnalysis
@@ -478,13 +478,13 @@ class RayBackend:
         dataset_name: str,
         batch_size: int,
     ) -> ArtifactStorage:
-        del ray
         ArtifactStorage.mkdir_if_needed(runtime_context.artifact_path)
         artifact_storage = ArtifactStorage(artifact_path=runtime_context.artifact_path, dataset_name=dataset_name)
         ArtifactStorage.mkdir_if_needed(artifact_storage.base_dataset_path)
         config_builder.get_builder_config().to_json(artifact_storage.base_dataset_path / SDG_CONFIG_FILENAME)
 
-        datasink = DataDesignerRayDatasink(
+        datasink = create_data_designer_ray_datasink(
+            ray=ray,
             base_dataset_path=artifact_storage.base_dataset_path,
             dataset_name=artifact_storage.resolved_dataset_name,
             target_num_records=num_records,

--- a/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
@@ -193,11 +193,14 @@ class FakeRayDataset:
             self.data_module.write_datasink_kwargs = dict(self.write_datasink_kwargs)
         datasink.on_write_start(schema=None)
         write_returns = []
+        num_rows = 0
         for task_idx, block in enumerate(self.blocks):
-            write_return = datasink.write([coerce_pandas_dataframe(block)], types.SimpleNamespace(task_idx=task_idx))
+            dataframe = coerce_pandas_dataframe(block)
+            num_rows += len(dataframe)
+            write_return = datasink.write([dataframe], types.SimpleNamespace(task_idx=task_idx))
             if write_return is not None:
                 write_returns.append(write_return)
-        datasink.on_write_complete(types.SimpleNamespace(write_returns=write_returns))
+        datasink.on_write_complete(types.SimpleNamespace(num_rows=num_rows, size_bytes=0, write_returns=write_returns))
 
     def repartition(
         self,

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import inspect
+import json
+import types
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +43,10 @@ from data_designer.integrations.ray import (
 )
 from data_designer.integrations.ray import backend as ray_backend_module
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
+from data_designer.integrations.ray.artifact_output import (
+    DataDesignerRayDatasink,
+    create_data_designer_ray_datasink,
+)
 from data_designer.interface.data_designer import DataDesigner
 
 pytestmark = pytest.mark.ray_fake
@@ -386,6 +392,45 @@ def test_ray_backend_writes_dropped_columns_and_processor_artifacts_with_fake_ra
     assert metadata["file_paths"]["processor-files"] == {
         "schema-transform": ["processors-files/schema-transform/batch_00000.parquet"]
     }
+
+
+def test_ray_datasink_metadata_uses_aggregate_write_result_count(tmp_path: Path) -> None:
+    datasink = DataDesignerRayDatasink(
+        base_dataset_path=tmp_path,
+        dataset_name="ray-output",
+        target_num_records=2,
+        buffer_size=1,
+        min_rows_per_write=1,
+        supports_distributed_writes=True,
+    )
+
+    datasink.on_write_complete(types.SimpleNamespace(num_rows=2, size_bytes=0, write_returns=[]))
+
+    with open(datasink.metadata_file_path, encoding="utf-8") as file:
+        metadata = json.load(file)
+    assert metadata["actual_num_records"] == 2
+    assert metadata["num_completed_batches"] == 0
+    assert metadata["file_paths"] == {"parquet-files": []}
+
+
+def test_create_data_designer_ray_datasink_subclasses_real_ray_datasink(tmp_path: Path) -> None:
+    class FakeRayDatasink:
+        pass
+
+    fake_ray = types.SimpleNamespace(data=types.SimpleNamespace(Datasink=FakeRayDatasink))
+
+    datasink = create_data_designer_ray_datasink(
+        ray=fake_ray,
+        base_dataset_path=tmp_path,
+        dataset_name="ray-output",
+        target_num_records=2,
+        buffer_size=1,
+        min_rows_per_write=1,
+        supports_distributed_writes=True,
+    )
+
+    assert isinstance(datasink, DataDesignerRayDatasink)
+    assert isinstance(datasink, FakeRayDatasink)
 
 
 def test_ray_backend_uses_override_num_blocks_for_from_scratch_dataset(

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -189,7 +189,10 @@ def test_real_ray_data_designer_artifact_write_smoke(
 
     assert artifact_storage is not None
     assert artifact_storage.metadata_file_path.is_file()
-    assert artifact_storage.read_metadata()["actual_num_records"] == 2
+    metadata = artifact_storage.read_metadata()
+    assert metadata["actual_num_records"] == 2
+    assert metadata["num_completed_batches"] >= 1
+    assert metadata["file_paths"]["parquet-files"]
     assert results.load_dataset().count() == 2
     assert sorted(artifact_storage.final_dataset_path.glob("*.parquet"))
 


### PR DESCRIPTION
## 📋 Summary

Fixes Ray artifact metadata written by `DataDesignerRayDatasink` under real Ray. The datasink now subclasses Ray's `Datasink` type when available and reads the aggregate Ray write result row count, while preserving per-block file path metadata when write returns are present.

## 🔗 Related Issue

Fixes #123

## 🔄 Changes

- Add a lazy factory that creates a DataDesigner datasink recognized by real Ray without importing Ray at module import time.
- Use Ray's aggregate `WriteResult.num_rows` as the authoritative row count when available.
- Extend the fake-Ray harness to mimic real Ray write result row counts.
- Strengthen fake and real-Ray artifact-write assertions for metadata and parquet file paths.

## 🧪 Testing

- [ ] `make test` passes (not run; focused Ray tests used)
- [x] Unit tests added/updated
- [x] E2E tests added/updated

Verification:

- `UV_CACHE_DIR=/tmp/uv-cache-dd-ray123 uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_writes_data_designer_artifacts_with_fake_ray packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_datasink_metadata_uses_aggregate_write_result_count packages/data-designer/tests/integrations/ray/test_backend.py::test_create_data_designer_ray_datasink_subclasses_real_ray_datasink -q` — 3 passed
- `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 UV_CACHE_DIR=/tmp/uv-cache-dd-ray123 DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_real_smoke.py::test_real_ray_data_designer_artifact_write_smoke -q` — 1 passed
- `UV_CACHE_DIR=/tmp/uv-cache-dd-ray123 uv run --group dev ruff check packages/data-designer/src/data_designer/integrations/ray/artifact_output.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_real_smoke.py` — passed
- `UV_CACHE_DIR=/tmp/uv-cache-dd-ray123 uv run --group dev ruff format --check packages/data-designer/src/data_designer/integrations/ray/artifact_output.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_real_smoke.py` — 5 files already formatted

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A; correctness fix only)