### PR TITLE
feat(ray): define provider-aware actor defaults

### DIFF
--- a/docs/concepts/ray-backend.md
+++ b/docs/concepts/ray-backend.md
@@ -35,3 +35,35 @@ artifacts/
 `metadata.json` records target and actual row counts, batch size, completed batch count, schema, and relative paths for final parquet files. When present, dropped-column and processor artifact paths are included under `dropped-columns-parquet-files` and `processor-files`.
 
 `distributed_artifact_writes=True` is the default. Use a cluster-visible artifact path when running Ray workers on multiple nodes, or set `distributed_artifact_writes=False` to force Ray Data write tasks onto the driver node.
+
+## Actor Pool Defaults
+
+`RayBackend` uses provider-aware actor-pool defaults for model-generated columns. If you do not pass
+`RayExecutionOptions(use_actor_pool=...)`, the backend inspects the model configs referenced by the job:
+
+- External provider APIs get a Ray Data actor pool with `max_size` capped by the effective provider throttle budget from `max_parallel_requests`. The automatic external-provider pool does not set `min_size` or `initial_size`, so Ray can read input blocks before starting model-client actors on small clusters while the actor cap still bounds fanout.
+- Multiple aliases that point at the same provider and model use the most constrained `max_parallel_requests` value, matching Data Designer's global provider throttle behavior.
+- Local endpoints such as `http://localhost:8000/v1` or `http://127.0.0.1:8000/v1` do not get an automatic actor pool size. Their best sizing depends on GPU placement, model memory, and the Ray resource requests you choose.
+- Sampler-only and expression-only jobs stay in Ray task mode by default.
+
+These defaults keep external API jobs from creating more Ray model-client workers than the provider throttle can use. Global provider throttling remains enabled by default, so even if you override actor-pool sizing, request concurrency is still coordinated across Ray workers by each model config's `max_parallel_requests`.
+
+Pass `RayExecutionOptions(use_actor_pool=False)` to force task execution, or `RayExecutionOptions(use_actor_pool=True, ...)` to provide your own actor-pool sizing:
+
+```python
+from data_designer.integrations.ray import RayBackend, RayExecutionOptions
+
+backend = RayBackend(
+    batch_size=1024,
+    execution_options=RayExecutionOptions(
+        use_actor_pool=True,
+        actor_pool_min_size=1,
+        actor_pool_initial_size=2,
+        actor_pool_max_size=8,
+    ),
+)
+```
+
+For external APIs, start with `actor_pool_max_size` at or below the sum of the effective `max_parallel_requests` values for the provider/model pairs used by the job. Raising the actor count above that value usually adds queued workers rather than more provider throughput.
+
+For local GPU inference, size the actor pool around GPU resources instead of API limits. For example, if each actor reserves one GPU, set `num_gpus=1` and `actor_pool_max_size` to the number of GPUs you want Ray to use. If each actor reserves half a GPU, set `num_gpus=0.5` and cap the actor pool at roughly twice the target GPU count. Keep `max_parallel_requests` aligned with what each local model server can handle without increasing tail latency.

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -602,6 +602,12 @@ class RayDriverPlanner:
         model_aliases = _model_health_check_aliases(config_builder)
         if self._backend.preflight_model_health_check:
             _run_driver_model_health_check(runtime_context, config_builder, model_aliases)
+        execution_options = self._backend.execution_options.resolve_actor_pool_defaults(
+            model_configs=config_builder.model_configs,
+            model_providers=list(runtime_context.model_providers),
+            default_provider_name=runtime_context.default_provider_name,
+            model_aliases=model_aliases,
+        )
 
         block_plan = self._backend.block_planning.resolve(num_records=num_records) if input_dataset is None else None
         dataset = self._backend._resolve_input_dataset(
@@ -689,7 +695,7 @@ class RayDriverPlanner:
             "batch_format": "pandas",
             "zero_copy_batch": self._backend.zero_copy_batch,
         }
-        map_batches_kwargs.update(self._backend.execution_options.to_map_batches_kwargs(self._ray))
+        map_batches_kwargs.update(execution_options.to_map_batches_kwargs(self._ray))
         map_batches_kwargs["udf_modifying_row_count"] = not row_count_preserving
 
         return RayJobPlan(

--- a/packages/data-designer/src/data_designer/integrations/ray/options.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/options.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import copy
 import math
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from typing import Any
+from urllib.parse import urlparse
 
 from data_designer.integrations.ray._validation import validate_finite_number
 from data_designer.integrations.ray.errors import RayBackendConfigurationError
@@ -52,6 +53,8 @@ _RAY_BACKEND_EXECUTION_OPTIONS_LEGACY_KWARGS = frozenset(
         "actor_pool_initial_size",
     }
 )
+_LOCAL_PROVIDER_TYPES = frozenset({"local", "local-openai", "ollama", "vllm"})
+_LOCAL_PROVIDER_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -154,10 +157,11 @@ class RayExecutionOptions:
     concurrency: RayMapConcurrency | None = None
     ray_remote_args_fn: Any | None = None
     ray_remote_args: Mapping[str, Any] | None = None
-    use_actor_pool: bool = False
+    use_actor_pool: bool | None = None
     actor_pool_min_size: int | None = None
     actor_pool_max_size: int | None = None
     actor_pool_initial_size: int | None = None
+    _default_actor_pool_min_size: bool = field(default=True, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         _validate_optional_non_negative_number("num_cpus", self.num_cpus)
@@ -168,6 +172,8 @@ class RayExecutionOptions:
             raise RayBackendConfigurationError(
                 "RayExecutionOptions scheduling_strategy must be non-empty when provided."
             )
+        if self.use_actor_pool is not None and not isinstance(self.use_actor_pool, bool):
+            raise RayBackendConfigurationError("RayExecutionOptions use_actor_pool must be a boolean or None.")
         if self.compute is not None and self.use_actor_pool:
             raise RayBackendConfigurationError(
                 "RayExecutionOptions compute cannot be combined with use_actor_pool=True."
@@ -182,11 +188,11 @@ class RayExecutionOptions:
         _validate_optional_positive_int("actor_pool_min_size", self.actor_pool_min_size)
         _validate_optional_positive_int("actor_pool_max_size", self.actor_pool_max_size)
         _validate_optional_positive_int("actor_pool_initial_size", self.actor_pool_initial_size)
-        if self.actor_pool_min_size is not None and not self.use_actor_pool:
+        if self.actor_pool_min_size is not None and self.use_actor_pool is not True:
             raise RayBackendConfigurationError("RayExecutionOptions actor_pool_min_size requires use_actor_pool=True.")
-        if self.actor_pool_max_size is not None and not self.use_actor_pool:
+        if self.actor_pool_max_size is not None and self.use_actor_pool is not True:
             raise RayBackendConfigurationError("RayExecutionOptions actor_pool_max_size requires use_actor_pool=True.")
-        if self.actor_pool_initial_size is not None and not self.use_actor_pool:
+        if self.actor_pool_initial_size is not None and self.use_actor_pool is not True:
             raise RayBackendConfigurationError(
                 "RayExecutionOptions actor_pool_initial_size requires use_actor_pool=True."
             )
@@ -209,6 +215,34 @@ class RayExecutionOptions:
                 )
         _validate_remote_arg_conflicts(self)
 
+    def resolve_actor_pool_defaults(
+        self,
+        *,
+        model_configs: list[Any],
+        model_providers: list[Any],
+        default_provider_name: str,
+        model_aliases: list[str],
+    ) -> RayExecutionOptions:
+        """Return execution options with provider-aware actor-pool defaults applied."""
+        if self.use_actor_pool is not None:
+            return self
+        policy = resolve_provider_aware_actor_pool_policy(
+            model_configs=model_configs,
+            model_providers=model_providers,
+            default_provider_name=default_provider_name,
+            model_aliases=model_aliases,
+        )
+        if not policy.use_actor_pool:
+            return replace(self, use_actor_pool=False)
+        return replace(
+            self,
+            use_actor_pool=True,
+            actor_pool_min_size=policy.min_size,
+            actor_pool_max_size=policy.max_size,
+            actor_pool_initial_size=policy.initial_size,
+            _default_actor_pool_min_size=False,
+        )
+
     def to_map_batches_kwargs(self, ray: Any | None = None) -> dict[str, Any]:
         """Return keyword arguments accepted by ``Dataset.map_batches``."""
         kwargs: dict[str, Any] = {}
@@ -230,6 +264,16 @@ class RayExecutionOptions:
                 )
             kwargs["compute"] = _create_actor_pool_strategy(ray, self)
         return kwargs
+
+
+@dataclass(frozen=True, slots=True)
+class RayActorPoolPolicy:
+    """Resolved Ray actor-pool policy for provider-aware defaults."""
+
+    use_actor_pool: bool
+    min_size: int | None = None
+    max_size: int | None = None
+    initial_size: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -619,6 +663,7 @@ def _resolve_ray_execution_options(
         )
     if execution_options is not None:
         return execution_options
+    use_actor_pool = legacy_options["use_actor_pool"] if "use_actor_pool" in legacy_options else None
     return RayExecutionOptions(
         num_cpus=legacy_options.get("num_cpus"),
         num_gpus=legacy_options.get("num_gpus"),
@@ -629,7 +674,7 @@ def _resolve_ray_execution_options(
         concurrency=legacy_options.get("map_concurrency"),
         ray_remote_args_fn=legacy_options.get("ray_remote_args_fn"),
         ray_remote_args=legacy_options.get("ray_remote_args"),
-        use_actor_pool=legacy_options.get("use_actor_pool", False),
+        use_actor_pool=use_actor_pool,
         actor_pool_min_size=legacy_options.get("actor_pool_min_size"),
         actor_pool_max_size=legacy_options.get("actor_pool_max_size"),
         actor_pool_initial_size=legacy_options.get("actor_pool_initial_size"),
@@ -661,6 +706,59 @@ def _has_effective_execution_legacy_options(legacy_options: Mapping[str, Any]) -
         if value is not None:
             return True
     return False
+
+
+def resolve_provider_aware_actor_pool_policy(
+    *,
+    model_configs: list[Any],
+    model_providers: list[Any],
+    default_provider_name: str,
+    model_aliases: list[str],
+) -> RayActorPoolPolicy:
+    """Resolve default Ray actor-pool sizing from referenced model providers.
+
+    External provider APIs get a bounded actor pool so Ray does not create more
+    model-client workers than the provider throttle budget can use. Local
+    OpenAI-compatible endpoints are left in task mode by default because their
+    best actor count depends on GPU placement and per-actor resource requests.
+    """
+    referenced_aliases = set(model_aliases)
+    if not referenced_aliases:
+        return RayActorPoolPolicy(use_actor_pool=False)
+
+    providers_by_name = {provider.name: provider for provider in model_providers}
+    external_caps: dict[tuple[str, str], int] = {}
+    for model_config in model_configs:
+        if model_config.alias not in referenced_aliases:
+            continue
+        provider_name = model_config.provider or default_provider_name
+        provider = providers_by_name.get(provider_name)
+        if _is_local_model_provider(provider):
+            continue
+        max_parallel_requests = int(model_config.inference_parameters.max_parallel_requests)
+        throttle_key = (provider_name, model_config.model)
+        external_caps[throttle_key] = min(external_caps.get(throttle_key, max_parallel_requests), max_parallel_requests)
+
+    if not external_caps:
+        return RayActorPoolPolicy(use_actor_pool=False)
+    max_size = max(sum(external_caps.values()), 1)
+    return RayActorPoolPolicy(use_actor_pool=True, max_size=max_size)
+
+
+def _is_local_model_provider(provider: Any | None) -> bool:
+    if provider is None:
+        return False
+    provider_type = getattr(provider, "provider_type", "")
+    if isinstance(provider_type, str) and provider_type.lower() in _LOCAL_PROVIDER_TYPES:
+        return True
+    endpoint = getattr(provider, "endpoint", "")
+    if not isinstance(endpoint, str) or not endpoint:
+        return False
+    parsed = urlparse(endpoint)
+    hostname = parsed.hostname
+    if hostname is None:
+        return endpoint.startswith("unix:")
+    return hostname.lower() in _LOCAL_PROVIDER_HOSTS
 
 
 def _validate_optional_positive_int(field_name: str, value: int | None) -> None:
@@ -806,7 +904,10 @@ def _create_actor_pool_strategy(ray: Any, options: RayExecutionOptions) -> Any:
             "RayExecutionOptions use_actor_pool=True requires ray.data.ActorPoolStrategy."
         )
     kwargs: dict[str, int] = {}
-    _set_if_not_none(kwargs, "min_size", options.actor_pool_min_size or 1)
+    min_size = options.actor_pool_min_size
+    if min_size is None and options._default_actor_pool_min_size:
+        min_size = 1
+    _set_if_not_none(kwargs, "min_size", min_size)
     _set_if_not_none(kwargs, "max_size", options.actor_pool_max_size)
     _set_if_not_none(kwargs, "initial_size", options.actor_pool_initial_size)
     return actor_pool_strategy(**kwargs)

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -17,6 +17,7 @@ from data_designer.config.base import ProcessorConfig
 from data_designer.config.column_configs import CustomColumnConfig, ExpressionColumnConfig, LLMTextColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.custom_column import custom_column_generator
+from data_designer.config.models import ChatCompletionInferenceParams, ModelConfig, ModelProvider
 from data_designer.config.processors import DropColumnsProcessorConfig, SchemaTransformProcessorConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import IndexRange, SamplingStrategy
@@ -78,6 +79,19 @@ def _llm_config_builder(stub_model_configs: Any) -> DataDesignerConfigBuilder:
             model_alias="stub-model",
         )
     )
+    return config_builder
+
+
+def _multi_llm_config_builder(model_configs: list[ModelConfig]) -> DataDesignerConfigBuilder:
+    config_builder = DataDesignerConfigBuilder(model_configs=model_configs)
+    for model_config in model_configs:
+        config_builder.add_column(
+            LLMTextColumnConfig(
+                name=f"text_{model_config.alias.replace('-', '_')}",
+                prompt="Say hello.",
+                model_alias=model_config.alias,
+            )
+        )
     return config_builder
 
 
@@ -1146,6 +1160,147 @@ def test_ray_backend_actor_pool_uses_autoscaling_strategy_and_constructor_payloa
         "max_size": 4,
         "initial_size": 2,
     }
+
+
+def test_ray_backend_defaults_to_provider_capped_actor_pool_for_external_llm(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [1]})])
+
+    def generate_batch(batch: lazy.pd.DataFrame, **_: Any) -> lazy.pd.DataFrame:
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1, preflight_model_health_check=False),
+    )
+
+    designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_kwargs["compute"].kwargs == {"max_size": 4}
+    assert "num_cpus" not in input_dataset.map_batches_kwargs
+
+
+def test_ray_backend_provider_default_actor_pool_uses_effective_throttle_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [1]})])
+    model_configs = [
+        ModelConfig(
+            alias="fast",
+            model="shared-model",
+            provider="provider-1",
+            inference_parameters=ChatCompletionInferenceParams(max_parallel_requests=8),
+        ),
+        ModelConfig(
+            alias="constrained",
+            model="shared-model",
+            provider="provider-1",
+            inference_parameters=ChatCompletionInferenceParams(max_parallel_requests=2),
+        ),
+    ]
+
+    def generate_batch(batch: lazy.pd.DataFrame, **_: Any) -> lazy.pd.DataFrame:
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1, preflight_model_health_check=False),
+    )
+
+    designer.create(_multi_llm_config_builder(model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_kwargs["compute"].kwargs["max_size"] == 2
+    assert "num_cpus" not in input_dataset.map_batches_kwargs
+
+
+def test_ray_backend_explicit_execution_options_disable_default_actor_pool(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [1]})])
+
+    def generate_batch(batch: lazy.pd.DataFrame, **_: Any) -> lazy.pd.DataFrame:
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            preflight_model_health_check=False,
+            execution_options=RayExecutionOptions(use_actor_pool=False),
+        ),
+    )
+
+    designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert "compute" not in input_dataset.map_batches_kwargs
+
+
+def test_ray_backend_leaves_local_provider_actor_pool_sizing_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [1]})])
+    providers = [
+        ModelProvider(
+            name="local-gpu",
+            endpoint="http://127.0.0.1:8000/v1",
+            provider_type="openai",
+            api_key="local-key",
+        )
+    ]
+    model_configs = [
+        ModelConfig(
+            alias="local-model",
+            model="gpu-model",
+            provider="local-gpu",
+            inference_parameters=ChatCompletionInferenceParams(max_parallel_requests=16),
+        )
+    ]
+
+    def generate_batch(batch: lazy.pd.DataFrame, **_: Any) -> lazy.pd.DataFrame:
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=1, preflight_model_health_check=False),
+    )
+
+    designer.create(_multi_llm_config_builder(model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is not None
+    assert "compute" not in input_dataset.map_batches_kwargs
 
 
 def test_ray_backend_rejects_actor_pool_with_map_concurrency() -> None:


### PR DESCRIPTION
## 📋 Summary

Defines intentional Ray actor-pool defaults for model-backed jobs so external provider execution is capped by the effective provider throttle budget while sampler/expression and local endpoint jobs stay explicitly controlled.

## 🔗 Related Issue

Closes #49

## 🔄 Changes

- Adds provider-aware actor-pool policy resolution to `RayExecutionOptions`.
- Applies the resolved execution options during Ray driver planning before `map_batches` is constructed.
- Preserves explicit user choices: `use_actor_pool=False` disables defaults and `use_actor_pool=True` keeps user-provided actor sizing.
- Documents external-provider, local-inference, and explicit actor-pool sizing guidance.
- Adds fake-Ray coverage for external provider caps, shared provider/model throttle aggregation, explicit disable, and local endpoint behavior.

## 🧪 Testing

- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray49-test uv run --group dev pytest packages/data-designer/tests/integrations/ray/test_options.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_provider_throttling.py -q -m ray_fake` (135 passed)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray49-ruff uv run --group dev ruff check docs/concepts/ray-backend.md packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray49-format uv run --group dev ruff format --check packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/options.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [x] Real-Ray mock provider benchmark, `max_parallel_requests=64`, 8 rows, 2 CPUs: passed, 8/8 requests successful, all output valid
- [x] Real-Ray constrained mock provider benchmark, `max_parallel_requests=2`, 12 rows, 2 CPUs: passed, 12/12 requests successful, service `max_in_flight=2`, all output valid

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated