### PR TITLE
feat(ray): add Ray Data LLM stage planning

### DIFF
--- a/architecture/ray-data-llm.md
+++ b/architecture/ray-data-llm.md
@@ -2,13 +2,13 @@
 
 Issue: [#52](https://github.com/eric-tramel/DataDesigner/issues/52)  
 Date: 2026-04-25  
-Status: recommended path documented; execution integration deferred
+Status: planning hook implemented; execution integration deferred
 
 ## Decision
 
 Ray Data LLM/vLLM should not be added as a first-class `ModelProvider` yet. Keep external provider behavior on the existing `ModelFacade` and HTTP client adapters. Treat Ray Data LLM as a future RayBackend-only stage optimization for local GPU inference after the Ray planner can prove a column stage is eligible.
 
-The safe slice is a capability probe: `probe_ray_data_llm_capabilities()` detects the optional `ray.data.llm` surface at runtime, and `assess_ray_data_llm_integration()` returns the current placement recommendation without importing Ray during package import.
+The safe slice is a capability and planning hook: `probe_ray_data_llm_capabilities()` detects the optional `ray.data.llm` surface at runtime, `assess_ray_data_llm_integration()` returns the current placement recommendation without importing Ray during package import, and `RayDataLLMStageOptions` lets `RayBackend` explicitly plan one opt-in local vLLM stage candidate while continuing to execute through the existing `ModelFacade` unless that fallback is disabled.
 
 ## Sources Reviewed
 
@@ -62,6 +62,8 @@ A narrow future prototype should only consider columns that meet all of these co
 
 All other model-generated columns should keep using the existing `ModelFacade`.
 
+The current implementation records this eligibility through `plan_ray_data_llm_stage()` and exposes the resolved plan as `RayDatasetCreationResults.llm_stage_plan`. `RayDataLLMStageOptions(allow_model_facade_fallback=False)` turns the hook into a fail-fast verifier so a job does not silently run through the existing facade when the requested Ray Data LLM stage is unavailable or ineligible.
+
 ## Non-Goals For This Slice
 
 - No new `ModelProvider.provider_type`.
@@ -72,3 +74,5 @@ All other model-generated columns should keep using the existing `ModelFacade`.
 ## Follow-Up Recommendation
 
 [Issue #118](https://github.com/eric-tramel/DataDesigner/issues/118) tracks a RayBackend-only proof of concept and benchmark. The POC should compare the existing RayBackend plus OpenAI-compatible vLLM server path against a Ray Data LLM processor stage for a single independent text column, then expand only if the result preserves usage stats, errors, ordering, dropped-row behavior, and observability.
+
+The remaining execution step needs an environment with `ray.data.llm` optional dependencies and a real local vLLM model source. Local package introspection on the current development environment found `ray.data.llm` imports fail because optional dependencies such as `boto3` are absent, so the merged hook intentionally fails fast or falls back instead of adding an unverified execution path.

--- a/packages/data-designer/src/data_designer/integrations/ray/__init__.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/__init__.py
@@ -22,7 +22,11 @@ from data_designer.integrations.ray.errors import (
 from data_designer.integrations.ray.llm import (
     RayDataLLMCapabilities,
     RayDataLLMIntegrationAssessment,
+    RayDataLLMStageCandidate,
+    RayDataLLMStageOptions,
+    RayDataLLMStagePlan,
     assess_ray_data_llm_integration,
+    plan_ray_data_llm_stage,
     probe_ray_data_llm_capabilities,
 )
 from data_designer.integrations.ray.metrics import (
@@ -55,6 +59,9 @@ __all__ = [
     "RayDataContextOptions",
     "RayDataLLMCapabilities",
     "RayDataLLMIntegrationAssessment",
+    "RayDataLLMStageCandidate",
+    "RayDataLLMStageOptions",
+    "RayDataLLMStagePlan",
     "RayDatasetAnalysis",
     "RayDatasetCreationResults",
     "RayDatasetGenerationError",
@@ -70,5 +77,6 @@ __all__ = [
     "RayWorkerMetrics",
     "RayWorkerProfile",
     "assess_ray_data_llm_integration",
+    "plan_ray_data_llm_stage",
     "probe_ray_data_llm_capabilities",
 ]

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -22,6 +22,11 @@ from data_designer.engine.storage.artifact_storage import SDG_CONFIG_FILENAME, A
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.integrations.ray.artifact_output import create_data_designer_ray_datasink
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
+from data_designer.integrations.ray.llm import (
+    RayDataLLMStageOptions,
+    RayDataLLMStagePlan,
+    plan_ray_data_llm_stage,
+)
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics
 from data_designer.integrations.ray.observability import RayDatasetAnalysis
 from data_designer.integrations.ray.observability_collection import (
@@ -124,6 +129,7 @@ class RayJobPlan:
     metrics_collector: Any | None
     throttle_manager: Any | None
     observability_options: _RayObservabilityOptions
+    llm_stage_plan: RayDataLLMStagePlan
     output: RayOutputMode
     num_records: int
     input_blocks: int | None
@@ -144,9 +150,11 @@ class RayDatasetCreationResults:
         artifact_storage: ArtifactStorage | None = None,
         output: Any | None = None,
         observability_options: _RayObservabilityOptions | None = None,
+        llm_stage_plan: RayDataLLMStagePlan | None = None,
     ) -> None:
         del config_builder, observability_options
         self.artifact_storage = artifact_storage
+        self.llm_stage_plan = llm_stage_plan
         self._artifacts = RayResultArtifacts(
             dataset=dataset,
             metrics=metrics,
@@ -295,12 +303,17 @@ class RayBackend:
         artifact_write_concurrency: int | None = None,
         artifact_write_ray_remote_args: dict[str, Any] | None = None,
         distributed_artifact_writes: bool = True,
+        llm_stage_options: RayDataLLMStageOptions | None = None,
         **legacy_options: Any,
     ) -> None:
         if output not in ("dataset", "arrow_refs"):
             raise RayBackendConfigurationError("RayBackend output must be 'dataset' or 'arrow_refs'.")
         if object_ref_format not in ("arrow", "pandas"):
             raise RayBackendConfigurationError("RayBackend object_ref_format must be 'arrow' or 'pandas'.")
+        if llm_stage_options is not None and not isinstance(llm_stage_options, RayDataLLMStageOptions):
+            raise RayBackendConfigurationError(
+                "RayBackend llm_stage_options must be a RayDataLLMStageOptions instance."
+            )
         _validate_ray_backend_batch_size(batch_size)
         if order_column is not None and order_column == "":
             raise RayBackendConfigurationError("RayBackend order_column must be a non-empty string when provided.")
@@ -343,6 +356,7 @@ class RayBackend:
         self.artifact_write_concurrency = artifact_write_concurrency
         self.artifact_write_ray_remote_args = artifact_write_ray_remote_args
         self.distributed_artifact_writes = distributed_artifact_writes
+        self.llm_stage_options = llm_stage_options or RayDataLLMStageOptions()
 
     def create(
         self,
@@ -432,6 +446,7 @@ class RayBackend:
             artifact_storage=artifact_storage,
             output=output,
             observability_options=plan.observability_options,
+            llm_stage_plan=plan.llm_stage_plan,
         )
 
     def _execute_plan(
@@ -648,6 +663,11 @@ class RayDriverPlanner:
             max_throttle_snapshots=self._backend.max_throttle_snapshots,
         )
         throttle_manager = self._create_throttle_manager(runtime_context, config_builder)
+        llm_stage_plan = plan_ray_data_llm_stage(
+            config_builder=config_builder,
+            options=self._backend.llm_stage_options,
+        )
+        _validate_llm_stage_plan(llm_stage_plan)
         worker_config_builder = _clone_config_builder_for_worker(
             config_builder,
             worker_model_health_checks=self._backend.worker_model_health_checks,
@@ -712,6 +732,7 @@ class RayDriverPlanner:
             metrics_collector=metrics_collector,
             throttle_manager=throttle_manager,
             observability_options=observability_options,
+            llm_stage_plan=llm_stage_plan,
             output=self._backend.output,
             num_records=num_records,
             input_blocks=_get_num_blocks(dataset),
@@ -1052,6 +1073,16 @@ def _generate_batch(
         metrics_collector=metrics_collector,
         observability_options=observability_options,
     )(batch)
+
+
+def _validate_llm_stage_plan(plan: RayDataLLMStagePlan) -> None:
+    if not plan.enabled or plan.has_eligible_stage or plan.options.allow_model_facade_fallback:
+        return
+    reason = plan.disabled_reason or "no eligible Ray Data LLM stage candidate was found"
+    raise RayBackendConfigurationError(
+        "RayBackend Ray Data LLM stage was explicitly requested but cannot be planned: "
+        f"{reason} Set allow_model_facade_fallback=True to use the existing ModelFacade execution path."
+    )
 
 
 def _import_ray() -> Any:

--- a/packages/data-designer/src/data_designer/integrations/ray/llm.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/llm.py
@@ -4,15 +4,29 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Mapping
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
-from typing import Literal
+from typing import Any, Literal
+
+from data_designer.config.column_configs import EmbeddingColumnConfig, LLMTextColumnConfig, TraceType
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.integrations.ray.errors import RayBackendConfigurationError
 
 RayDataLLMPlacement = Literal["ray-backend-stage-optimization"]
+RayDataLLMTaskType = Literal["generate", "embed", "classify", "score"]
+RayDataLLMStageStatus = Literal["disabled", "unavailable", "eligible", "ineligible"]
 
 _REQUIRED_RAY_DATA_LLM_SYMBOLS = ("build_processor", "vLLMEngineProcessorConfig")
 _SUPPORTED_TASK_TYPES = ("generate", "embed", "classify", "score")
 _RECOMMENDED_PLACEMENT: RayDataLLMPlacement = "ray-backend-stage-optimization"
+_DEFAULT_SEMANTIC_CONTRACT = (
+    "The prototype hook is planning-only; selected stages still execute through the existing ModelFacade path.",
+    "Usage stats remain the ModelFacade source of truth until Ray Data LLM responses are normalized into model usage deltas.",
+    "Ray Data LLM execution must wrap Ray/vLLM exceptions in RayDatasetGenerationError before it replaces a worker stage.",
+    "Ordering and dropped-row semantics must remain owned by RayBackend ordering and row-count validation.",
+    "Artifact and observability output must use existing RayBackend artifact columns, metrics, and dataset analysis payloads.",
+)
 _RECOMMENDATION = (
     "Keep Ray Data LLM/vLLM behind the Ray integration as an optional stage optimization. "
     "Do not model it as a general ModelProvider until DataDesigner can preserve ModelFacade semantics "
@@ -28,8 +42,71 @@ _BLOCKING_GAPS = (
 )
 _SAFE_FIRST_SLICE = (
     "Detect Ray Data LLM availability and keep external providers on the existing OpenAI-compatible facade. "
-    "A future prototype can add a RayBackend-only stage for eligible chat or embedding columns."
+    "A future prototype can add a RayBackend-only stage for one eligible independent LLM text column."
 )
+
+
+@dataclass(frozen=True, slots=True)
+class RayDataLLMStageOptions:
+    """Explicit opt-in controls for the RayBackend Ray Data LLM/vLLM prototype hook."""
+
+    enabled: bool = False
+    model_source: str | None = None
+    column_names: tuple[str, ...] = ()
+    model_aliases: tuple[str, ...] = ()
+    task_type: RayDataLLMTaskType = "generate"
+    batch_size: int | None = None
+    concurrency: int | tuple[int, int] | tuple[int, int, int] | None = None
+    engine_kwargs: Mapping[str, Any] | None = None
+    dynamic_lora_loading_path: str | None = None
+    allow_model_facade_fallback: bool = True
+
+    def __post_init__(self) -> None:
+        _validate_bool("enabled", self.enabled)
+        _validate_optional_non_empty_string("model_source", self.model_source)
+        _validate_non_empty_string_tuple("column_names", self.column_names)
+        _validate_non_empty_string_tuple("model_aliases", self.model_aliases)
+        if self.task_type not in _SUPPORTED_TASK_TYPES:
+            raise RayBackendConfigurationError(
+                f"RayDataLLMStageOptions task_type must be one of {_SUPPORTED_TASK_TYPES!r}."
+            )
+        _validate_optional_positive_int("batch_size", self.batch_size)
+        _validate_optional_concurrency(self.concurrency)
+        if self.engine_kwargs is not None and not isinstance(self.engine_kwargs, Mapping):
+            raise RayBackendConfigurationError("RayDataLLMStageOptions engine_kwargs must be a mapping.")
+        _validate_optional_non_empty_string("dynamic_lora_loading_path", self.dynamic_lora_loading_path)
+        _validate_bool("allow_model_facade_fallback", self.allow_model_facade_fallback)
+        if self.enabled and self.model_source is None:
+            raise RayBackendConfigurationError(
+                "RayDataLLMStageOptions enabled=True requires model_source for the local vLLM engine."
+            )
+        if self.enabled and not self.column_names and not self.model_aliases:
+            raise RayBackendConfigurationError(
+                "RayDataLLMStageOptions enabled=True requires column_names or model_aliases."
+            )
+
+    @property
+    def has_explicit_opt_in(self) -> bool:
+        """Return whether the RayBackend should evaluate Ray Data LLM stage eligibility."""
+        return self.enabled
+
+    def processor_config_kwargs(self) -> dict[str, Any]:
+        """Return Ray Data LLM processor config kwargs for a future execution stage."""
+        if self.model_source is None:
+            return {}
+        kwargs: dict[str, Any] = {
+            "model_source": self.model_source,
+            "task_type": self.task_type,
+        }
+        if self.batch_size is not None:
+            kwargs["batch_size"] = self.batch_size
+        if self.concurrency is not None:
+            kwargs["concurrency"] = self.concurrency
+        if self.engine_kwargs is not None:
+            kwargs["engine_kwargs"] = dict(self.engine_kwargs)
+        if self.dynamic_lora_loading_path is not None:
+            kwargs["dynamic_lora_loading_path"] = self.dynamic_lora_loading_path
+        return kwargs
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,6 +144,45 @@ class RayDataLLMIntegrationAssessment:
     broad_integration_ready: bool
     safe_first_slice: str
     blocking_gaps: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RayDataLLMStageCandidate:
+    """Planning result for one model-generated column considered for Ray Data LLM."""
+
+    column_name: str
+    model_alias: str | None
+    task_type: RayDataLLMTaskType
+    model_source: str | None
+    blocked_reasons: tuple[str, ...] = ()
+
+    @property
+    def eligible(self) -> bool:
+        """Return whether this column can use the future Ray Data LLM stage."""
+        return not self.blocked_reasons
+
+
+@dataclass(frozen=True, slots=True)
+class RayDataLLMStagePlan:
+    """RayBackend-only planning record for the optional Ray Data LLM stage."""
+
+    status: RayDataLLMStageStatus
+    options: RayDataLLMStageOptions
+    capabilities: RayDataLLMCapabilities | None
+    candidates: tuple[RayDataLLMStageCandidate, ...]
+    selected_candidate: RayDataLLMStageCandidate | None
+    disabled_reason: str | None
+    semantic_contract: tuple[str, ...] = _DEFAULT_SEMANTIC_CONTRACT
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether the user explicitly enabled Ray Data LLM planning."""
+        return self.options.enabled
+
+    @property
+    def has_eligible_stage(self) -> bool:
+        """Return whether the planner found exactly one executable prototype stage."""
+        return self.selected_candidate is not None
 
 
 def probe_ray_data_llm_capabilities() -> RayDataLLMCapabilities:
@@ -115,8 +231,177 @@ def assess_ray_data_llm_integration(
     )
 
 
+def plan_ray_data_llm_stage(
+    *,
+    config_builder: DataDesignerConfigBuilder,
+    options: RayDataLLMStageOptions,
+    capabilities: RayDataLLMCapabilities | None = None,
+) -> RayDataLLMStagePlan:
+    """Plan the RayBackend-only Ray Data LLM prototype stage without executing it."""
+    if not options.has_explicit_opt_in:
+        return RayDataLLMStagePlan(
+            status="disabled",
+            options=options,
+            capabilities=None,
+            candidates=(),
+            selected_candidate=None,
+            disabled_reason="Ray Data LLM stage planning is disabled.",
+        )
+
+    resolved_capabilities = capabilities or probe_ray_data_llm_capabilities()
+    if not resolved_capabilities.supports_local_vllm:
+        return RayDataLLMStagePlan(
+            status="unavailable",
+            options=options,
+            capabilities=resolved_capabilities,
+            candidates=(),
+            selected_candidate=None,
+            disabled_reason="Ray Data LLM local vLLM processor APIs are unavailable.",
+        )
+
+    candidates = tuple(
+        candidate
+        for column_config in config_builder.get_column_configs()
+        if (candidate := _assess_stage_candidate(column_config, options)) is not None
+    )
+    eligible_candidates = tuple(candidate for candidate in candidates if candidate.eligible)
+    if len(eligible_candidates) == 1:
+        return RayDataLLMStagePlan(
+            status="eligible",
+            options=options,
+            capabilities=resolved_capabilities,
+            candidates=candidates,
+            selected_candidate=eligible_candidates[0],
+            disabled_reason=None,
+        )
+    disabled_reason = (
+        "Ray Data LLM prototype requires exactly one eligible independent LLM text column."
+        if eligible_candidates
+        else "No eligible Ray Data LLM stage candidate was found."
+    )
+    return RayDataLLMStagePlan(
+        status="ineligible",
+        options=options,
+        capabilities=resolved_capabilities,
+        candidates=candidates,
+        selected_candidate=None,
+        disabled_reason=disabled_reason,
+    )
+
+
 def _package_version(package_name: str) -> str | None:
     try:
         return version(package_name)
     except PackageNotFoundError:
         return None
+
+
+def _assess_stage_candidate(column_config: Any, options: RayDataLLMStageOptions) -> RayDataLLMStageCandidate | None:
+    model_alias = getattr(column_config, "model_alias", None)
+    column_name = getattr(column_config, "name", None)
+    if not _matches_explicit_selection(column_name=column_name, model_alias=model_alias, options=options):
+        return None
+
+    blocked_reasons: list[str] = []
+    if type(column_config) is LLMTextColumnConfig:
+        blocked_reasons.extend(_text_stage_blocked_reasons(column_config, options))
+    elif isinstance(column_config, EmbeddingColumnConfig):
+        blocked_reasons.extend(_embedding_stage_blocked_reasons(column_config, options))
+    else:
+        blocked_reasons.append(
+            "Only LLMTextColumnConfig and EmbeddingColumnConfig are supported by this prototype slice."
+        )
+    return RayDataLLMStageCandidate(
+        column_name=str(column_name),
+        model_alias=str(model_alias) if model_alias is not None else None,
+        task_type=options.task_type,
+        model_source=options.model_source,
+        blocked_reasons=tuple(blocked_reasons),
+    )
+
+
+def _matches_explicit_selection(
+    *,
+    column_name: Any,
+    model_alias: Any,
+    options: RayDataLLMStageOptions,
+) -> bool:
+    if options.column_names and column_name not in options.column_names:
+        return False
+    if options.model_aliases and model_alias not in options.model_aliases:
+        return False
+    return bool(options.column_names or options.model_aliases)
+
+
+def _text_stage_blocked_reasons(
+    column_config: LLMTextColumnConfig,
+    options: RayDataLLMStageOptions,
+) -> list[str]:
+    blocked_reasons: list[str] = []
+    if options.task_type != "generate":
+        blocked_reasons.append("LLMTextColumnConfig requires task_type='generate'.")
+    if column_config.required_columns:
+        blocked_reasons.append("The prototype supports only independent text columns with no prompt dependencies.")
+    if column_config.tool_alias is not None:
+        blocked_reasons.append("MCP tool calls are not supported by the Ray Data LLM stage prototype.")
+    if column_config.multi_modal_context:
+        blocked_reasons.append("Multi-modal context is not supported by the Ray Data LLM stage prototype.")
+    if column_config.with_trace != TraceType.NONE:
+        blocked_reasons.append("Trace side-effect columns are not supported by the Ray Data LLM stage prototype.")
+    if column_config.extract_reasoning_content:
+        blocked_reasons.append(
+            "Reasoning-content side-effect columns are not supported by the Ray Data LLM stage prototype."
+        )
+    return blocked_reasons
+
+
+def _embedding_stage_blocked_reasons(
+    column_config: EmbeddingColumnConfig,
+    options: RayDataLLMStageOptions,
+) -> list[str]:
+    blocked_reasons: list[str] = []
+    del column_config
+    if options.task_type != "embed":
+        blocked_reasons.append("EmbeddingColumnConfig requires task_type='embed'.")
+    return blocked_reasons
+
+
+def _validate_bool(field_name: str, value: bool) -> None:
+    if not isinstance(value, bool):
+        raise RayBackendConfigurationError(f"RayDataLLMStageOptions {field_name} must be a boolean.")
+
+
+def _validate_optional_non_empty_string(field_name: str, value: str | None) -> None:
+    if value is not None and (not isinstance(value, str) or not value):
+        raise RayBackendConfigurationError(f"RayDataLLMStageOptions {field_name} must be a non-empty string.")
+
+
+def _validate_non_empty_string_tuple(field_name: str, value: tuple[str, ...]) -> None:
+    if not isinstance(value, tuple):
+        raise RayBackendConfigurationError(f"RayDataLLMStageOptions {field_name} must be a tuple of strings.")
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise RayBackendConfigurationError(
+                f"RayDataLLMStageOptions {field_name} must contain only non-empty strings."
+            )
+
+
+def _validate_optional_positive_int(field_name: str, value: int | None) -> None:
+    if value is not None and (isinstance(value, bool) or not isinstance(value, int) or value <= 0):
+        raise RayBackendConfigurationError(f"RayDataLLMStageOptions {field_name} must be a positive integer.")
+
+
+def _validate_optional_concurrency(value: int | tuple[int, int] | tuple[int, int, int] | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, int):
+        _validate_optional_positive_int("concurrency", value)
+        return
+    if not isinstance(value, tuple) or len(value) not in (2, 3):
+        raise RayBackendConfigurationError(
+            "RayDataLLMStageOptions concurrency must be a positive integer or a 2/3-item tuple."
+        )
+    for item in value:
+        _validate_optional_positive_int("concurrency", item)
+    if value[0] > value[1]:
+        raise RayBackendConfigurationError("RayDataLLMStageOptions concurrency minimum must not exceed maximum.")

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -35,6 +35,7 @@ from data_designer.integrations.ray import (
     RayBlockPlanning,
     RayDataCheckpointConfig,
     RayDataContextOptions,
+    RayDataLLMStageOptions,
     RayDatasetCreationResults,
     RayDatasetGenerationError,
     RayDatasetMetrics,
@@ -1306,6 +1307,74 @@ def test_ray_backend_leaves_local_provider_actor_pool_sizing_explicit(
 def test_ray_backend_rejects_actor_pool_with_map_concurrency() -> None:
     with pytest.raises(RayBackendConfigurationError, match="use_actor_pool"):
         RayBackend(use_actor_pool=True, map_concurrency=2)
+
+
+def test_ray_backend_exposes_llm_stage_plan_with_facade_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+
+    def generate_batch(batch: lazy.pd.DataFrame, **_: Any) -> lazy.pd.DataFrame:
+        return batch
+
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            preflight_model_health_check=False,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                model_source="local-model",
+                column_names=("text",),
+            ),
+        ),
+    )
+
+    results = designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert results.llm_stage_plan is not None
+    assert results.llm_stage_plan.enabled is True
+    assert results.llm_stage_plan.status in {"unavailable", "eligible"}
+    assert input_dataset.map_batches_kwargs is not None
+
+
+def test_ray_backend_llm_stage_can_fail_fast_when_fallback_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            preflight_model_health_check=False,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                model_source="local-model",
+                column_names=("missing_text_column",),
+                allow_model_facade_fallback=False,
+            ),
+        ),
+    )
+
+    with pytest.raises(RayBackendConfigurationError, match="Ray Data LLM stage"):
+        designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is None
 
 
 def test_ray_backend_driver_model_health_check_runs_once_and_workers_skip_by_default(

--- a/packages/data-designer/tests/integrations/ray/test_llm.py
+++ b/packages/data-designer/tests/integrations/ray/test_llm.py
@@ -8,7 +8,11 @@ from typing import Any
 
 import pytest
 
+from data_designer.config.column_configs import EmbeddingColumnConfig, LLMTextColumnConfig, TraceType
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.models import ChatCompletionInferenceParams, EmbeddingInferenceParams, ModelConfig
 from data_designer.integrations.ray import llm as ray_llm
+from data_designer.integrations.ray.errors import RayBackendConfigurationError
 
 pytestmark = pytest.mark.ray_fake
 
@@ -77,3 +81,192 @@ def test_assess_ray_data_llm_integration_keeps_vllm_out_of_provider_abstraction(
     assert assessment.broad_integration_ready is False
     assert "Do not model it as a general ModelProvider" in assessment.recommendation
     assert any("ModelFacade contracts" in gap for gap in assessment.blocking_gaps)
+
+
+def test_ray_data_llm_stage_options_require_explicit_model_source() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="model_source"):
+        ray_llm.RayDataLLMStageOptions(enabled=True, column_names=("summary",))
+
+
+def test_ray_data_llm_stage_options_build_processor_config_kwargs() -> None:
+    options = ray_llm.RayDataLLMStageOptions(
+        enabled=True,
+        model_source="local-model",
+        column_names=("summary",),
+        batch_size=8,
+        concurrency=(1, 2),
+        engine_kwargs={"tensor_parallel_size": 2},
+        dynamic_lora_loading_path="/models/lora",
+    )
+
+    assert options.processor_config_kwargs() == {
+        "model_source": "local-model",
+        "task_type": "generate",
+        "batch_size": 8,
+        "concurrency": (1, 2),
+        "engine_kwargs": {"tensor_parallel_size": 2},
+        "dynamic_lora_loading_path": "/models/lora",
+    }
+
+
+def test_plan_ray_data_llm_stage_stays_disabled_without_opt_in() -> None:
+    plan = ray_llm.plan_ray_data_llm_stage(
+        config_builder=_text_config_builder(),
+        options=ray_llm.RayDataLLMStageOptions(),
+        capabilities=_available_capabilities(),
+    )
+
+    assert plan.status == "disabled"
+    assert plan.selected_candidate is None
+    assert plan.disabled_reason is not None
+    assert plan.capabilities is None
+
+
+def test_plan_ray_data_llm_stage_marks_unavailable_when_optional_surface_is_missing() -> None:
+    capabilities = ray_llm.RayDataLLMCapabilities(
+        available=False,
+        ray_version="2.55.1",
+        missing_symbols=("build_processor", "vLLMEngineProcessorConfig"),
+        has_build_processor=False,
+        has_vllm_engine_processor=False,
+        has_http_request_processor=False,
+        has_serve_deployment_processor=False,
+        import_error="ModuleNotFoundError: boto3",
+    )
+
+    plan = ray_llm.plan_ray_data_llm_stage(
+        config_builder=_text_config_builder(),
+        options=ray_llm.RayDataLLMStageOptions(
+            enabled=True,
+            model_source="local-model",
+            column_names=("summary",),
+        ),
+        capabilities=capabilities,
+    )
+
+    assert plan.status == "unavailable"
+    assert plan.capabilities is capabilities
+    assert plan.candidates == ()
+    assert plan.selected_candidate is None
+
+
+def test_plan_ray_data_llm_stage_selects_single_independent_text_column() -> None:
+    plan = ray_llm.plan_ray_data_llm_stage(
+        config_builder=_text_config_builder(),
+        options=ray_llm.RayDataLLMStageOptions(
+            enabled=True,
+            model_source="local-model",
+            column_names=("summary",),
+        ),
+        capabilities=_available_capabilities(),
+    )
+
+    assert plan.status == "eligible"
+    assert plan.selected_candidate is not None
+    assert plan.selected_candidate.column_name == "summary"
+    assert plan.selected_candidate.model_alias == "text-model"
+    assert plan.selected_candidate.task_type == "generate"
+    assert plan.selected_candidate.blocked_reasons == ()
+
+
+def test_plan_ray_data_llm_stage_reports_text_column_semantic_blockers() -> None:
+    config_builder = DataDesignerConfigBuilder(
+        model_configs=[
+            ModelConfig(
+                alias="text-model",
+                model="local-model",
+                inference_parameters=ChatCompletionInferenceParams(),
+            )
+        ]
+    )
+    config_builder.add_column(
+        LLMTextColumnConfig(
+            name="summary",
+            prompt="Summarize {{ source_text }}.",
+            model_alias="text-model",
+            with_trace=TraceType.LAST_MESSAGE,
+        )
+    )
+
+    plan = ray_llm.plan_ray_data_llm_stage(
+        config_builder=config_builder,
+        options=ray_llm.RayDataLLMStageOptions(
+            enabled=True,
+            model_source="local-model",
+            column_names=("summary",),
+        ),
+        capabilities=_available_capabilities(),
+    )
+
+    assert plan.status == "ineligible"
+    assert plan.selected_candidate is None
+    assert len(plan.candidates) == 1
+    assert any("prompt dependencies" in reason for reason in plan.candidates[0].blocked_reasons)
+    assert any("Trace side-effect" in reason for reason in plan.candidates[0].blocked_reasons)
+
+
+def test_plan_ray_data_llm_stage_selects_embedding_column_with_embed_task() -> None:
+    config_builder = DataDesignerConfigBuilder(
+        model_configs=[
+            ModelConfig(
+                alias="embedding-model",
+                model="local-embedding-model",
+                inference_parameters=EmbeddingInferenceParams(),
+            )
+        ]
+    )
+    config_builder.add_column(
+        EmbeddingColumnConfig(
+            name="text_embedding",
+            target_column="source_text",
+            model_alias="embedding-model",
+        )
+    )
+
+    plan = ray_llm.plan_ray_data_llm_stage(
+        config_builder=config_builder,
+        options=ray_llm.RayDataLLMStageOptions(
+            enabled=True,
+            model_source="local-embedding-model",
+            model_aliases=("embedding-model",),
+            task_type="embed",
+        ),
+        capabilities=_available_capabilities(),
+    )
+
+    assert plan.status == "eligible"
+    assert plan.selected_candidate is not None
+    assert plan.selected_candidate.column_name == "text_embedding"
+    assert plan.selected_candidate.task_type == "embed"
+
+
+def _available_capabilities() -> ray_llm.RayDataLLMCapabilities:
+    return ray_llm.RayDataLLMCapabilities(
+        available=True,
+        ray_version="2.55.1",
+        missing_symbols=(),
+        has_build_processor=True,
+        has_vllm_engine_processor=True,
+        has_http_request_processor=True,
+        has_serve_deployment_processor=True,
+    )
+
+
+def _text_config_builder() -> DataDesignerConfigBuilder:
+    config_builder = DataDesignerConfigBuilder(
+        model_configs=[
+            ModelConfig(
+                alias="text-model",
+                model="local-model",
+                inference_parameters=ChatCompletionInferenceParams(),
+            )
+        ]
+    )
+    config_builder.add_column(
+        LLMTextColumnConfig(
+            name="summary",
+            prompt="Summarize briefly.",
+            model_alias="text-model",
+        )
+    )
+    return config_builder

--- a/packages/data-designer/tests/integrations/ray/test_public_api.py
+++ b/packages/data-designer/tests/integrations/ray/test_public_api.py
@@ -21,6 +21,9 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayDataContextOptions",
         "RayDataLLMCapabilities",
         "RayDataLLMIntegrationAssessment",
+        "RayDataLLMStageCandidate",
+        "RayDataLLMStageOptions",
+        "RayDataLLMStagePlan",
         "RayDatasetAnalysis",
         "RayDatasetCreationResults",
         "RayDatasetGenerationError",
@@ -36,6 +39,7 @@ def test_ray_package_root_exports_stable_public_api() -> None:
         "RayWorkerMetrics",
         "RayWorkerProfile",
         "assess_ray_data_llm_integration",
+        "plan_ray_data_llm_stage",
         "probe_ray_data_llm_capabilities",
     }
 


### PR DESCRIPTION
## 📋 Summary

Adds an explicit RayBackend planning hook for the Ray Data LLM/vLLM optimization path tracked by #118. The hook detects whether a requested local vLLM stage is available and semantically eligible, exposes the plan on Ray results, and lets users fail fast instead of silently falling back to the existing ModelFacade path.

## 🔗 Related Issue

Part of #118

## 🔄 Changes

- Adds `RayDataLLMStageOptions`, `RayDataLLMStagePlan`, and candidate eligibility planning for one explicit local Ray Data LLM stage.
- Supports eligibility checks for independent `LLMTextColumnConfig` generation and embedding columns while rejecting unsupported traces, tools, multimodal context, prompt dependencies, and mismatched task types.
- Threads the resolved plan through `RayBackend` and exposes it as `RayDatasetCreationResults.llm_stage_plan`.
- Adds `allow_model_facade_fallback=False` fail-fast behavior when an explicitly requested Ray Data LLM stage cannot be planned.
- Updates `architecture/ray-data-llm.md` and the Ray public API exports.

## 🧪 Testing

- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray118-rebase-test uv run --all-packages pytest packages/data-designer/tests/integrations/ray/test_llm.py packages/data-designer/tests/integrations/ray/test_public_api.py packages/data-designer/tests/integrations/ray/test_backend.py -q -m ray_fake` (95 passed)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray118-rebase-ruff uv run --all-packages ruff check architecture/ray-data-llm.md packages/data-designer/src/data_designer/integrations/ray/llm.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/test_llm.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_public_api.py`
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-ray118-format uv run --all-packages ruff format --check packages/data-designer/src/data_designer/integrations/ray/llm.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/src/data_designer/integrations/ray/__init__.py packages/data-designer/tests/integrations/ray/test_llm.py packages/data-designer/tests/integrations/ray/test_backend.py packages/data-designer/tests/integrations/ray/test_public_api.py`
- [x] Real-Ray mock provider smoke with the planning hook disabled by default: 8 rows, 8/8 requests successful, all output valid

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated