### PR TITLE
feat(ray): stream engine block chunks

### DIFF
--- a/docs/concepts/ray-backend.md
+++ b/docs/concepts/ray-backend.md
@@ -36,6 +36,20 @@ artifacts/
 
 `distributed_artifact_writes=True` is the default. Use a cluster-visible artifact path when running Ray workers on multiple nodes, or set `distributed_artifact_writes=False` to force Ray Data write tasks onto the driver node.
 
+## Streaming Worker Chunks
+
+Set `output_chunk_rows` to have Ray workers emit generated output in smaller Ray Data chunks. For partition-local jobs without artifact capture, RayBackend now uses the engine async row-group path, so a worker can release each generated row group instead of first materializing the full `map_batches` output frame. If processor artifacts are being captured, or if hidden ordering would need to reconcile row-count-changing output, RayBackend falls back to the older materialized chunking path to preserve artifacts and ordering semantics.
+
+```python
+backend = RayBackend(
+    batch_size=4096,
+    output_chunk_rows=512,
+    output="dataset",
+)
+```
+
+The `scripts/benchmarks/benchmark_ray_streaming_out_of_core.py` benchmark accepts `--output-chunk-rows` to exercise this path against Ray Data streaming reads and Parquet writes.
+
 ## Actor Pool Defaults
 
 `RayBackend` uses provider-aware actor-pool defaults for model-generated columns. If you do not pass

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py
@@ -17,7 +17,7 @@ from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import SeedConfig
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
-from data_designer.engine.dataset_builders.dataset_builder import DatasetBuilder
+from data_designer.engine.dataset_builders.dataset_builder import DatasetBlockChunk, DatasetBuilder
 from data_designer.engine.dataset_builders.errors import DatasetGenerationError
 from data_designer.engine.errors import DataDesignerError
 from data_designer.engine.model_provider import resolve_model_provider_registry
@@ -93,6 +93,64 @@ class BlockExecutionResult:
     artifact_storage: ArtifactStorage | None = None
 
 
