### PR TITLE
feat(ray): add opt-in Ray Data LLM execution

### DIFF
--- a/architecture/ray-data-llm.md
+++ b/architecture/ray-data-llm.md
@@ -2,13 +2,13 @@
 
 Issue: [#52](https://github.com/eric-tramel/DataDesigner/issues/52)  
 Date: 2026-04-25  
-Status: planning hook implemented; execution integration deferred
+Status: planning hook implemented; narrow opt-in execution prototype implemented
 
 ## Decision
 
 Ray Data LLM/vLLM should not be added as a first-class `ModelProvider` yet. Keep external provider behavior on the existing `ModelFacade` and HTTP client adapters. Treat Ray Data LLM as a future RayBackend-only stage optimization for local GPU inference after the Ray planner can prove a column stage is eligible.
 
-The safe slice is a capability and planning hook: `probe_ray_data_llm_capabilities()` detects the optional `ray.data.llm` surface at runtime, `assess_ray_data_llm_integration()` returns the current placement recommendation without importing Ray during package import, and `RayDataLLMStageOptions` lets `RayBackend` explicitly plan one opt-in local vLLM stage candidate while continuing to execute through the existing `ModelFacade` unless that fallback is disabled.
+The safe slice is a capability and planning hook plus a tightly bounded execution prototype: `probe_ray_data_llm_capabilities()` detects the optional `ray.data.llm` surface at runtime, `assess_ray_data_llm_integration()` returns the current placement recommendation without importing Ray during package import, and `RayDataLLMStageOptions` lets `RayBackend` explicitly plan one opt-in local vLLM stage candidate. `execute=True` replaces the standard worker path only for one independent plain `LLMTextColumnConfig`; otherwise the backend fails fast or falls back to the existing `ModelFacade` path depending on the configured fallback policy.
 
 ## Sources Reviewed
 
@@ -62,7 +62,18 @@ A narrow future prototype should only consider columns that meet all of these co
 
 All other model-generated columns should keep using the existing `ModelFacade`.
 
-The current implementation records this eligibility through `plan_ray_data_llm_stage()` and exposes the resolved plan as `RayDatasetCreationResults.llm_stage_plan`. `RayDataLLMStageOptions(allow_model_facade_fallback=False)` turns the hook into a fail-fast verifier so a job does not silently run through the existing facade when the requested Ray Data LLM stage is unavailable or ineligible.
+The current implementation records this eligibility through `plan_ray_data_llm_stage()` and exposes the resolved plan as `RayDatasetCreationResults.llm_stage_plan`. `RayDataLLMStageOptions(allow_model_facade_fallback=False)` turns the hook into a fail-fast verifier so a job does not silently run through the existing facade when the requested Ray Data LLM stage is unavailable or ineligible. `RayDataLLMStageOptions(execute=True)` is stricter: it requires the selected stage to be executable, imports optional Ray Data LLM and vLLM dependencies lazily, and bypasses the worker `ModelFacade` path only for the supported one-column prototype.
+
+## Execution Prototype
+
+The executable slice intentionally supports less than the planner can describe:
+
+- exactly one selected `LLMTextColumnConfig`
+- no prompt dependencies, tools, trace columns, reasoning-content side effects, `skip`, `drop`, `allow_resize`, or DataDesigner processor configs
+- fixed chat-completion sampling parameters only; timeout, `extra_body`, and distribution-sampled parameters continue through the `ModelFacade` path
+- no seed-window hydration and no `output_chunk_rows`
+
+The Ray Data LLM processor preprocess function builds OpenAI-style chat messages and preserves the original Ray row in an internal field. The postprocess function writes the vLLM `generated_text` into the selected DataDesigner column and restores pre-existing non-selected columns. From-scratch range ids are not exposed unless they are needed internally for `preserve_order=True`.
 
 ## Non-Goals For This Slice
 
@@ -70,9 +81,10 @@ The current implementation records this eligibility through `plan_ray_data_llm_s
 - No required `vllm` dependency.
 - No changes to existing external OpenAI-compatible provider behavior.
 - No planner rewrite or GPU benchmark in this PR.
+- No usage-stat parity, trace parity, MCP/tool loop support, structured parsing, or processor support in the execution prototype.
 
 ## Follow-Up Recommendation
 
 [Issue #118](https://github.com/eric-tramel/DataDesigner/issues/118) tracks a RayBackend-only proof of concept and benchmark. The POC should compare the existing RayBackend plus OpenAI-compatible vLLM server path against a Ray Data LLM processor stage for a single independent text column, then expand only if the result preserves usage stats, errors, ordering, dropped-row behavior, and observability.
 
-The remaining execution step needs an environment with `ray.data.llm` optional dependencies and a real local vLLM model source. Local package introspection on the current development environment found `ray.data.llm` imports fail because optional dependencies such as `boto3` are absent, so the merged hook intentionally fails fast or falls back instead of adding an unverified execution path.
+The remaining validation step needs an environment with `ray.data.llm` optional dependencies, vLLM, GPU resources, and a real local model source. Local package introspection on the current development environment found `ray.data.llm` imports fail because optional dependencies such as `boto3` are absent, so local tests use a fake Ray Data LLM processor and the real path fails fast when those optional dependencies are unavailable.

--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -25,7 +25,9 @@ from data_designer.integrations.ray.errors import RayBackendConfigurationError, 
 from data_designer.integrations.ray.llm import (
     RayDataLLMStageOptions,
     RayDataLLMStagePlan,
+    apply_ray_data_llm_stage,
     plan_ray_data_llm_stage,
+    validate_ray_data_llm_execution_plan,
 )
 from data_designer.integrations.ray.metrics import RayDatasetMetrics, RayWorkerMetrics
 from data_designer.integrations.ray.observability import RayDatasetAnalysis
@@ -130,6 +132,7 @@ class RayJobPlan:
     throttle_manager: Any | None
     observability_options: _RayObservabilityOptions
     llm_stage_plan: RayDataLLMStagePlan
+    llm_stage_config_builder: DataDesignerConfigBuilder
     output: RayOutputMode
     num_records: int
     input_blocks: int | None
@@ -452,14 +455,24 @@ class RayBackend:
     def _execute_plan(
         self, ray: Any, plan: RayJobPlan, *, materialize_output: bool = True
     ) -> tuple[Any, Any, Any | None]:
-        try:
-            mapped = plan.dataset_source.dataset.map_batches(_RayBatchWorker, **plan.map_batches_kwargs)
-        except RayDatasetGenerationError:
-            raise
-        except Exception as exc:
-            raise RayDatasetGenerationError(
-                "RayBackend failed while constructing the Ray map_batches execution plan."
-            ) from exc
+        if plan.llm_stage_plan.should_execute:
+            mapped = apply_ray_data_llm_stage(
+                plan.dataset_source.dataset,
+                config_builder=plan.llm_stage_config_builder,
+                plan=plan.llm_stage_plan,
+                preserve_input_columns=plan.dataset_source.use_input_dataset,
+                hidden_order_column=plan.ordering_mode.hidden_order_column,
+                range_order_column=ray_seed_planning.RAY_RANGE_ID_COLUMN,
+            )
+        else:
+            try:
+                mapped = plan.dataset_source.dataset.map_batches(_RayBatchWorker, **plan.map_batches_kwargs)
+            except RayDatasetGenerationError:
+                raise
+            except Exception as exc:
+                raise RayDatasetGenerationError(
+                    "RayBackend failed while constructing the Ray map_batches execution plan."
+                ) from exc
 
         try:
             mapped = plan.ordering_mode.apply(mapped)
@@ -668,6 +681,12 @@ class RayDriverPlanner:
             options=self._backend.llm_stage_options,
         )
         _validate_llm_stage_plan(llm_stage_plan)
+        validate_ray_data_llm_execution_plan(config_builder=config_builder, plan=llm_stage_plan)
+        _validate_llm_stage_execution_backend_support(
+            plan=llm_stage_plan,
+            dataset_source_kind=dataset_source_kind,
+            output_chunk_rows=self._backend.output_chunk_rows,
+        )
         worker_config_builder = _clone_config_builder_for_worker(
             config_builder,
             worker_model_health_checks=self._backend.worker_model_health_checks,
@@ -733,6 +752,7 @@ class RayDriverPlanner:
             throttle_manager=throttle_manager,
             observability_options=observability_options,
             llm_stage_plan=llm_stage_plan,
+            llm_stage_config_builder=config_builder,
             output=self._backend.output,
             num_records=num_records,
             input_blocks=_get_num_blocks(dataset),
@@ -1079,6 +1099,12 @@ def _generate_batch(
 
 
 def _validate_llm_stage_plan(plan: RayDataLLMStagePlan) -> None:
+    if plan.should_execute and not plan.has_eligible_stage:
+        reason = plan.disabled_reason or "no eligible Ray Data LLM stage candidate was found"
+        raise RayBackendConfigurationError(
+            "RayBackend Ray Data LLM execution was explicitly requested but cannot be planned: "
+            f"{reason} Disable execute=True to use the existing ModelFacade execution path."
+        )
     if not plan.enabled or plan.has_eligible_stage or plan.options.allow_model_facade_fallback:
         return
     reason = plan.disabled_reason or "no eligible Ray Data LLM stage candidate was found"
@@ -1086,6 +1112,22 @@ def _validate_llm_stage_plan(plan: RayDataLLMStagePlan) -> None:
         "RayBackend Ray Data LLM stage was explicitly requested but cannot be planned: "
         f"{reason} Set allow_model_facade_fallback=True to use the existing ModelFacade execution path."
     )
+
+
+def _validate_llm_stage_execution_backend_support(
+    *,
+    plan: RayDataLLMStagePlan,
+    dataset_source_kind: RayDatasetSourceKind,
+    output_chunk_rows: int | None,
+) -> None:
+    if not plan.should_execute:
+        return
+    if dataset_source_kind == "seed_window":
+        raise RayBackendConfigurationError(
+            "RayBackend Ray Data LLM execution does not yet support streaming seed-window hydration."
+        )
+    if output_chunk_rows is not None:
+        raise RayBackendConfigurationError("RayBackend Ray Data LLM execution does not yet support output_chunk_rows.")
 
 
 def _import_ray() -> Any:

--- a/packages/data-designer/src/data_designer/integrations/ray/llm.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/llm.py
@@ -11,7 +11,8 @@ from typing import Any, Literal
 
 from data_designer.config.column_configs import EmbeddingColumnConfig, LLMTextColumnConfig, TraceType
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.integrations.ray.errors import RayBackendConfigurationError
+from data_designer.config.models import ChatCompletionInferenceParams, ModelConfig
+from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 
 RayDataLLMPlacement = Literal["ray-backend-stage-optimization"]
 RayDataLLMTaskType = Literal["generate", "embed", "classify", "score"]
@@ -21,10 +22,10 @@ _REQUIRED_RAY_DATA_LLM_SYMBOLS = ("build_processor", "vLLMEngineProcessorConfig"
 _SUPPORTED_TASK_TYPES = ("generate", "embed", "classify", "score")
 _RECOMMENDED_PLACEMENT: RayDataLLMPlacement = "ray-backend-stage-optimization"
 _DEFAULT_SEMANTIC_CONTRACT = (
-    "The prototype hook is planning-only; selected stages still execute through the existing ModelFacade path.",
-    "Usage stats remain the ModelFacade source of truth until Ray Data LLM responses are normalized into model usage deltas.",
-    "Ray Data LLM execution must wrap Ray/vLLM exceptions in RayDatasetGenerationError before it replaces a worker stage.",
-    "Ordering and dropped-row semantics must remain owned by RayBackend ordering and row-count validation.",
+    "Ray Data LLM execution is opt-in and limited to one independent plain LLMTextColumnConfig stage.",
+    "Usage stats remain unavailable for the Ray Data LLM execution path until responses are normalized into model usage deltas.",
+    "Ray Data LLM execution wraps Ray/vLLM exceptions in RayDatasetGenerationError before replacing a worker stage.",
+    "Ordering semantics remain owned by RayBackend ordering; dropped-row and processor semantics are not supported by the prototype.",
     "Artifact and observability output must use existing RayBackend artifact columns, metrics, and dataset analysis payloads.",
 )
 _RECOMMENDATION = (
@@ -42,8 +43,10 @@ _BLOCKING_GAPS = (
 )
 _SAFE_FIRST_SLICE = (
     "Detect Ray Data LLM availability and keep external providers on the existing OpenAI-compatible facade. "
-    "A future prototype can add a RayBackend-only stage for one eligible independent LLM text column."
+    "The executable prototype is RayBackend-only and supports one eligible independent LLM text column."
 )
+_ORIGINAL_ROW_KEY = "__data_designer_ray_llm_original_row"
+_RAY_RANGE_ID_COLUMN = "id"
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,6 +54,7 @@ class RayDataLLMStageOptions:
     """Explicit opt-in controls for the RayBackend Ray Data LLM/vLLM prototype hook."""
 
     enabled: bool = False
+    execute: bool = False
     model_source: str | None = None
     column_names: tuple[str, ...] = ()
     model_aliases: tuple[str, ...] = ()
@@ -63,6 +67,7 @@ class RayDataLLMStageOptions:
 
     def __post_init__(self) -> None:
         _validate_bool("enabled", self.enabled)
+        _validate_bool("execute", self.execute)
         _validate_optional_non_empty_string("model_source", self.model_source)
         _validate_non_empty_string_tuple("column_names", self.column_names)
         _validate_non_empty_string_tuple("model_aliases", self.model_aliases)
@@ -80,6 +85,8 @@ class RayDataLLMStageOptions:
             raise RayBackendConfigurationError(
                 "RayDataLLMStageOptions enabled=True requires model_source for the local vLLM engine."
             )
+        if self.execute and not self.enabled:
+            raise RayBackendConfigurationError("RayDataLLMStageOptions execute=True requires enabled=True.")
         if self.enabled and not self.column_names and not self.model_aliases:
             raise RayBackendConfigurationError(
                 "RayDataLLMStageOptions enabled=True requires column_names or model_aliases."
@@ -89,6 +96,11 @@ class RayDataLLMStageOptions:
     def has_explicit_opt_in(self) -> bool:
         """Return whether the RayBackend should evaluate Ray Data LLM stage eligibility."""
         return self.enabled
+
+    @property
+    def should_execute(self) -> bool:
+        """Return whether the RayBackend should replace worker execution with Ray Data LLM."""
+        return self.enabled and self.execute
 
     def processor_config_kwargs(self) -> dict[str, Any]:
         """Return Ray Data LLM processor config kwargs for a future execution stage."""
@@ -183,6 +195,60 @@ class RayDataLLMStagePlan:
     def has_eligible_stage(self) -> bool:
         """Return whether the planner found exactly one executable prototype stage."""
         return self.selected_candidate is not None
+
+    @property
+    def should_execute(self) -> bool:
+        """Return whether this plan requests Ray Data LLM execution."""
+        return self.options.should_execute
+
+
+@dataclass(frozen=True, slots=True)
+class _RayDataLLMExecutionAPI:
+    build_processor: Any
+    vllm_engine_processor_config: Any
+
+
+@dataclass(frozen=True, slots=True)
+class _RayDataLLMTextPreprocessor:
+    prompt: str
+    system_prompt: str | None
+    sampling_params: Mapping[str, Any]
+    preserve_input_columns: bool
+    hidden_order_column: str | None
+    range_order_column: str
+
+    def __call__(self, row: Mapping[str, Any]) -> dict[str, Any]:
+        original_row = dict(row) if self.preserve_input_columns else {}
+        if self.hidden_order_column is not None:
+            if self.hidden_order_column in row:
+                original_row[self.hidden_order_column] = row[self.hidden_order_column]
+            elif self.range_order_column in row:
+                original_row[self.hidden_order_column] = row[self.range_order_column]
+        messages: list[dict[str, str]] = []
+        if self.system_prompt is not None:
+            messages.append({"role": "system", "content": self.system_prompt})
+        messages.append({"role": "user", "content": self.prompt})
+        output: dict[str, Any] = {
+            _ORIGINAL_ROW_KEY: original_row,
+            "messages": messages,
+        }
+        if self.sampling_params:
+            output["sampling_params"] = dict(self.sampling_params)
+        return output
+
+
+@dataclass(frozen=True, slots=True)
+class _RayDataLLMTextPostprocessor:
+    column_name: str
+
+    def __call__(self, row: Mapping[str, Any]) -> dict[str, Any]:
+        if _ORIGINAL_ROW_KEY not in row:
+            raise RayDatasetGenerationError("Ray Data LLM postprocess did not receive the preserved original row.")
+        if "generated_text" not in row:
+            raise RayDatasetGenerationError("Ray Data LLM vLLM response did not contain generated_text.")
+        output = dict(row[_ORIGINAL_ROW_KEY])
+        output[self.column_name] = row["generated_text"]
+        return output
 
 
 def probe_ray_data_llm_capabilities() -> RayDataLLMCapabilities:
@@ -289,11 +355,200 @@ def plan_ray_data_llm_stage(
     )
 
 
+def validate_ray_data_llm_execution_plan(
+    *,
+    config_builder: DataDesignerConfigBuilder,
+    plan: RayDataLLMStagePlan,
+) -> None:
+    """Validate the executable Ray Data LLM prototype slice.
+
+    The planner can record broader future candidates. Actual execution is much
+    narrower so the backend does not silently bypass ModelFacade-only semantics.
+    """
+    if not plan.should_execute:
+        return
+    if not plan.has_eligible_stage:
+        reason = plan.disabled_reason or "no eligible Ray Data LLM stage candidate was found"
+        raise RayBackendConfigurationError(
+            "RayBackend Ray Data LLM execution was requested but cannot be planned: "
+            f"{reason} Disable execute=True to use the existing ModelFacade execution path."
+        )
+    selected_candidate = plan.selected_candidate
+    if selected_candidate is None or selected_candidate.task_type != "generate":
+        raise RayBackendConfigurationError(
+            "RayBackend Ray Data LLM execution currently supports only task_type='generate'."
+        )
+
+    column_configs = config_builder.get_column_configs()
+    if len(column_configs) != 1:
+        raise RayBackendConfigurationError(
+            "RayBackend Ray Data LLM execution currently supports configs with exactly one selected "
+            "LLMTextColumnConfig and no other generated columns."
+        )
+    column_config = column_configs[0]
+    if type(column_config) is not LLMTextColumnConfig or column_config.name != selected_candidate.column_name:
+        raise RayBackendConfigurationError(
+            "RayBackend Ray Data LLM execution currently supports exactly one selected LLMTextColumnConfig."
+        )
+    if config_builder.get_processor_configs():
+        raise RayBackendConfigurationError(
+            "RayBackend Ray Data LLM execution does not yet support DataDesigner processor configs."
+        )
+
+    model_config = _model_config_for_alias(config_builder, selected_candidate.model_alias)
+    blocked_reasons = _text_execution_blocked_reasons(column_config, model_config, plan.options)
+    if blocked_reasons:
+        raise RayBackendConfigurationError(
+            "RayBackend Ray Data LLM execution cannot preserve this LLM text column yet: " + " ".join(blocked_reasons)
+        )
+
+
+def apply_ray_data_llm_stage(
+    dataset: Any,
+    *,
+    config_builder: DataDesignerConfigBuilder,
+    plan: RayDataLLMStagePlan,
+    preserve_input_columns: bool,
+    hidden_order_column: str | None = None,
+    range_order_column: str = _RAY_RANGE_ID_COLUMN,
+) -> Any:
+    """Apply the optional Ray Data LLM processor stage to a Ray Dataset."""
+    validate_ray_data_llm_execution_plan(config_builder=config_builder, plan=plan)
+    selected_candidate = plan.selected_candidate
+    if selected_candidate is None:
+        raise RayDatasetGenerationError("RayBackend Ray Data LLM execution has no selected stage candidate.")
+    column_config = _selected_text_column_config(config_builder, selected_candidate)
+    model_config = _model_config_for_alias(config_builder, selected_candidate.model_alias)
+    execution_api = _load_ray_data_llm_execution_api()
+    try:
+        processor_config = execution_api.vllm_engine_processor_config(**plan.options.processor_config_kwargs())
+        processor = execution_api.build_processor(
+            processor_config,
+            preprocess=_RayDataLLMTextPreprocessor(
+                prompt=column_config.prompt,
+                system_prompt=column_config.system_prompt,
+                sampling_params=_sampling_params_from_model_config(model_config),
+                preserve_input_columns=preserve_input_columns,
+                hidden_order_column=hidden_order_column,
+                range_order_column=range_order_column,
+            ),
+            postprocess=_RayDataLLMTextPostprocessor(column_name=column_config.name),
+        )
+        return processor(dataset)
+    except RayDatasetGenerationError:
+        raise
+    except RayBackendConfigurationError:
+        raise
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend Ray Data LLM execution failed.") from exc
+
+
 def _package_version(package_name: str) -> str | None:
     try:
         return version(package_name)
     except PackageNotFoundError:
         return None
+
+
+def _load_ray_data_llm_execution_api() -> _RayDataLLMExecutionAPI:
+    try:
+        ray_data_llm = importlib.import_module("ray.data.llm")
+    except Exception as exc:
+        raise RayDatasetGenerationError(
+            "RayBackend Ray Data LLM execution requires Ray LLM optional dependencies. "
+            "Install the Ray LLM extra, including dependencies such as boto3 and vLLM."
+        ) from exc
+
+    missing_symbols = tuple(symbol for symbol in _REQUIRED_RAY_DATA_LLM_SYMBOLS if not hasattr(ray_data_llm, symbol))
+    if missing_symbols:
+        raise RayDatasetGenerationError(
+            "RayBackend Ray Data LLM execution requires ray.data.llm symbols "
+            f"{_REQUIRED_RAY_DATA_LLM_SYMBOLS!r}; missing {missing_symbols!r}."
+        )
+    try:
+        importlib.import_module("vllm")
+    except Exception as exc:
+        raise RayDatasetGenerationError(
+            "RayBackend Ray Data LLM execution requires vLLM to be importable on the driver and Ray workers."
+        ) from exc
+    return _RayDataLLMExecutionAPI(
+        build_processor=ray_data_llm.build_processor,
+        vllm_engine_processor_config=ray_data_llm.vLLMEngineProcessorConfig,
+    )
+
+
+def _selected_text_column_config(
+    config_builder: DataDesignerConfigBuilder,
+    selected_candidate: RayDataLLMStageCandidate,
+) -> LLMTextColumnConfig:
+    for column_config in config_builder.get_column_configs():
+        if type(column_config) is LLMTextColumnConfig and column_config.name == selected_candidate.column_name:
+            return column_config
+    raise RayBackendConfigurationError(
+        f"RayBackend Ray Data LLM selected column {selected_candidate.column_name!r} was not found."
+    )
+
+
+def _model_config_for_alias(
+    config_builder: DataDesignerConfigBuilder,
+    model_alias: str | None,
+) -> ModelConfig:
+    if model_alias is None:
+        raise RayBackendConfigurationError("RayBackend Ray Data LLM selected column has no model alias.")
+    for model_config in config_builder.model_configs:
+        if model_config.alias == model_alias:
+            return model_config
+    raise RayBackendConfigurationError(f"RayBackend Ray Data LLM model alias {model_alias!r} was not found.")
+
+
+def _text_execution_blocked_reasons(
+    column_config: LLMTextColumnConfig,
+    model_config: ModelConfig,
+    options: RayDataLLMStageOptions,
+) -> list[str]:
+    blocked_reasons: list[str] = []
+    if column_config.drop:
+        blocked_reasons.append("drop=True is not supported.")
+    if column_config.skip is not None:
+        blocked_reasons.append("skip expressions are not supported.")
+    if column_config.allow_resize:
+        blocked_reasons.append("allow_resize is not supported.")
+    if not isinstance(model_config.inference_parameters, ChatCompletionInferenceParams):
+        blocked_reasons.append("the selected model must use ChatCompletionInferenceParams.")
+    if isinstance(options.concurrency, tuple) and len(options.concurrency) != 2:
+        blocked_reasons.append("execution supports only integer concurrency or a 2-item autoscaling tuple.")
+    blocked_reasons.extend(_sampling_params_blocked_reasons(model_config))
+    return blocked_reasons
+
+
+def _sampling_params_blocked_reasons(model_config: ModelConfig) -> list[str]:
+    inference_params = model_config.inference_parameters
+    if not isinstance(inference_params, ChatCompletionInferenceParams):
+        return []
+    blocked_reasons: list[str] = []
+    if inference_params.timeout is not None:
+        blocked_reasons.append("per-request timeout is not a vLLM sampling parameter.")
+    if inference_params.extra_body:
+        blocked_reasons.append("extra_body passthrough is not supported by the prototype.")
+    for field_name in ("temperature", "top_p"):
+        value = getattr(inference_params, field_name)
+        if hasattr(value, "sample"):
+            blocked_reasons.append(f"{field_name} distributions are not supported by the prototype.")
+    return blocked_reasons
+
+
+def _sampling_params_from_model_config(model_config: ModelConfig) -> dict[str, Any]:
+    inference_params = model_config.inference_parameters
+    if not isinstance(inference_params, ChatCompletionInferenceParams):
+        return {}
+    sampling_params: dict[str, Any] = {}
+    if inference_params.temperature is not None:
+        sampling_params["temperature"] = inference_params.temperature
+    if inference_params.top_p is not None:
+        sampling_params["top_p"] = inference_params.top_p
+    if inference_params.max_tokens is not None:
+        sampling_params["max_tokens"] = inference_params.max_tokens
+    return sampling_params
 
 
 def _assess_stage_candidate(column_config: Any, options: RayDataLLMStageOptions) -> RayDataLLMStageCandidate | None:

--- a/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
+++ b/packages/data-designer/tests/integrations/ray/fake_ray_harness.py
@@ -157,8 +157,28 @@ class FakeRayDataset:
         self.map_batches_kwargs: dict[str, Any] | None = None
         self.map_batches_fn: Any | None = None
         self.map_batches_calls: list[FakeMapBatchesCall] = []
+        self.map_calls: list[dict[str, Any]] = []
         self.repartition_calls: list[dict[str, Any]] = []
         self.write_datasink_kwargs: dict[str, Any] | None = None
+
+    def map(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
+        self.map_calls.append({"fn": fn, "kwargs": dict(kwargs)})
+        if self.data_module is not None:
+            self.data_module.map_calls.append({"fn": fn, "kwargs": dict(kwargs)})
+        blocks: list[lazy.pd.DataFrame] = []
+        for block in self.blocks:
+            dataframe = coerce_pandas_dataframe(block)
+            records = [fn(row, **(kwargs.get("fn_kwargs") or {})) for row in dataframe.to_dict(orient="records")]
+            blocks.append(lazy.pd.DataFrame(records))
+        mapped = FakeRayDataset(
+            blocks,
+            data_module=self.data_module,
+            reverse_mapped_blocks=self.reverse_mapped_blocks,
+            data_context=self.data_context,
+        )
+        mapped.repartition_calls = list(self.repartition_calls)
+        mapped.map_calls = list(self.map_calls)
+        return mapped
 
     def map_batches(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
         if self.data_module is not None:
@@ -179,6 +199,7 @@ class FakeRayDataset:
             data_context=self.data_context,
         )
         mapped.repartition_calls = list(self.repartition_calls)
+        mapped.map_calls = list(self.map_calls)
         return mapped
 
     def write_datasink(
@@ -227,6 +248,7 @@ class FakeRayDataset:
             data_context=self.data_context,
         )
         repartitioned.repartition_calls = list(self.repartition_calls)
+        repartitioned.map_calls = list(self.map_calls)
         return repartitioned
 
     def zip(self, other: FakeRayDataset) -> FakeRayDataset:
@@ -246,6 +268,7 @@ class FakeRayDataset:
             data_context=self.data_context or other.data_context,
         )
         zipped.repartition_calls = list(self.repartition_calls)
+        zipped.map_calls = list(self.map_calls)
         return zipped
 
     def filter(self, fn: Any, **kwargs: Any) -> FakeRayDataset:
@@ -262,6 +285,7 @@ class FakeRayDataset:
             data_context=self.data_context,
         )
         filtered.repartition_calls = list(self.repartition_calls)
+        filtered.map_calls = list(self.map_calls)
         return filtered
 
     def limit(self, limit: int) -> FakeRayDataset:
@@ -283,6 +307,7 @@ class FakeRayDataset:
             data_context=self.data_context,
         )
         limited.repartition_calls = list(self.repartition_calls)
+        limited.map_calls = list(self.map_calls)
         return limited
 
     def union(self, *others: FakeRayDataset) -> FakeRayDataset:
@@ -293,6 +318,7 @@ class FakeRayDataset:
             data_context=self.data_context,
         )
         unioned.repartition_calls = list(self.repartition_calls)
+        unioned.map_calls = list(self.map_calls)
         return unioned
 
     def to_arrow_refs(self) -> list[Any]:
@@ -312,6 +338,7 @@ class FakeRayDataset:
         sorted_df = self.to_pandas().sort_values(column, kind="stable").reset_index(drop=True)
         sorted_dataset = FakeRayDataset([sorted_df], data_module=self.data_module, data_context=self.data_context)
         sorted_dataset.repartition_calls = list(self.repartition_calls)
+        sorted_dataset.map_calls = list(self.map_calls)
         return sorted_dataset
 
     def drop_columns(self, columns: list[str]) -> FakeRayDataset:
@@ -322,6 +349,7 @@ class FakeRayDataset:
             data_context=self.data_context,
         )
         dropped.repartition_calls = list(self.repartition_calls)
+        dropped.map_calls = list(self.map_calls)
         return dropped
 
     def num_blocks(self) -> int:
@@ -369,6 +397,7 @@ class FakeRayDataModule:
         self.ExecutionResources = FakeExecutionResources
         self.latest_dataset_context: FakeDataContext | None = None
         self.map_batches_calls: list[FakeMapBatchesCall] = []
+        self.map_calls: list[dict[str, Any]] = []
 
     def dataset(
         self,

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -44,6 +44,7 @@ from data_designer.integrations.ray import (
     RayInputRepartition,
 )
 from data_designer.integrations.ray import backend as ray_backend_module
+from data_designer.integrations.ray import llm as ray_llm_module
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
 from data_designer.integrations.ray.artifact_output import (
     DataDesignerRayDatasink,
@@ -119,6 +120,69 @@ def _map_batches_call_for(fake_ray: Any, fn: Any) -> FakeMapBatchesCall:
         if call.fn is fn:
             return call
     raise AssertionError(f"fake Ray did not record map_batches call for {fn!r}")
+
+
+def _install_fake_ray_data_llm(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    processor_calls: list[dict[str, Any]] = []
+
+    class FakeVLLMEngineProcessorConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class FakeRayDataLLMProcessor:
+        def __init__(self, *, preprocess: Any, postprocess: Any) -> None:
+            self._preprocess = preprocess
+            self._postprocess = postprocess
+
+        def __call__(self, dataset: FakeRayDataset) -> FakeRayDataset:
+            def preprocess_row(row: dict[str, Any]) -> dict[str, Any]:
+                output = dict(row)
+                output.update(self._preprocess(row))
+                return output
+
+            def run_vllm_batch(batch: lazy.pd.DataFrame) -> lazy.pd.DataFrame:
+                rows: list[dict[str, Any]] = []
+                for row in batch.to_dict(orient="records"):
+                    messages = row["messages"]
+                    row["generated_text"] = f"fake-vllm:{messages[-1]['content']}"
+                    rows.append(row)
+                return lazy.pd.DataFrame(rows)
+
+            return dataset.map(preprocess_row).map_batches(run_vllm_batch, batch_format="pandas").map(self._postprocess)
+
+    def build_processor(
+        config: FakeVLLMEngineProcessorConfig,
+        preprocess: Any,
+        postprocess: Any,
+        **kwargs: Any,
+    ) -> FakeRayDataLLMProcessor:
+        processor_calls.append(
+            {
+                "config": config,
+                "preprocess": preprocess,
+                "postprocess": postprocess,
+                "kwargs": kwargs,
+            }
+        )
+        return FakeRayDataLLMProcessor(preprocess=preprocess, postprocess=postprocess)
+
+    fake_ray_data_llm = types.SimpleNamespace(
+        build_processor=build_processor,
+        vLLMEngineProcessorConfig=FakeVLLMEngineProcessorConfig,
+        HttpRequestProcessorConfig=object(),
+        ServeDeploymentProcessorConfig=object(),
+    )
+    original_import_module = ray_llm_module.importlib.import_module
+
+    def import_module(name: str) -> Any:
+        if name == "ray.data.llm":
+            return fake_ray_data_llm
+        if name == "vllm":
+            return types.SimpleNamespace()
+        return original_import_module(name)
+
+    monkeypatch.setattr(ray_llm_module.importlib, "import_module", import_module)
+    return processor_calls
 
 
 @custom_column_generator(required_columns=["x"])
@@ -1375,6 +1439,173 @@ def test_ray_backend_llm_stage_can_fail_fast_when_fallback_is_disabled(
         designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
 
     assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_backend_executes_opt_in_ray_data_llm_stage_with_fake_processor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    processor_calls = _install_fake_ray_data_llm(monkeypatch)
+    input_dataset = FakeRayDataset(
+        [
+            lazy.pd.DataFrame(
+                {
+                    "id": [1, 2],
+                    "source": ["alpha", "beta"],
+                    "generated_text": ["keep-a", "keep-b"],
+                }
+            )
+        ]
+    )
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=2,
+            preflight_model_health_check=False,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                execute=True,
+                model_source="local-model",
+                column_names=("text",),
+                batch_size=4,
+                concurrency=(1, 2),
+            ),
+        ),
+    )
+
+    results = designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+    output_df = results.load_dataset().to_pandas()
+
+    assert output_df.to_dict(orient="records") == [
+        {
+            "id": 1,
+            "source": "alpha",
+            "generated_text": "keep-a",
+            "text": "fake-vllm:Say hello.",
+        },
+        {
+            "id": 2,
+            "source": "beta",
+            "generated_text": "keep-b",
+            "text": "fake-vllm:Say hello.",
+        },
+    ]
+    assert results.llm_stage_plan is not None
+    assert results.llm_stage_plan.should_execute is True
+    assert len(processor_calls) == 1
+    assert processor_calls[0]["config"].kwargs["model_source"] == "local-model"
+    assert processor_calls[0]["config"].kwargs["batch_size"] == 4
+    assert processor_calls[0]["config"].kwargs["concurrency"] == (1, 2)
+    assert all(call.fn is not ray_backend_module._RayBatchWorker for call in input_dataset.map_batches_calls)
+
+
+def test_ray_backend_ray_data_llm_stage_drops_range_id_for_from_scratch_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    _install_fake_ray_data_llm(monkeypatch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=2,
+            preflight_model_health_check=False,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                execute=True,
+                model_source="local-model",
+                column_names=("text",),
+            ),
+        ),
+    )
+
+    results = designer.create(_llm_config_builder(stub_model_configs), num_records=2)
+    output_df = results.load_dataset().to_pandas()
+
+    assert output_df.to_dict(orient="records") == [
+        {"text": "fake-vllm:Say hello."},
+        {"text": "fake-vllm:Say hello."},
+    ]
+
+
+def test_ray_backend_ray_data_llm_execution_requires_optional_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            preflight_model_health_check=False,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                execute=True,
+                model_source="local-model",
+                column_names=("text",),
+            ),
+        ),
+    )
+
+    with pytest.raises(RayBackendConfigurationError, match="execution was explicitly requested"):
+        designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_backend_default_llm_stage_planning_does_not_execute_ray_data_llm(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    processor_calls = _install_fake_ray_data_llm(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+
+    def generate_batch(batch: lazy.pd.DataFrame, **_: Any) -> lazy.pd.DataFrame:
+        return batch.assign(text="facade-path")
+
+    monkeypatch.setattr(ray_backend_module, "_generate_batch", generate_batch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            preflight_model_health_check=False,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                model_source="local-model",
+                column_names=("text",),
+            ),
+        ),
+    )
+
+    results = designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert results.load_dataset().to_pandas().to_dict(orient="records") == [{"id": 0, "text": "facade-path"}]
+    assert processor_calls == []
+    assert input_dataset.map_batches_kwargs is not None
+    assert input_dataset.map_batches_fn is ray_backend_module._RayBatchWorker
 
 
 def test_ray_backend_driver_model_health_check_runs_once_and_workers_skip_by_default(

--- a/packages/data-designer/tests/integrations/ray/test_llm.py
+++ b/packages/data-designer/tests/integrations/ray/test_llm.py
@@ -88,9 +88,19 @@ def test_ray_data_llm_stage_options_require_explicit_model_source() -> None:
         ray_llm.RayDataLLMStageOptions(enabled=True, column_names=("summary",))
 
 
+def test_ray_data_llm_stage_options_require_enabled_before_execute() -> None:
+    with pytest.raises(RayBackendConfigurationError, match="execute=True requires enabled=True"):
+        ray_llm.RayDataLLMStageOptions(
+            execute=True,
+            model_source="local-model",
+            column_names=("summary",),
+        )
+
+
 def test_ray_data_llm_stage_options_build_processor_config_kwargs() -> None:
     options = ray_llm.RayDataLLMStageOptions(
         enabled=True,
+        execute=True,
         model_source="local-model",
         column_names=("summary",),
         batch_size=8,


### PR DESCRIPTION
## 📋 Summary

Adds a narrow opt-in Ray Data LLM/vLLM execution path on top of the #128 planning hook. The new path is intentionally constrained to one independent plain `LLMTextColumnConfig`, preserves existing non-selected Ray row columns, and fails fast when optional Ray Data LLM or vLLM dependencies are unavailable.

## 🔗 Related Issue

Part of #118

## 🔄 Changes

- Adds `RayDataLLMStageOptions.execute` to distinguish planning from execution.
- Applies a lazy Ray Data LLM `build_processor(vLLMEngineProcessorConfig, preprocess, postprocess)` stage when the executable prototype is explicitly requested.
- Restricts execution to the semantics-safe slice: one selected `LLMTextColumnConfig`, no processors, no skip/drop/resize behavior, no trace/reasoning/tool side effects, fixed chat-completion sampling params, and no seed-window or output chunking.
- Preserves original input rows through Ray Data LLM preprocess/postprocess wiring while dropping from-scratch Ray range ids from user output.
- Extends the fake Ray harness with row-wise `Dataset.map()` support and adds fake processor tests for execution, dependency failure, and default non-execution behavior.
- Updates `architecture/ray-data-llm.md` with the executable prototype boundaries and remaining validation gaps.

## 🧪 Testing

- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-n uv run --all-packages pytest packages/data-designer/tests/integrations/ray/test_llm.py packages/data-designer/tests/integrations/ray/test_backend.py -q -m ray_fake` (98 passed)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-n uv run --all-packages pytest packages/data-designer/tests/integrations/ray -m 'ray_fake or ray_worker_boundary or ray_benchmark' -q` (266 passed, 1 skipped, 7 deselected)
- [x] `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 UV_CACHE_DIR=/tmp/uv-cache-dd-worker-n uv run --all-packages --extra ray --group dev --group recipes pytest packages/data-designer/tests/integrations/ray/test_real_smoke.py -m 'ray_real_smoke and not ray_live_provider' -q` (6 passed, 1 deselected)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-n uv run --all-packages ruff check architecture/ray-data-llm.md packages/data-designer/src/data_designer/integrations/ray/llm.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_llm.py packages/data-designer/tests/integrations/ray/test_backend.py`
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-n uv run --all-packages ruff format --check packages/data-designer/src/data_designer/integrations/ray/llm.py packages/data-designer/src/data_designer/integrations/ray/backend.py packages/data-designer/tests/integrations/ray/fake_ray_harness.py packages/data-designer/tests/integrations/ray/test_llm.py packages/data-designer/tests/integrations/ray/test_backend.py`

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated