### PR TITLE
feat(ray): report worker memory profiles

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/observability.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability.py
@@ -99,6 +99,8 @@ class RayWorkerProfile:
     non_null_counts: dict[str, int] = field(default_factory=dict)
     null_counts: dict[str, int] = field(default_factory=dict)
     memory_usage_bytes: int | None = None
+    input_memory_usage_bytes: int | None = None
+    process_maxrss_bytes: int | None = None
     model_usage: ModelUsageSummary | None = None
     warnings: list[str] = field(default_factory=list)
 
@@ -109,6 +111,18 @@ class RayWorkerProfile:
             validate_non_negative_int_field(
                 "memory_usage_bytes",
                 self.memory_usage_bytes,
+                field_label=_OBSERVABILITY_FIELD_LABEL,
+            )
+        if self.input_memory_usage_bytes is not None:
+            validate_non_negative_int_field(
+                "input_memory_usage_bytes",
+                self.input_memory_usage_bytes,
+                field_label=_OBSERVABILITY_FIELD_LABEL,
+            )
+        if self.process_maxrss_bytes is not None:
+            validate_non_negative_int_field(
+                "process_maxrss_bytes",
+                self.process_maxrss_bytes,
                 field_label=_OBSERVABILITY_FIELD_LABEL,
             )
         for column in self.columns:
@@ -466,6 +480,16 @@ def normalize_ray_worker_profile(payload: RayWorkerProfilePayload) -> RayWorkerP
         memory_usage_bytes=coerce_optional_int_field(
             payload.get("memory_usage_bytes"),
             "memory_usage_bytes",
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        input_memory_usage_bytes=coerce_optional_int_field(
+            payload.get("input_memory_usage_bytes"),
+            "input_memory_usage_bytes",
+            field_label=_OBSERVABILITY_FIELD_LABEL,
+        ),
+        process_maxrss_bytes=coerce_optional_int_field(
+            payload.get("process_maxrss_bytes"),
+            "process_maxrss_bytes",
             field_label=_OBSERVABILITY_FIELD_LABEL,
         ),
         model_usage=coerce_model_usage(

--- a/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/observability_collection.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+import platform
 import socket
 import time
 from collections.abc import Callable, Mapping
@@ -428,15 +429,21 @@ def _record_worker_metrics(metrics_collector: Any | None, metrics: RayWorkerMetr
 
 
 def _profile_worker_output(
-    output: Any, *, block_id: str, model_usage: dict[str, dict[str, Any]] | None
+    output: Any,
+    *,
+    block_id: str,
+    model_usage: dict[str, dict[str, Any]] | None,
+    input_frame: Any | None = None,
 ) -> RayWorkerProfile:
     warnings: list[str] = []
+    process_maxrss_bytes = _process_maxrss_bytes(warnings)
+    input_memory_usage_bytes = _dataframe_memory_usage_bytes(input_frame, warnings, label="input")
     try:
         columns = [str(column) for column in output.columns]
         column_dtypes = {str(column): str(dtype) for column, dtype in output.dtypes.items()}
         non_null_counts = {str(column): int(value) for column, value in output.notna().sum().to_dict().items()}
         null_counts = {str(column): int(value) for column, value in output.isna().sum().to_dict().items()}
-        memory_usage_bytes = int(output.memory_usage(deep=True).sum())
+        memory_usage_bytes = _dataframe_memory_usage_bytes(output, warnings, label="output")
     except Exception as exc:
         columns = []
         column_dtypes = {}
@@ -452,9 +459,36 @@ def _profile_worker_output(
         non_null_counts=non_null_counts,
         null_counts=null_counts,
         memory_usage_bytes=memory_usage_bytes,
+        input_memory_usage_bytes=input_memory_usage_bytes,
+        process_maxrss_bytes=process_maxrss_bytes,
         model_usage=model_usage,
         warnings=warnings,
     )
+
+
+def _dataframe_memory_usage_bytes(dataframe: Any | None, warnings: list[str], *, label: str) -> int | None:
+    if dataframe is None:
+        return None
+    try:
+        memory_usage = getattr(dataframe, "memory_usage", None)
+        if not callable(memory_usage):
+            return None
+        return int(memory_usage(deep=True).sum())
+    except Exception as exc:
+        warnings.append(f"Failed to profile Ray worker {label} memory: {type(exc).__name__}: {exc}")
+        return None
+
+
+def _process_maxrss_bytes(warnings: list[str]) -> int | None:
+    try:
+        resource_module = importlib.import_module("resource")
+        value = int(resource_module.getrusage(resource_module.RUSAGE_SELF).ru_maxrss)
+    except Exception as exc:
+        warnings.append(f"Failed to profile Ray worker process RSS: {type(exc).__name__}: {exc}")
+        return None
+    if platform.system() == "Darwin":
+        return value
+    return value * 1024
 
 
 def _snapshot_worker_throttle(throttle_manager: Any | None) -> list[RayThrottleSnapshot]:

--- a/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
@@ -125,12 +125,18 @@ class _RayWorkerProfileAccumulator:
     non_null_counts: dict[str, int] = field(default_factory=dict)
     null_counts: dict[str, int] = field(default_factory=dict)
     memory_usage_bytes: int = 0
+    input_memory_usage_bytes: int | None = None
+    process_maxrss_bytes: int | None = None
     warnings: list[str] = field(default_factory=list)
 
-    def observe(self, dataframe: Any) -> None:
-        profile = _profile_worker_output(dataframe, block_id=self.block_id, model_usage=None)
+    def observe(self, dataframe: Any, *, input_frame: Any | None = None) -> None:
+        profile = _profile_worker_output(dataframe, block_id=self.block_id, model_usage=None, input_frame=input_frame)
         self.total_rows += profile.total_rows
         self.memory_usage_bytes += profile.memory_usage_bytes or 0
+        if profile.input_memory_usage_bytes is not None and self.input_memory_usage_bytes is None:
+            self.input_memory_usage_bytes = profile.input_memory_usage_bytes
+        if profile.process_maxrss_bytes is not None:
+            self.process_maxrss_bytes = max(self.process_maxrss_bytes or 0, profile.process_maxrss_bytes)
         self.warnings.extend(profile.warnings)
         if not self.columns:
             self.columns = list(profile.columns)
@@ -157,6 +163,8 @@ class _RayWorkerProfileAccumulator:
             non_null_counts=self.non_null_counts,
             null_counts=self.null_counts,
             memory_usage_bytes=self.memory_usage_bytes,
+            input_memory_usage_bytes=self.input_memory_usage_bytes,
+            process_maxrss_bytes=self.process_maxrss_bytes,
             model_usage=model_usage,
             warnings=self.warnings,
         )
@@ -268,9 +276,10 @@ class _RayWorkerGenerationPipeline:
                     _validate_output_row_count(input_rows=chunk.input_rows, output_rows=len(output))
                 if not output_columns:
                     output_columns = [str(column) for column in output.columns]
+                input_profile_frame = worker_batch.dataframe if emitted_rows == 0 else None
                 emitted_rows += len(output)
                 if self._observability_options.profile_workers:
-                    profile.observe(output)
+                    profile.observe(output, input_frame=input_profile_frame)
                 yield output
 
             block_summary = stream.summary
@@ -493,7 +502,12 @@ class _RayWorkerBatchObserver:
         _record_worker_observability(
             self._metrics_collector,
             worker_profile=(
-                _profile_worker_output(worker_batch.dataframe, block_id=worker_batch.block_id, model_usage=None)
+                _profile_worker_output(
+                    worker_batch.dataframe,
+                    block_id=worker_batch.block_id,
+                    model_usage=None,
+                    input_frame=worker_batch.dataframe,
+                )
                 if self._observability_options.profile_workers
                 else None
             ),
@@ -560,6 +574,7 @@ class _RayWorkerBatchObserver:
                     generation_result.dataframe,
                     block_id=worker_batch.block_id,
                     model_usage=generation_result.model_usage,
+                    input_frame=worker_batch.dataframe,
                 )
                 if self._observability_options.profile_workers
                 else None

--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 import data_designer.lazy_heavy_imports as lazy
-from data_designer.integrations.ray import RayDatasetAnalysis, RayDatasetStats, RayTraceEvent
+from data_designer.integrations.ray import RayDatasetAnalysis, RayDatasetStats, RayTraceEvent, RayWorkerProfile
 
 pytestmark = pytest.mark.ray_benchmark
 
@@ -54,6 +54,39 @@ def test_ray_benchmark_scripts_import_with_shared_helpers() -> None:
     assert modules["benchmark_ray_openai"].RESULT_PREFIX == "RAY_OPENAI_BENCHMARK_RESULT="
     assert modules["benchmark_ray_mock_provider"].RESULT_PREFIX == "RAY_MOCK_PROVIDER_BENCHMARK_RESULT="
     assert modules["benchmark_ray_streaming_out_of_core"].RESULT_PREFIX == "RAY_STREAMING_OUT_OF_CORE_RESULT="
+
+
+def test_streaming_benchmark_summarizes_worker_memory_profiles() -> None:
+    module = _load_benchmark_module(
+        "benchmark_ray_streaming_out_of_core",
+        _benchmark_dir() / "benchmark_ray_streaming_out_of_core.py",
+    )
+    analysis = RayDatasetAnalysis(
+        worker_profiles=[
+            RayWorkerProfile(
+                block_id="block-a",
+                total_rows=2,
+                input_memory_usage_bytes=100,
+                memory_usage_bytes=150,
+                process_maxrss_bytes=1024,
+            ),
+            RayWorkerProfile(
+                block_id="block-b",
+                total_rows=2,
+                input_memory_usage_bytes=200,
+                memory_usage_bytes=250,
+                process_maxrss_bytes=2048,
+            ),
+        ]
+    )
+
+    summary = module._worker_memory_summary(analysis)
+
+    assert summary["profile_count"] == 2
+    assert summary["input_memory_usage_bytes"]["max"] == 200.0
+    assert summary["output_memory_usage_bytes"]["total"] == 400.0
+    assert summary["process_maxrss_bytes"]["max"] == 2048.0
+    assert summary["max_output_to_input_memory_ratio"] == 1.5
 
 
 def test_parse_backends_supports_full_apples_to_apples_suite() -> None:

--- a/packages/data-designer/tests/integrations/ray/test_observability.py
+++ b/packages/data-designer/tests/integrations/ray/test_observability.py
@@ -45,6 +45,8 @@ def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
                 non_null_counts={"id": 2, "label": 1},
                 null_counts={"id": 0, "label": 1},
                 memory_usage_bytes=128,
+                input_memory_usage_bytes=96,
+                process_maxrss_bytes=1024,
             ).to_dict(),
             "trace_events": [
                 RayTraceEvent(
@@ -89,6 +91,8 @@ def test_ray_results_load_analysis_returns_profiles_traces_and_throttle(
     assert analysis.blocks == 1
     assert analysis.worker_profiles[0].block_id == "block-a"
     assert analysis.worker_profiles[0].null_counts == {"id": 0, "label": 1}
+    assert analysis.worker_profiles[0].input_memory_usage_bytes == 96
+    assert analysis.worker_profiles[0].process_maxrss_bytes == 1024
     assert analysis.worker_profiles_dropped == 0
     assert analysis.trace_events[0].event_type == "block_started"
     assert analysis.trace_events_dropped == 1
@@ -472,6 +476,9 @@ def test_normalize_ray_trace_event_rejects_invalid_optional_string() -> None:
 def test_normalize_ray_worker_profile_preserves_engine_model_usage_optional_fields() -> None:
     payload = {
         "block_id": "block-a",
+        "input_memory_usage_bytes": 96,
+        "memory_usage_bytes": 128,
+        "process_maxrss_bytes": 1024,
         "model_usage": {
             "model-a": {
                 "token_usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
@@ -492,6 +499,9 @@ def test_normalize_ray_worker_profile_preserves_engine_model_usage_optional_fiel
     profile = normalize_ray_worker_profile(payload)
 
     assert profile.model_usage == payload["model_usage"]
+    assert profile.input_memory_usage_bytes == 96
+    assert profile.memory_usage_bytes == 128
+    assert profile.process_maxrss_bytes == 1024
     assert profile.model_usage is not payload["model_usage"]
     assert profile.model_usage["model-a"]["image_usage"] is not payload["model_usage"]["model-a"]["image_usage"]
 

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -155,6 +155,9 @@ def test_real_ray_streaming_out_of_core_parquet_smoke(
     assert analysis is not None
     assert analysis.total_rows == num_records
     assert analysis.worker_profiles
+    assert any(profile.input_memory_usage_bytes is not None for profile in analysis.worker_profiles)
+    assert any(profile.memory_usage_bytes is not None for profile in analysis.worker_profiles)
+    assert any(profile.process_maxrss_bytes is not None for profile in analysis.worker_profiles)
     assert analysis.trace_events
     assert analysis.ray_dataset_stats is not None
     assert analysis.ray_dataset_stats.stats_text is not None or analysis.ray_dataset_stats.warnings

--- a/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
+++ b/packages/data-designer/tests/integrations/ray/test_worker_boundary.py
@@ -262,10 +262,13 @@ def test_ray_batch_worker_delegates_to_engine_block_api(
 
 def test_ray_batch_worker_uses_engine_block_stream_for_output_chunks(
     monkeypatch: pytest.MonkeyPatch,
+    fake_ray_installer: Any,
     tmp_path: Path,
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
+    fake_ray = fake_ray_installer(with_remote=True)
+    collector = ray_observability_collection._create_metrics_collector(fake_ray)
     designer = DataDesigner(
         artifact_path=tmp_path,
         model_providers=stub_model_providers,
@@ -303,11 +306,21 @@ def test_ray_batch_worker_uses_engine_block_stream_for_output_chunks(
         return _block_chunk_stream(chunks, input_rows=3)
 
     monkeypatch.setattr(ray_backend_module, "execute_dataset_block_stream", execute_dataset_block_stream)
-    worker = ray_backend_module._RayBatchWorker(execution_payload=payload)
+    worker = ray_backend_module._RayBatchWorker(
+        execution_payload=payload,
+        metrics_collector=collector,
+        observability_options=ray_observability_collection._RayObservabilityOptions(profile_workers=True),
+    )
 
     output = list(worker(lazy.pd.DataFrame({"x": [1, 2, 3], "label": ["a", "b", "c"]})))
+    observability = fake_ray.get(collector.observability_snapshot.remote())
+    worker_profile = observability["worker_profiles"][0]
 
     assert [chunk.to_dict(orient="records") for chunk in output] == [[{"row": 0}, {"row": 1}], [{"row": 2}]]
+    assert worker_profile["total_rows"] == 3
+    assert worker_profile["memory_usage_bytes"] > 0
+    assert worker_profile["input_memory_usage_bytes"] > 0
+    assert worker_profile["process_maxrss_bytes"] is None or worker_profile["process_maxrss_bytes"] > 0
     assert len(calls) == 1
     assert calls[0]["rows_per_chunk"] == 2
     assert calls[0]["input_frame"].to_dict(orient="records") == [

--- a/scripts/benchmarks/benchmark_ray_streaming_out_of_core.py
+++ b/scripts/benchmarks/benchmark_ray_streaming_out_of_core.py
@@ -158,6 +158,7 @@ def _run_streaming_case(ray: Any, args: argparse.Namespace) -> dict[str, Any]:
     )
     metrics = results.load_metrics().to_dict()
     analysis = results.load_analysis()
+    worker_memory = _worker_memory_summary(analysis)
     elapsed_seconds = time.perf_counter() - started_at
     parquet_files = sorted(args.parquet_output.glob("*.parquet"))
 
@@ -185,6 +186,7 @@ def _run_streaming_case(ray: Any, args: argparse.Namespace) -> dict[str, Any]:
             "driver_maxrss_bytes_after_create": rss_after_create,
             "driver_maxrss_bytes_after_write": rss_after_write,
             "driver_maxrss_delta_bytes": max(rss_after_write - rss_before, 0),
+            "worker_profiles": worker_memory,
         },
         "dataset": {
             "source_blocks_observed": source_blocks_observed,
@@ -338,6 +340,52 @@ def _stream_sample(dataset: Any, *, stream_batch_size: int, max_batches: int) ->
         "batch_count": batch_count,
         "rows": rows,
         "first_rows": first_rows,
+    }
+
+
+def _worker_memory_summary(analysis: Any | None) -> dict[str, Any]:
+    if analysis is None:
+        return {
+            "profile_count": 0,
+            "input_memory_usage_bytes": _numeric_summary([]),
+            "output_memory_usage_bytes": _numeric_summary([]),
+            "process_maxrss_bytes": _numeric_summary([]),
+            "max_output_to_input_memory_ratio": None,
+        }
+    profiles = list(getattr(analysis, "worker_profiles", []) or [])
+    input_values = _profile_values(profiles, "input_memory_usage_bytes")
+    output_values = _profile_values(profiles, "memory_usage_bytes")
+    process_values = _profile_values(profiles, "process_maxrss_bytes")
+    ratios = [
+        output_value / input_value for input_value, output_value in zip(input_values, output_values) if input_value > 0
+    ]
+    return {
+        "profile_count": len(profiles),
+        "input_memory_usage_bytes": _numeric_summary(input_values),
+        "output_memory_usage_bytes": _numeric_summary(output_values),
+        "process_maxrss_bytes": _numeric_summary(process_values),
+        "max_output_to_input_memory_ratio": max(ratios) if ratios else None,
+    }
+
+
+def _profile_values(profiles: list[Any], field_name: str) -> list[float]:
+    values: list[float] = []
+    for profile in profiles:
+        value = getattr(profile, field_name, None)
+        if value is not None:
+            values.append(float(value))
+    return values
+
+
+def _numeric_summary(values: list[float]) -> dict[str, float | int | None]:
+    if not values:
+        return {"min": None, "max": None, "mean": None, "total": 0, "n": 0}
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": sum(values) / len(values),
+        "total": sum(values),
+        "n": len(values),
     }
 
 


### PR DESCRIPTION
## 📋 Summary

Adds worker-level memory instrumentation to Ray observability and the out-of-core streaming benchmark. After #130, this measures the new engine row-group streaming path directly, including input DataFrame memory, emitted output memory, and worker process max RSS.

## 🔗 Related Issue

Part of #116

## 🔄 Changes

- Extends `RayWorkerProfile` with input DataFrame memory and worker process max RSS fields while preserving the existing output `memory_usage_bytes` field.
- Records input/output memory and process RSS from Ray workers when `profile_workers=True`, including streamed worker chunk output.
- Summarizes worker memory profiles in `benchmark_ray_streaming_out_of_core.py` alongside driver RSS, Ray Data stats, quality checks, and stream samples.
- Adds focused tests for normalization/reporting, streamed worker profile aggregation, and real-smoke assertions for worker memory fields.

## 🧪 Testing

- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-131-fix-test uv run --all-packages pytest packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py -q -m 'ray_fake or ray_worker_boundary or ray_benchmark'` (48 passed, 1 skipped, 6 deselected)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-131-fix-ruff uv run --all-packages ruff check packages/data-designer/src/data_designer/integrations/ray/observability.py packages/data-designer/src/data_designer/integrations/ray/observability_collection.py packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py scripts/benchmarks/benchmark_ray_streaming_out_of_core.py packages/data-designer/tests/integrations/ray/test_observability.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py packages/data-designer/tests/integrations/ray/test_real_smoke.py packages/data-designer/tests/integrations/ray/test_worker_boundary.py`
- [x] Real-Ray streaming/out-of-core benchmark with `--output-chunk-rows 8`: 64 rows, 4 source blocks, 4 worker profiles, all output valid; worker profile summary included input/output memory and process RSS.

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [ ] Architecture docs updated (N/A — instrumentation-only slice)