+@dataclass(frozen=True)
+class BlockExecutionChunk:
+    """One generated chunk from a backend block stream."""
+
+    dataframe: pd.DataFrame
+    raw_dataframe: pd.DataFrame
+    row_group: int
+    input_start: int
+    input_rows: int
+    output_rows: int
+
+
+@dataclass(frozen=True)
+class BlockExecutionStreamSummary:
+    """Summary emitted after a block chunk stream is exhausted."""
+
+    task_traces: list[TaskTrace]
+    model_usage_stats: dict[str, dict[str, Any]]
+    model_usage_deltas: dict[str, ModelUsageStats]
+    processor_artifacts: dict[str, pd.DataFrame]
+    input_rows: int
+    output_rows: int
+    dropped_rows: int
+    all_rows_dropped: bool
+    partial_rows_dropped: bool
+    artifact_storage: ArtifactStorage | None = None
+
+
+class BlockExecutionChunkStream(Iterator[BlockExecutionChunk]):
+    """Iterator returned by ``execute_dataset_block_stream``.
+
+    The final summary is available through ``summary`` after the iterator is
+    exhausted. This keeps chunk delivery streaming while preserving the metrics
+    and observability fields backends need once generation completes.
+    """
+
+    def __init__(
+        self,
+        iterator: Iterator[BlockExecutionChunk],
+        summary_holder: dict[str, BlockExecutionStreamSummary],
+    ) -> None:
+        self._iterator = iterator
+        self._summary_holder = summary_holder
+
+    def __iter__(self) -> BlockExecutionChunkStream:
+        return self
+
+    def __next__(self) -> BlockExecutionChunk:
+        return next(self._iterator)
+
+    @property
+    def summary(self) -> BlockExecutionStreamSummary:
+        try:
+            return self._summary_holder["summary"]
+        except KeyError as exc:
+            raise RuntimeError("Block execution stream summary is available only after exhaustion.") from exc
+
+
 def execute_dataset_block(
     *,
     config_builder: DataDesignerConfigBuilder | None = None,
@@ -143,6 +201,64 @@ def execute_dataset_block(
             options=block_options,
             return_storage=False,
         )
+
+
+def execute_dataset_block_stream(
+    *,
+    rows_per_chunk: int,
+    config_builder: DataDesignerConfigBuilder | None = None,
+    data_designer_config: DataDesignerConfig | None = None,
+    runtime_context: BlockRuntimeContext | None = None,
+    resource_provider: ResourceProvider | None = None,
+    input_frame: pd.DataFrame | None = None,
+    num_records: int | None = None,
+    options: BlockExecutionOptions | None = None,
+    artifact_storage: ArtifactStorage | None = None,
+) -> BlockExecutionChunkStream:
+    """Execute one backend block and stream row-group chunks as they complete."""
+    summary_holder: dict[str, BlockExecutionStreamSummary] = {}
+
+    def _iterator() -> Iterator[BlockExecutionChunk]:
+        block_options = options or BlockExecutionOptions()
+        block_builder, block_config = _resolve_block_config(
+            config_builder=config_builder,
+            data_designer_config=data_designer_config,
+            input_frame=input_frame,
+        )
+        block_num_records = _resolve_num_records(input_frame=input_frame, num_records=num_records)
+
+        if artifact_storage is not None:
+            yield from _execute_stream_with_storage(
+                data_designer_config=block_config,
+                config_builder=block_builder,
+                runtime_context=runtime_context,
+                resource_provider=resource_provider,
+                artifact_storage=artifact_storage,
+                num_records=block_num_records,
+                rows_per_chunk=rows_per_chunk,
+                options=block_options,
+                return_storage=True,
+                summary_holder=summary_holder,
+            )
+            return
+
+        with tempfile.TemporaryDirectory(prefix="data-designer-block-") as artifact_dir:
+            ArtifactStorage.mkdir_if_needed(Path(artifact_dir))
+            temp_storage = ArtifactStorage(artifact_path=artifact_dir, dataset_name=block_options.dataset_name)
+            yield from _execute_stream_with_storage(
+                data_designer_config=block_config,
+                config_builder=block_builder,
+                runtime_context=runtime_context,
+                resource_provider=resource_provider,
+                artifact_storage=temp_storage,
+                num_records=block_num_records,
+                rows_per_chunk=rows_per_chunk,
+                options=block_options,
+                return_storage=False,
+                summary_holder=summary_holder,
+            )
+
+    return BlockExecutionChunkStream(_iterator(), summary_holder)
 
 
 def _resolve_block_config(
@@ -231,6 +347,80 @@ def _execute_with_storage(
         raise
     except Exception as exc:
         raise DatasetGenerationError(f"🛑 Failed to execute dataset block: {exc}") from exc
+
+
+def _execute_stream_with_storage(
+    *,
+    data_designer_config: DataDesignerConfig,
+    config_builder: DataDesignerConfigBuilder | None,
+    runtime_context: BlockRuntimeContext | None,
+    resource_provider: ResourceProvider | None,
+    artifact_storage: ArtifactStorage,
+    num_records: int,
+    rows_per_chunk: int,
+    options: BlockExecutionOptions,
+    return_storage: bool,
+    summary_holder: dict[str, BlockExecutionStreamSummary],
+) -> Iterator[BlockExecutionChunk]:
+    if (runtime_context is None) == (resource_provider is None):
+        raise ValueError("Provide exactly one of runtime_context or resource_provider.")
+
+    start_time = time.perf_counter()
+    output_rows = 0
+    try:
+        with _async_engine_environment(options.use_async):
+            block_resource_provider = resource_provider or _create_resource_provider(
+                config_builder=config_builder,
+                data_designer_config=data_designer_config,
+                runtime_context=runtime_context,
+                artifact_storage=artifact_storage,
+            )
+            usage_snapshot = block_resource_provider.model_registry.get_model_usage_snapshot()
+            builder = DatasetBuilder(
+                data_designer_config=data_designer_config,
+                resource_provider=block_resource_provider,
+                use_async=options.use_async,
+            )
+            for chunk in builder.build_block_chunks(
+                num_records=num_records,
+                rows_per_chunk=rows_per_chunk,
+                current_batch_number=options.current_batch_number,
+            ):
+                output_rows += len(chunk.dataframe)
+                yield _block_execution_chunk(chunk)
+
+            elapsed = time.perf_counter() - start_time
+            model_usage_stats = block_resource_provider.model_registry.get_model_usage_stats(elapsed)
+            model_usage_deltas = block_resource_provider.model_registry.get_usage_deltas(usage_snapshot)
+            processor_artifacts = _load_processor_artifacts(artifact_storage)
+            dropped_rows = max(num_records - output_rows, 0)
+            summary_holder["summary"] = BlockExecutionStreamSummary(
+                task_traces=builder.task_traces,
+                model_usage_stats=model_usage_stats,
+                model_usage_deltas=model_usage_deltas,
+                processor_artifacts=processor_artifacts,
+                input_rows=num_records,
+                output_rows=output_rows,
+                dropped_rows=dropped_rows,
+                all_rows_dropped=num_records > 0 and output_rows == 0,
+                partial_rows_dropped=0 < output_rows < num_records,
+                artifact_storage=artifact_storage if return_storage else None,
+            )
+    except DataDesignerError:
+        raise
+    except Exception as exc:
+        raise DatasetGenerationError(f"🛑 Failed to execute dataset block stream: {exc}") from exc
+
+
+def _block_execution_chunk(chunk: DatasetBlockChunk) -> BlockExecutionChunk:
+    return BlockExecutionChunk(
+        dataframe=chunk.dataframe,
+        raw_dataframe=chunk.raw_dataframe,
+        row_group=chunk.row_group,
+        input_start=chunk.input_start,
+        input_rows=chunk.input_rows,
+        output_rows=len(chunk.dataframe),
+    )
 
 
 def _create_resource_provider(

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py
@@ -7,12 +7,14 @@ import contextlib
 import functools
 import logging
 import os
+import queue
 import sys
 import time
 import uuid
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import CustomColumnConfig
@@ -112,6 +114,17 @@ def _ensure_async_engine_available() -> None:
 
 
 _CLIENT_VERSION: str = get_library_version()
+
+
+@dataclass(frozen=True)
+class DatasetBlockChunk:
+    """One generated block chunk emitted by the engine streaming path."""
+
+    raw_dataframe: pd.DataFrame
+    dataframe: pd.DataFrame
+    row_group: int
+    input_start: int
+    input_rows: int
 
 
 def _is_async_trace_enabled(settings: RunConfig) -> bool:
@@ -484,10 +497,183 @@ class DatasetBuilder:
         raw_dataset = self.build_preview(num_records=num_records)
         return raw_dataset, self.process_block(raw_dataset, current_batch_number=current_batch_number)
 
+    def build_block_chunks(
+        self,
+        *,
+        num_records: int,
+        rows_per_chunk: int,
+        current_batch_number: int | None = None,
+    ) -> Iterator[DatasetBlockChunk]:
+        """Build one block as ordered chunks when the async engine can stream row groups.
+
+        If global after-generation processors or sync-only compatibility constraints
+        prevent row-group streaming, this falls back to the existing materialized
+        block path so processor semantics stay identical.
+        """
+        if isinstance(rows_per_chunk, bool) or rows_per_chunk <= 0:
+            raise ValueError("rows_per_chunk must be a positive integer.")
+
+        if self._processor_runner.has_processors_for(ProcessorStage.AFTER_GENERATION):
+            raw_dataset, dataset = self.build_block(
+                num_records=num_records,
+                current_batch_number=current_batch_number,
+            )
+            yield DatasetBlockChunk(
+                raw_dataframe=raw_dataset,
+                dataframe=dataset,
+                row_group=0,
+                input_start=0,
+                input_rows=num_records,
+            )
+            return
+
+        self._run_model_health_check_if_needed()
+        self._run_mcp_tool_check_if_needed()
+
+        if self._has_image_columns():
+            self.artifact_storage.set_media_storage_mode(StorageMode.DATAFRAME)
+
+        generators, self._graph = self._initialize_generators_and_graph()
+        self._use_async = self._resolve_async_selection()
+        if not self._use_async:
+            raw_dataset, dataset = self._build_sync_block_with_initialized_generators(
+                generators=generators,
+                num_records=num_records,
+                current_batch_number=current_batch_number,
+            )
+            yield DatasetBlockChunk(
+                raw_dataframe=raw_dataset,
+                dataframe=dataset,
+                row_group=0,
+                input_start=0,
+                input_rows=num_records,
+            )
+            return
+
+        yield from self._build_async_block_chunks(
+            generators,
+            num_records=num_records,
+            rows_per_chunk=rows_per_chunk,
+            current_batch_number=current_batch_number,
+        )
+
     def process_block(self, dataset: pd.DataFrame, *, current_batch_number: int | None = None) -> pd.DataFrame:
         """Run post-batch and after-generation processors for an in-memory block."""
         df = self._processor_runner.run_post_batch(dataset.copy(), current_batch_number=current_batch_number)
         return self._processor_runner.run_after_generation_on_df(df)
+
+    def _build_sync_block_with_initialized_generators(
+        self,
+        *,
+        generators: list[ColumnGenerator],
+        num_records: int,
+        current_batch_number: int | None,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Run the sync preview path after callers have initialized generators."""
+        group_id = uuid.uuid4().hex
+        start_time = time.perf_counter()
+        self.batch_manager.start(num_records=num_records, buffer_size=num_records)
+        self._run_batch(generators, batch_mode="preview", save_partial_results=False, group_id=group_id)
+        raw_dataset = self.batch_manager.get_current_batch(as_dataframe=True)
+        self.batch_manager.reset()
+        self._resource_provider.model_registry.log_model_usage(time.perf_counter() - start_time)
+        return raw_dataset, self.process_block(raw_dataset, current_batch_number=current_batch_number)
+
+    def _build_async_block_chunks(
+        self,
+        generators: list[ColumnGenerator],
+        *,
+        num_records: int,
+        rows_per_chunk: int,
+        current_batch_number: int | None,
+    ) -> Iterator[DatasetBlockChunk]:
+        """Async block path that emits row groups as soon as they finalize."""
+        if num_records == 0:
+            return
+
+        logger.info("⚡ DATA_DESIGNER_ASYNC_ENGINE is enabled - using async task-queue block streaming")
+
+        settings = self._resource_provider.run_config
+        trace_enabled = _is_async_trace_enabled(settings)
+        start_time = time.perf_counter()
+        chunk_queue: queue.Queue[DatasetBlockChunk | BaseException] = queue.Queue()
+        row_group_count = (num_records + rows_per_chunk - 1) // rows_per_chunk
+
+        def finalize_row_group(rg_id: int) -> None:
+            try:
+                raw_df = buffer_manager.get_dataframe(rg_id)
+                processed_df = self._processor_runner.run_post_batch(
+                    raw_df.copy(),
+                    current_batch_number=current_batch_number,
+                )
+                chunk_queue.put(
+                    DatasetBlockChunk(
+                        raw_dataframe=raw_df,
+                        dataframe=processed_df,
+                        row_group=rg_id,
+                        input_start=rg_id * rows_per_chunk,
+                        input_rows=min(rows_per_chunk, num_records - rg_id * rows_per_chunk),
+                    )
+                )
+            except DatasetGenerationError as exc:
+                chunk_queue.put(exc)
+                raise
+            except Exception as exc:
+                wrapped = DatasetGenerationError(f"Post-batch processor failed for row group {rg_id}: {exc}")
+                chunk_queue.put(wrapped)
+                raise wrapped from exc
+            finally:
+                buffer_manager.free_row_group(rg_id)
+
+        scheduler, buffer_manager = self._prepare_async_run(
+            generators,
+            num_records,
+            rows_per_chunk,
+            on_finalize_row_group=finalize_row_group,
+            run_post_batch_in_scheduler=False,
+            shutdown_error_rate=settings.shutdown_error_rate,
+            shutdown_error_window=settings.shutdown_error_window,
+            disable_early_shutdown=settings.disable_early_shutdown,
+            trace=trace_enabled,
+        )
+
+        loop = ensure_async_engine_loop()
+        future = asyncio.run_coroutine_threadsafe(scheduler.run(), loop)
+        pending: dict[int, DatasetBlockChunk] = {}
+        next_row_group = 0
+        try:
+            while next_row_group < row_group_count:
+                if next_row_group in pending:
+                    yield pending.pop(next_row_group)
+                    next_row_group += 1
+                    continue
+
+                if future.done() and chunk_queue.empty():
+                    future.result()
+                    next_row_group += 1
+                    continue
+
+                try:
+                    item = chunk_queue.get(timeout=0.05)
+                except queue.Empty:
+                    if future.done():
+                        future.result()
+                    continue
+
+                if isinstance(item, BaseException):
+                    raise item
+                if item.row_group == next_row_group:
+                    yield item
+                    next_row_group += 1
+                else:
+                    pending[item.row_group] = item
+
+            future.result()
+            self._task_traces = scheduler.traces
+            self._resource_provider.model_registry.log_model_usage(time.perf_counter() - start_time)
+        finally:
+            if not future.done():
+                future.cancel()
 
     def _has_image_columns(self) -> bool:
         """Check if config has any image generation columns."""

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py
@@ -19,6 +19,7 @@ from data_designer.engine.dataset_builders.block_execution import (
     BlockExecutionOptions,
     DataDesignerBlockRuntimeContext,
     execute_dataset_block,
+    execute_dataset_block_stream,
 )
 from data_designer.engine.dataset_builders.utils.task_model import TaskTrace
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
@@ -91,6 +92,44 @@ def test_execute_dataset_block_uses_input_frame_as_seed(
         {"x": 2, "label": "b", "x_label": "2-b"},
     ]
     assert input_frame.to_dict(orient="records") == [{"x": 1, "label": "a"}, {"x": 2, "label": "b"}]
+
+
+def test_execute_dataset_block_streams_ordered_chunks_and_summary(
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="x_label", expr="{{ x }}-{{ label }}"))
+    config_builder.add_processor(processor_type=ProcessorType.DROP_COLUMNS, name="drop-label", column_names=["label"])
+    input_frame = lazy.pd.DataFrame({"x": [1, 2, 3, 4, 5], "label": ["a", "b", "c", "d", "e"]})
+
+    stream = execute_dataset_block_stream(
+        rows_per_chunk=2,
+        config_builder=config_builder,
+        runtime_context=_runtime_context(tmp_path, stub_model_providers),
+        input_frame=input_frame,
+        options=BlockExecutionOptions(use_async=True),
+    )
+
+    chunks = list(stream)
+
+    assert [chunk.input_start for chunk in chunks] == [0, 2, 4]
+    assert [chunk.input_rows for chunk in chunks] == [2, 2, 1]
+    assert [len(chunk.dataframe) for chunk in chunks] == [2, 2, 1]
+    assert chunks[0].raw_dataframe.columns.to_list() == ["x", "label", "x_label"]
+    assert chunks[0].dataframe.columns.to_list() == ["x", "x_label"]
+    assert lazy.pd.concat([chunk.dataframe for chunk in chunks], ignore_index=True).to_dict(orient="records") == [
+        {"x": 1, "x_label": "1-a"},
+        {"x": 2, "x_label": "2-b"},
+        {"x": 3, "x_label": "3-c"},
+        {"x": 4, "x_label": "4-d"},
+        {"x": 5, "x_label": "5-e"},
+    ]
+    assert stream.summary.input_rows == 5
+    assert stream.summary.output_rows == 5
+    assert stream.summary.dropped_rows == 0
+    assert stream.summary.all_rows_dropped is False
 
 
 def test_execute_dataset_block_uses_model_columns(

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -17,7 +17,7 @@ from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.processors import ProcessorType
 from data_designer.engine.column_generators.utils.generator_classification import column_type_is_model_generated
-from data_designer.engine.dataset_builders.block_execution import execute_dataset_block
+from data_designer.engine.dataset_builders.block_execution import execute_dataset_block, execute_dataset_block_stream
 from data_designer.engine.storage.artifact_storage import SDG_CONFIG_FILENAME, ArtifactStorage
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.integrations.ray.artifact_output import create_data_designer_ray_datasink
@@ -1017,14 +1017,12 @@ class _RayBatchWorker:
             metrics_collector=metrics_collector,
             observability_options=self._observability_options,
             execute_block=execute_dataset_block,
+            execute_block_stream=execute_dataset_block_stream,
         )
         self._worker_options: _RayWorkerOptions = self._pipeline.worker_options
 
     def __call__(self, batch: Any) -> Any:
-        output = _generate_batch(batch, worker=self, metrics_collector=self._metrics_collector)
-        if self._execution_payload.output_chunk_rows is None:
-            return output
-        return _iter_dataframe_chunks(output, rows_per_chunk=self._execution_payload.output_chunk_rows)
+        return _generate_batch(batch, worker=self, metrics_collector=self._metrics_collector)
 
     def close(self) -> None:
         return None
@@ -1034,7 +1032,12 @@ class _RayBatchWorker:
         batch_observer = self._pipeline.begin_observability(worker_batch)
         if worker_batch.num_records == 0:
             return self._pipeline.complete_empty_batch(worker_batch, batch_observer)
-        return self._pipeline.generate_non_empty_batch(worker_batch, batch_observer)
+        if self._pipeline.should_stream_worker_output():
+            return self._pipeline.generate_non_empty_batch_stream(worker_batch, batch_observer)
+        output = self._pipeline.generate_non_empty_batch(worker_batch, batch_observer)
+        if self._execution_payload.output_chunk_rows is None:
+            return output
+        return _iter_dataframe_chunks(output, rows_per_chunk=self._execution_payload.output_chunk_rows)
 
 
 def _generate_batch(

--- a/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
@@ -10,7 +10,7 @@ import pickle
 import time
 import uuid
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
 import data_designer.lazy_heavy_imports as lazy
@@ -19,9 +19,13 @@ from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import SeedConfig
 from data_designer.engine.dataset_builders.block_execution import (
+    BlockExecutionChunk,
+    BlockExecutionChunkStream,
     BlockExecutionOptions,
     BlockExecutionResult,
+    BlockExecutionStreamSummary,
     execute_dataset_block,
+    execute_dataset_block_stream,
 )
 from data_designer.engine.resources.person_reader import PersonReader
 from data_designer.engine.resources.seed_reader import SeedReader
@@ -34,7 +38,7 @@ from data_designer.integrations.ray.errors import (
     RayDatasetGenerationError,
 )
 from data_designer.integrations.ray.metrics import RayWorkerMetrics
-from data_designer.integrations.ray.observability import RayTraceEvent
+from data_designer.integrations.ray.observability import RayTraceEvent, RayWorkerProfile
 from data_designer.integrations.ray.observability_collection import (
     _create_trace_event,
     _get_ray_worker_context,
@@ -53,6 +57,10 @@ if TYPE_CHECKING:
 
 _RAY_INTERNAL_ROW_ID_COLUMN = "__data_designer_ray_row_id"
 _ExecuteDatasetBlock = Callable[..., BlockExecutionResult]
+_ExecuteDatasetBlockStream = Callable[..., BlockExecutionChunkStream]
+
+
+BlockExecutionOutcome = BlockExecutionResult | BlockExecutionStreamSummary
 
 
 @dataclass(frozen=True)
@@ -94,16 +102,64 @@ class _RayWorkerBatch:
 @dataclass(frozen=True)
 class _RayWorkerGenerationResult:
     dataframe: Any
-    block_result: BlockExecutionResult
+    block_result: BlockExecutionOutcome
     model_usage: dict[str, dict[str, Any]] | None
 
 
 class _RayWorkerAllRowsDroppedError(Exception):
-    def __init__(self, block_result: BlockExecutionResult) -> None:
+    def __init__(self, block_result: BlockExecutionOutcome) -> None:
         super().__init__(
             f"all input rows were dropped during block execution (input_rows={block_result.input_rows}, output_rows=0)"
         )
         self.block_result = block_result
+
+
+@dataclass
+class _RayWorkerProfileAccumulator:
+    """Accumulate chunk profiles without rebuilding a full worker output frame."""
+
+    block_id: str
+    total_rows: int = 0
+    columns: list[str] = field(default_factory=list)
+    column_dtypes: dict[str, str] = field(default_factory=dict)
+    non_null_counts: dict[str, int] = field(default_factory=dict)
+    null_counts: dict[str, int] = field(default_factory=dict)
+    memory_usage_bytes: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def observe(self, dataframe: Any) -> None:
+        profile = _profile_worker_output(dataframe, block_id=self.block_id, model_usage=None)
+        self.total_rows += profile.total_rows
+        self.memory_usage_bytes += profile.memory_usage_bytes or 0
+        self.warnings.extend(profile.warnings)
+        if not self.columns:
+            self.columns = list(profile.columns)
+            self.column_dtypes = dict(profile.column_dtypes)
+        elif set(self.columns) != set(profile.columns):
+            self.warnings.append("Streaming chunk column sets differed within one Ray worker block.")
+        for column, dtype in profile.column_dtypes.items():
+            existing_dtype = self.column_dtypes.get(column)
+            if existing_dtype is not None and existing_dtype != dtype:
+                self.warnings.append(
+                    f"Streaming chunk dtype for column {column!r} changed from {existing_dtype!r} to {dtype!r}."
+                )
+        for column, count in profile.non_null_counts.items():
+            self.non_null_counts[column] = self.non_null_counts.get(column, 0) + count
+        for column, count in profile.null_counts.items():
+            self.null_counts[column] = self.null_counts.get(column, 0) + count
+
+    def to_profile(self, *, model_usage: dict[str, dict[str, Any]] | None) -> RayWorkerProfile:
+        return RayWorkerProfile(
+            block_id=self.block_id,
+            total_rows=self.total_rows,
+            columns=self.columns,
+            column_dtypes=self.column_dtypes,
+            non_null_counts=self.non_null_counts,
+            null_counts=self.null_counts,
+            memory_usage_bytes=self.memory_usage_bytes,
+            model_usage=model_usage,
+            warnings=self.warnings,
+        )
 
 
 class _RayWorkerGenerationPipeline:
@@ -116,6 +172,7 @@ class _RayWorkerGenerationPipeline:
         metrics_collector: Any | None = None,
         observability_options: _RayObservabilityOptions | None = None,
         execute_block: _ExecuteDatasetBlock | None = None,
+        execute_block_stream: _ExecuteDatasetBlockStream | None = None,
     ) -> None:
         os.environ["DATA_DESIGNER_ASYNC_ENGINE"] = "1"
         self._execution_payload = execution_payload
@@ -125,6 +182,7 @@ class _RayWorkerGenerationPipeline:
             observability_options=self._observability_options,
         )
         self._execute_block = execute_block or execute_dataset_block
+        self._execute_block_stream = execute_block_stream or execute_dataset_block_stream
         self._observer = _RayWorkerObserver(
             metrics_collector=metrics_collector,
             observability_options=self._observability_options,
@@ -139,7 +197,19 @@ class _RayWorkerGenerationPipeline:
         batch_observer = self.begin_observability(worker_batch)
         if worker_batch.num_records == 0:
             return self.complete_empty_batch(worker_batch, batch_observer)
+        if self.should_stream_worker_output():
+            return self.generate_non_empty_batch_stream(worker_batch, batch_observer)
         return self.generate_non_empty_batch(worker_batch, batch_observer)
+
+    def should_stream_worker_output(self) -> bool:
+        if self._execution_payload.output_chunk_rows is None:
+            return False
+        if self._execution_payload.capture_artifacts:
+            return False
+        return not (
+            self._execution_payload.hidden_order_column is not None
+            and not self._execution_payload.preserve_output_row_count
+        )
 
     def begin_observability(self, worker_batch: _RayWorkerBatch) -> _RayWorkerBatchObserver:
         return self._observer.begin_batch(worker_batch)
@@ -158,6 +228,77 @@ class _RayWorkerGenerationPipeline:
                     output_rows=len(generation_result.dataframe),
                 )
             return self.complete_successful_batch(worker_batch, generation_result, batch_observer)
+        except _RayWorkerAllRowsDroppedError as exc:
+            batch_observer.record_all_rows_dropped(worker_batch, exc.block_result)
+            raise RayDatasetGenerationError(
+                _format_worker_failure_message(dataframe=worker_batch.dataframe, exc=exc)
+            ) from None
+        except Exception as exc:
+            batch_observer.record_failure(worker_batch, exc)
+            if isinstance(exc, RayDatasetGenerationError):
+                raise
+            raise RayDatasetGenerationError(
+                _format_worker_failure_message(dataframe=worker_batch.dataframe, exc=exc)
+            ) from exc
+
+    def generate_non_empty_batch_stream(
+        self,
+        worker_batch: _RayWorkerBatch,
+        batch_observer: _RayWorkerBatchObserver,
+    ) -> Iterator[Any]:
+        try:
+            batch_observer.record_generation_started(worker_batch)
+            stream = self.generate_row_chunks(worker_batch)
+            profile = _RayWorkerProfileAccumulator(block_id=worker_batch.block_id)
+            emitted_rows = 0
+            output_columns: list[str] = []
+            for chunk in stream:
+                output = chunk.dataframe
+                if self._execution_payload.hidden_order_column is not None:
+                    output = _append_hidden_order_column(
+                        output,
+                        order_values=_chunk_order_values(
+                            worker_batch.dataframe,
+                            chunk=chunk,
+                            hidden_order_column=self._execution_payload.hidden_order_column,
+                        ),
+                        hidden_order_column=self._execution_payload.hidden_order_column,
+                    )
+                if self._execution_payload.preserve_output_row_count:
+                    _validate_output_row_count(input_rows=chunk.input_rows, output_rows=len(output))
+                if not output_columns:
+                    output_columns = [str(column) for column in output.columns]
+                emitted_rows += len(output)
+                if self._observability_options.profile_workers:
+                    profile.observe(output)
+                yield output
+
+            block_summary = stream.summary
+            if block_summary.all_rows_dropped:
+                raise _RayWorkerAllRowsDroppedError(block_summary)
+            if self._execution_payload.preserve_output_row_count:
+                _validate_output_row_count(
+                    input_rows=worker_batch.num_records,
+                    output_rows=block_summary.output_rows,
+                )
+            if emitted_rows != block_summary.output_rows:
+                raise RayDatasetGenerationError(
+                    "RayBackend engine stream emitted "
+                    f"{emitted_rows} row(s), but the block summary reported {block_summary.output_rows} row(s)."
+                )
+            batch_observer.record_success(
+                worker_batch,
+                _RayWorkerGenerationResult(
+                    dataframe=None,
+                    block_result=block_summary,
+                    model_usage=block_summary.model_usage_stats or None,
+                ),
+                throttle_manager=self._worker_options.throttle_manager,
+                worker_profile=profile.to_profile(model_usage=block_summary.model_usage_stats or None)
+                if self._observability_options.profile_workers
+                else None,
+                output_columns=output_columns,
+            )
         except _RayWorkerAllRowsDroppedError as exc:
             batch_observer.record_all_rows_dropped(worker_batch, exc.block_result)
             raise RayDatasetGenerationError(
@@ -213,6 +354,24 @@ class _RayWorkerGenerationPipeline:
             dataframe=output,
             block_result=block_result,
             model_usage=block_result.model_usage_stats or None,
+        )
+
+    def generate_row_chunks(self, worker_batch: _RayWorkerBatch) -> BlockExecutionChunkStream:
+        block_config = self.create_block_config(worker_batch.dataframe)
+        input_frame = _create_worker_input_frame(
+            worker_batch.dataframe,
+            use_input_dataset=self._execution_payload.use_input_dataset,
+            range_input_columns=self._execution_payload.range_input_columns,
+        )
+        if self._execution_payload.output_chunk_rows is None:
+            raise RayDatasetGenerationError("RayBackend output chunk rows are required for engine block streaming.")
+        return self._execute_block_stream(
+            rows_per_chunk=self._execution_payload.output_chunk_rows,
+            data_designer_config=block_config,
+            runtime_context=self._worker_options,
+            input_frame=input_frame,
+            num_records=worker_batch.num_records,
+            options=BlockExecutionOptions(use_async=True, dataset_name="ray-block"),
         )
 
     def complete_empty_batch(self, worker_batch: _RayWorkerBatch, batch_observer: _RayWorkerBatchObserver) -> Any:
@@ -348,9 +507,19 @@ class _RayWorkerBatchObserver:
         generation_result: _RayWorkerGenerationResult,
         *,
         throttle_manager: Any | None,
+        worker_profile: RayWorkerProfile | None = None,
+        output_columns: list[str] | None = None,
     ) -> None:
         elapsed_seconds = time.perf_counter() - worker_batch.start_time
         block_result = generation_result.block_result
+        output_row_count = (
+            len(generation_result.dataframe) if generation_result.dataframe is not None else block_result.output_rows
+        )
+        output_columns = (
+            [str(column) for column in generation_result.dataframe.columns]
+            if generation_result.dataframe is not None
+            else (output_columns or (worker_profile.columns if worker_profile is not None else []))
+        )
         if self._observability_options.trace_enabled:
             self._trace_events.extend(
                 _task_traces_to_events(
@@ -364,10 +533,10 @@ class _RayWorkerBatchObserver:
                     worker_batch.block_id,
                     "block_completed",
                     worker_batch.start_time,
-                    row_count=len(generation_result.dataframe),
+                    row_count=output_row_count,
                     worker_context=worker_batch.worker_context,
                     details={
-                        "output_columns": [str(column) for column in generation_result.dataframe.columns],
+                        "output_columns": output_columns,
                         "input_rows": block_result.input_rows,
                         "output_rows": block_result.output_rows,
                         "dropped_rows": block_result.dropped_rows,
@@ -384,7 +553,9 @@ class _RayWorkerBatchObserver:
         )
         _record_worker_observability(
             self._metrics_collector,
-            worker_profile=(
+            worker_profile=worker_profile
+            if worker_profile is not None
+            else (
                 _profile_worker_output(
                     generation_result.dataframe,
                     block_id=worker_batch.block_id,
@@ -397,7 +568,7 @@ class _RayWorkerBatchObserver:
             throttle_snapshots=_snapshot_worker_throttle(throttle_manager),
         )
 
-    def record_all_rows_dropped(self, worker_batch: _RayWorkerBatch, block_result: BlockExecutionResult) -> None:
+    def record_all_rows_dropped(self, worker_batch: _RayWorkerBatch, block_result: BlockExecutionOutcome) -> None:
         elapsed_seconds = time.perf_counter() - worker_batch.start_time
         if self._observability_options.trace_enabled:
             self._trace_events.append(
@@ -582,6 +753,16 @@ def _get_hidden_order_values(dataframe: Any, *, hidden_order_column: str | None)
     return [int(value) for value in values]
 
 
+def _chunk_order_values(
+    dataframe: Any,
+    *,
+    chunk: BlockExecutionChunk,
+    hidden_order_column: str,
+) -> list[int]:
+    order_values = _get_hidden_order_values(dataframe, hidden_order_column=hidden_order_column)
+    return order_values[chunk.input_start : chunk.input_start + chunk.input_rows]
+
+
 def _append_hidden_order_column(
     output: Any,
     *,
@@ -617,7 +798,7 @@ def _validate_output_row_count(*, input_rows: int, output_rows: int) -> None:
 
 
 def _metrics_from_block_result(
-    block_result: BlockExecutionResult,
+    block_result: BlockExecutionOutcome,
     *,
     elapsed_seconds: float,
     block_id: str,

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -130,6 +130,7 @@ def test_real_ray_streaming_out_of_core_parquet_smoke(
         managed_assets_path=real_ray_smoke_paths.managed_assets_path,
         backend=RayBackend(
             batch_size=4,
+            output_chunk_rows=2,
             output="dataset",
             profile_workers=True,
             trace_enabled=True,

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -19,7 +19,12 @@ from data_designer.config.data_designer_config import DataDesignerConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.seed import SamplingStrategy
 from data_designer.config.seed_source_dataframe import DataFrameSeedSource
-from data_designer.engine.dataset_builders.block_execution import BlockExecutionResult
+from data_designer.engine.dataset_builders.block_execution import (
+    BlockExecutionChunk,
+    BlockExecutionChunkStream,
+    BlockExecutionResult,
+    BlockExecutionStreamSummary,
+)
 from data_designer.engine.resources.seed_reader import DataFrameSeedReader
 from data_designer.engine.secret_resolver import PlaintextResolver
 from data_designer.integrations.ray import RayBackend, RayBackendConfigurationError, RayDatasetGenerationError
@@ -191,6 +196,29 @@ def _block_result(*, dataframe: Any, input_rows: int, model_usage: dict[str, dic
     )
 
 
+def _block_chunk_stream(chunks: list[BlockExecutionChunk], *, input_rows: int) -> BlockExecutionChunkStream:
+    summary_holder: dict[str, BlockExecutionStreamSummary] = {}
+
+    def iterator() -> Any:
+        output_rows = 0
+        for chunk in chunks:
+            output_rows += chunk.output_rows
+            yield chunk
+        summary_holder["summary"] = BlockExecutionStreamSummary(
+            task_traces=[],
+            model_usage_stats={},
+            model_usage_deltas={},
+            processor_artifacts={},
+            input_rows=input_rows,
+            output_rows=output_rows,
+            dropped_rows=max(input_rows - output_rows, 0),
+            all_rows_dropped=input_rows > 0 and output_rows == 0,
+            partial_rows_dropped=0 < output_rows < input_rows,
+        )
+
+    return BlockExecutionChunkStream(iterator(), summary_holder)
+
+
 def test_ray_batch_worker_delegates_to_engine_block_api(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -230,6 +258,63 @@ def test_ray_batch_worker_delegates_to_engine_block_api(
     assert all(call["runtime_context"] is worker._worker_options for call in calls)
     assert all(call["options"].use_async is True for call in calls)
     assert all(call["data_designer_config"].seed_config is None for call in calls)
+
+
+def test_ray_batch_worker_uses_engine_block_stream_for_output_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+    )
+    payload = ray_backend_module._compile_ray_execution_payload(
+        config_builder=_input_expression_config_builder(stub_model_configs),
+        worker_options=_worker_options_from_designer(designer),
+        use_input_dataset=True,
+        output_chunk_rows=2,
+    )
+    calls: list[dict[str, Any]] = []
+
+    def execute_dataset_block_stream(**kwargs: Any) -> BlockExecutionChunkStream:
+        calls.append(kwargs)
+        chunks = [
+            BlockExecutionChunk(
+                dataframe=lazy.pd.DataFrame({"row": [0, 1]}),
+                raw_dataframe=lazy.pd.DataFrame({"row": [0, 1]}),
+                row_group=0,
+                input_start=0,
+                input_rows=2,
+                output_rows=2,
+            ),
+            BlockExecutionChunk(
+                dataframe=lazy.pd.DataFrame({"row": [2]}),
+                raw_dataframe=lazy.pd.DataFrame({"row": [2]}),
+                row_group=1,
+                input_start=2,
+                input_rows=1,
+                output_rows=1,
+            ),
+        ]
+        return _block_chunk_stream(chunks, input_rows=3)
+
+    monkeypatch.setattr(ray_backend_module, "execute_dataset_block_stream", execute_dataset_block_stream)
+    worker = ray_backend_module._RayBatchWorker(execution_payload=payload)
+
+    output = list(worker(lazy.pd.DataFrame({"x": [1, 2, 3], "label": ["a", "b", "c"]})))
+
+    assert [chunk.to_dict(orient="records") for chunk in output] == [[{"row": 0}, {"row": 1}], [{"row": 2}]]
+    assert len(calls) == 1
+    assert calls[0]["rows_per_chunk"] == 2
+    assert calls[0]["input_frame"].to_dict(orient="records") == [
+        {"x": 1, "label": "a"},
+        {"x": 2, "label": "b"},
+        {"x": 3, "label": "c"},
+    ]
 
 
 def test_worker_generation_pipeline_core_runs_without_metrics_actor_or_ray_runtime(

--- a/scripts/benchmarks/benchmark_ray_streaming_out_of_core.py
+++ b/scripts/benchmarks/benchmark_ray_streaming_out_of_core.py
@@ -60,6 +60,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--source-blocks", type=int, default=DEFAULT_SOURCE_BLOCKS)
     parser.add_argument("--source-batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--output-chunk-rows", type=int, default=None)
     parser.add_argument("--stream-batch-size", type=int, default=DEFAULT_STREAM_BATCH_SIZE)
     parser.add_argument("--stream-sample-batches", type=int, default=3)
     parser.add_argument("--ray-cpus", type=int, default=DEFAULT_RAY_CPUS)
@@ -119,6 +120,7 @@ def _run_streaming_case(ray: Any, args: argparse.Namespace) -> dict[str, Any]:
             profile_workers=True,
             trace_enabled=args.trace_enabled,
             max_trace_events=args.max_trace_events,
+            output_chunk_rows=args.output_chunk_rows,
         ),
     )
     designer.set_run_config(
@@ -166,6 +168,7 @@ def _run_streaming_case(ray: Any, args: argparse.Namespace) -> dict[str, Any]:
             "source_blocks": args.source_blocks,
             "source_batch_size": args.source_batch_size,
             "batch_size": args.batch_size,
+            "output_chunk_rows": args.output_chunk_rows,
             "stream_batch_size": args.stream_batch_size,
             "stream_sample_batches": args.stream_sample_batches,
             "ray_cpus": args.ray_cpus,
@@ -388,6 +391,8 @@ def _validate_args(args: argparse.Namespace) -> None:
         value = getattr(args, field_name)
         if value < 1:
             raise ValueError(f"--{field_name.replace('_', '-')} must be >= 1.")
+    if args.output_chunk_rows is not None and args.output_chunk_rows < 1:
+        raise ValueError("--output-chunk-rows must be >= 1 when provided.")
 
 
 def _emit(payload: dict[str, Any]) -> None:


### PR DESCRIPTION
## 📋 Summary

Adds an engine-native row-group streaming path for Ray worker blocks so `output_chunk_rows` can emit generated chunks without first materializing the full worker output frame for non-artifact jobs. This preserves row ordering, row-count validation, processor behavior, usage stats, metrics, and trace/profile summaries while keeping artifact capture on the existing materialized fallback until #129 is addressed.

## 🔗 Related Issue

Closes #116. Follow-up: #129.

## 🔄 Changes

- Added `DatasetBuilder.build_block_chunks()` and `execute_dataset_block_stream()` for ordered async row-group chunk emission with final block summaries.
- Wired Ray workers to use the engine stream when `output_chunk_rows` is configured, with safe fallbacks for artifact capture and hidden-order row-count-changing cases.
- Preserved Ray metrics, row-count validation, trace completion events, and worker profile aggregation across streamed chunks.
- Added engine and Ray worker-boundary coverage for streamed chunks and enabled the real-Ray out-of-core smoke to exercise `output_chunk_rows`.
- Added `--output-chunk-rows` to the streaming out-of-core benchmark and documented the behavior.

## 🧪 Testing

- [ ] `make test` passes (not run; focused validation below)
- [x] Unit tests added/updated
- [x] E2E tests added/updated (real-Ray smoke and benchmark coverage)

Focused validation:
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-l-116 uv run --group dev ruff check docs/concepts/ray-backend.md packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py scripts/benchmarks/benchmark_ray_streaming_out_of_core.py packages/data-designer/tests/integrations/ray/test_real_smoke.py`
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-l-116 uv run --all-packages pytest packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py packages/data-designer-engine/tests/engine/dataset_builders/test_dataset_builder.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_can_yield_output_chunks -q` (79 passed, 1 skipped)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-l-116 uv run --all-packages pytest packages/data-designer/tests/integrations/ray -m 'ray_fake or ray_worker_boundary or ray_benchmark' -q` (260 passed, 1 skipped, 7 deselected)
- [x] `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 UV_CACHE_DIR=/tmp/uv-cache-dd-worker-l-116 DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 uv run --package data-designer --extra ray pytest packages/data-designer/tests/integrations/ray/test_real_smoke.py::test_real_ray_streaming_out_of_core_parquet_smoke -q` (1 passed)
- [x] `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 UV_CACHE_DIR=/tmp/uv-cache-dd-worker-l-116 uv run --package data-designer --extra ray python scripts/benchmarks/benchmark_ray_streaming_out_of_core.py --num-records 64 --source-blocks 4 --source-batch-size 16 --batch-size 16 --output-chunk-rows 8 --stream-batch-size 8 --stream-sample-batches 2 --ray-cpus 2 --sandbox-safe-ray-init --output-json /tmp/dd-worker-l-116-streaming-post-rebase.json` (`status=ok`, 64/64 rows, no diagnostic warnings)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (Ray backend concept docs)