### PR TITLE
feat(ray): stream artifact capture chunks

### DIFF
--- a/docs/concepts/ray-backend.md
+++ b/docs/concepts/ray-backend.md
@@ -38,7 +38,7 @@ artifacts/
 
 ## Streaming Worker Chunks
 
-Set `output_chunk_rows` to have Ray workers emit generated output in smaller Ray Data chunks. For partition-local jobs without artifact capture, RayBackend now uses the engine async row-group path, so a worker can release each generated row group instead of first materializing the full `map_batches` output frame. If processor artifacts are being captured, or if hidden ordering would need to reconcile row-count-changing output, RayBackend falls back to the older materialized chunking path to preserve artifacts and ordering semantics.
+Set `output_chunk_rows` to have Ray workers emit generated output in smaller Ray Data chunks. For partition-local jobs, RayBackend uses the engine async row-group path, so a worker can release each generated row group instead of first materializing the full `map_batches` output frame. When `write_artifacts=True`, dropped-column and processor artifact payloads are attached to each emitted chunk and split back out by the Ray datasink. If hidden ordering would need to reconcile row-count-changing output, RayBackend falls back to the older materialized chunking path to preserve ordering semantics.
 
 ```python
 backend = RayBackend(

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/block_execution.py
@@ -73,6 +73,7 @@ class BlockExecutionOptions:
     use_async: bool = True
     dataset_name: str = "dataset-block"
     current_batch_number: int | None = None
+    capture_stream_artifacts: bool = False
 
 
 @dataclass(frozen=True)
@@ -103,6 +104,7 @@ class BlockExecutionChunk:
     input_start: int
     input_rows: int
     output_rows: int
+    processor_artifacts: dict[str, pd.DataFrame] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -385,6 +387,7 @@ def _execute_stream_with_storage(
                 num_records=num_records,
                 rows_per_chunk=rows_per_chunk,
                 current_batch_number=options.current_batch_number,
+                capture_artifacts=options.capture_stream_artifacts,
             ):
                 output_rows += len(chunk.dataframe)
                 yield _block_execution_chunk(chunk)
@@ -392,7 +395,9 @@ def _execute_stream_with_storage(
             elapsed = time.perf_counter() - start_time
             model_usage_stats = block_resource_provider.model_registry.get_model_usage_stats(elapsed)
             model_usage_deltas = block_resource_provider.model_registry.get_usage_deltas(usage_snapshot)
-            processor_artifacts = _load_processor_artifacts(artifact_storage)
+            processor_artifacts = (
+                {} if options.capture_stream_artifacts else _load_processor_artifacts(artifact_storage)
+            )
             dropped_rows = max(num_records - output_rows, 0)
             summary_holder["summary"] = BlockExecutionStreamSummary(
                 task_traces=builder.task_traces,
@@ -420,6 +425,7 @@ def _block_execution_chunk(chunk: DatasetBlockChunk) -> BlockExecutionChunk:
         input_start=chunk.input_start,
         input_rows=chunk.input_rows,
         output_rows=len(chunk.dataframe),
+        processor_artifacts=chunk.processor_artifacts,
     )
 
 

--- a/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py
+++ b/packages/data-designer-engine/src/data_designer/engine/dataset_builders/dataset_builder.py
@@ -12,7 +12,7 @@ import sys
 import time
 import uuid
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator
 
@@ -56,7 +56,11 @@ from data_designer.engine.processing.processors.base import Processor
 from data_designer.engine.processing.processors.drop_columns import DropColumnsProcessor
 from data_designer.engine.registry.data_designer_registry import DataDesignerRegistry
 from data_designer.engine.resources.resource_provider import ResourceProvider
-from data_designer.engine.storage.artifact_storage import SDG_CONFIG_FILENAME, ArtifactStorage
+from data_designer.engine.storage.artifact_storage import (
+    BATCH_FILE_NAME_FORMAT,
+    SDG_CONFIG_FILENAME,
+    ArtifactStorage,
+)
 from data_designer.engine.storage.media_storage import StorageMode
 
 if TYPE_CHECKING:
@@ -125,10 +129,22 @@ class DatasetBlockChunk:
     row_group: int
     input_start: int
     input_rows: int
+    processor_artifacts: dict[str, pd.DataFrame] = field(default_factory=dict)
 
 
 def _is_async_trace_enabled(settings: RunConfig) -> bool:
     return settings.async_trace or os.environ.get("DATA_DESIGNER_ASYNC_TRACE", "0") == "1"
+
+
+def _row_group_batch_number(
+    *,
+    current_batch_number: int | None,
+    row_group: int,
+    capture_artifacts: bool,
+) -> int | None:
+    if not capture_artifacts:
+        return current_batch_number
+    return (current_batch_number or 0) + row_group
 
 
 class DatasetBuilder:
@@ -503,6 +519,7 @@ class DatasetBuilder:
         num_records: int,
         rows_per_chunk: int,
         current_batch_number: int | None = None,
+        capture_artifacts: bool = False,
     ) -> Iterator[DatasetBlockChunk]:
         """Build one block as ordered chunks when the async engine can stream row groups.
 
@@ -514,9 +531,14 @@ class DatasetBuilder:
             raise ValueError("rows_per_chunk must be a positive integer.")
 
         if self._processor_runner.has_processors_for(ProcessorStage.AFTER_GENERATION):
+            row_group_batch_number = _row_group_batch_number(
+                current_batch_number=current_batch_number,
+                row_group=0,
+                capture_artifacts=capture_artifacts,
+            )
             raw_dataset, dataset = self.build_block(
                 num_records=num_records,
-                current_batch_number=current_batch_number,
+                current_batch_number=row_group_batch_number,
             )
             yield DatasetBlockChunk(
                 raw_dataframe=raw_dataset,
@@ -524,6 +546,7 @@ class DatasetBuilder:
                 row_group=0,
                 input_start=0,
                 input_rows=num_records,
+                processor_artifacts=self._load_processor_artifacts_for_row_group(row_group_batch_number),
             )
             return
 
@@ -536,10 +559,15 @@ class DatasetBuilder:
         generators, self._graph = self._initialize_generators_and_graph()
         self._use_async = self._resolve_async_selection()
         if not self._use_async:
+            row_group_batch_number = _row_group_batch_number(
+                current_batch_number=current_batch_number,
+                row_group=0,
+                capture_artifacts=capture_artifacts,
+            )
             raw_dataset, dataset = self._build_sync_block_with_initialized_generators(
                 generators=generators,
                 num_records=num_records,
-                current_batch_number=current_batch_number,
+                current_batch_number=row_group_batch_number,
             )
             yield DatasetBlockChunk(
                 raw_dataframe=raw_dataset,
@@ -547,6 +575,7 @@ class DatasetBuilder:
                 row_group=0,
                 input_start=0,
                 input_rows=num_records,
+                processor_artifacts=self._load_processor_artifacts_for_row_group(row_group_batch_number),
             )
             return
 
@@ -555,6 +584,7 @@ class DatasetBuilder:
             num_records=num_records,
             rows_per_chunk=rows_per_chunk,
             current_batch_number=current_batch_number,
+            capture_artifacts=capture_artifacts,
         )
 
     def process_block(self, dataset: pd.DataFrame, *, current_batch_number: int | None = None) -> pd.DataFrame:
@@ -586,6 +616,7 @@ class DatasetBuilder:
         num_records: int,
         rows_per_chunk: int,
         current_batch_number: int | None,
+        capture_artifacts: bool,
     ) -> Iterator[DatasetBlockChunk]:
         """Async block path that emits row groups as soon as they finalize."""
         if num_records == 0:
@@ -602,9 +633,14 @@ class DatasetBuilder:
         def finalize_row_group(rg_id: int) -> None:
             try:
                 raw_df = buffer_manager.get_dataframe(rg_id)
+                row_group_batch_number = _row_group_batch_number(
+                    current_batch_number=current_batch_number,
+                    row_group=rg_id,
+                    capture_artifacts=capture_artifacts,
+                )
                 processed_df = self._processor_runner.run_post_batch(
                     raw_df.copy(),
-                    current_batch_number=current_batch_number,
+                    current_batch_number=row_group_batch_number,
                 )
                 chunk_queue.put(
                     DatasetBlockChunk(
@@ -613,6 +649,7 @@ class DatasetBuilder:
                         row_group=rg_id,
                         input_start=rg_id * rows_per_chunk,
                         input_rows=min(rows_per_chunk, num_records - rg_id * rows_per_chunk),
+                        processor_artifacts=self._load_processor_artifacts_for_row_group(row_group_batch_number),
                     )
                 )
             except DatasetGenerationError as exc:
@@ -674,6 +711,17 @@ class DatasetBuilder:
         finally:
             if not future.done():
                 future.cancel()
+
+    def _load_processor_artifacts_for_row_group(self, batch_number: int | None) -> dict[str, pd.DataFrame]:
+        if batch_number is None:
+            return {}
+        parquet_file_name = BATCH_FILE_NAME_FORMAT.format(batch_number=batch_number)
+        artifacts: dict[str, pd.DataFrame] = {}
+        for processor_name in self.artifact_storage.list_processor_names():
+            file_path = self.artifact_storage.processors_outputs_path / processor_name / parquet_file_name
+            if file_path.is_file():
+                artifacts[processor_name] = lazy.pd.read_parquet(file_path)
+        return artifacts
 
     def _has_image_columns(self) -> bool:
         """Check if config has any image generation columns."""

--- a/packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py
+++ b/packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py
@@ -11,7 +11,7 @@ import pytest
 import data_designer.lazy_heavy_imports as lazy
 from data_designer.config.column_configs import ExpressionColumnConfig, LLMTextColumnConfig, SamplerColumnConfig
 from data_designer.config.config_builder import DataDesignerConfigBuilder
-from data_designer.config.processors import ProcessorType
+from data_designer.config.processors import ProcessorType, SchemaTransformProcessorConfig
 from data_designer.config.run_config import RunConfig
 from data_designer.config.sampler_params import SamplerType
 from data_designer.engine.dataset_builders import block_execution as block_execution_module
@@ -130,6 +130,40 @@ def test_execute_dataset_block_streams_ordered_chunks_and_summary(
     assert stream.summary.output_rows == 5
     assert stream.summary.dropped_rows == 0
     assert stream.summary.all_rows_dropped is False
+
+
+def test_execute_dataset_block_stream_captures_chunk_processor_artifacts(
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="x_label", expr="{{ x }}-{{ label }}"))
+    config_builder.add_processor(
+        SchemaTransformProcessorConfig(name="schema-transform", template={"combined": "{{ x_label }}"})
+    )
+    config_builder.add_processor(processor_type=ProcessorType.DROP_COLUMNS, name="drop-label", column_names=["label"])
+    input_frame = lazy.pd.DataFrame({"x": [1, 2, 3], "label": ["a", "b", "c"]})
+
+    stream = execute_dataset_block_stream(
+        rows_per_chunk=2,
+        config_builder=config_builder,
+        runtime_context=_runtime_context(tmp_path, stub_model_providers),
+        input_frame=input_frame,
+        options=BlockExecutionOptions(use_async=True, capture_stream_artifacts=True),
+    )
+
+    chunks = list(stream)
+
+    assert [chunk.processor_artifacts["schema-transform"].to_dict(orient="records") for chunk in chunks] == [
+        [{"combined": "1-a"}, {"combined": "2-b"}],
+        [{"combined": "3-c"}],
+    ]
+    assert lazy.pd.concat([chunk.dataframe for chunk in chunks], ignore_index=True).to_dict(orient="records") == [
+        {"x": 1, "x_label": "1-a"},
+        {"x": 2, "x_label": "2-b"},
+        {"x": 3, "x_label": "3-c"},
+    ]
 
 
 def test_execute_dataset_block_uses_model_columns(

--- a/packages/data-designer/src/data_designer/integrations/ray/artifact_output.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/artifact_output.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import data_designer.lazy_heavy_imports as lazy
-from data_designer.engine.dataset_builders.block_execution import BlockExecutionResult
+from data_designer.engine.dataset_builders.block_execution import BlockExecutionChunk, BlockExecutionResult
 from data_designer.engine.storage.artifact_storage import (
     BATCH_FILE_NAME_FORMAT,
     FINAL_DATASET_FOLDER_NAME,
@@ -175,21 +175,22 @@ def create_data_designer_ray_datasink(
 
 def append_ray_artifact_columns(dataframe: Any, block_result: BlockExecutionResult) -> Any:
     """Append internal artifact columns that the Ray datasink can split back out."""
-    output = dataframe.copy()
-    dropped_dataframe = _dropped_columns_dataframe(
+    return _append_ray_artifact_columns(
+        dataframe,
         raw_dataframe=block_result.raw_dataframe,
         final_dataframe=block_result.dataframe,
+        processor_artifacts=block_result.processor_artifacts,
     )
-    if len(dropped_dataframe.columns) > 0:
-        output = _append_prefixed_dataframe_columns(output, dropped_dataframe, (_DROPPED_ARTIFACT_KIND,))
 
-    for processor_name, processor_dataframe in block_result.processor_artifacts.items():
-        output = _append_prefixed_dataframe_columns(
-            output,
-            processor_dataframe.reset_index(drop=True),
-            (_PROCESSOR_ARTIFACT_KIND, processor_name),
-        )
-    return output
+
+def append_ray_artifact_chunk_columns(dataframe: Any, chunk: BlockExecutionChunk) -> Any:
+    """Append internal artifact columns for one streamed engine chunk."""
+    return _append_ray_artifact_columns(
+        dataframe,
+        raw_dataframe=chunk.raw_dataframe,
+        final_dataframe=chunk.dataframe,
+        processor_artifacts=chunk.processor_artifacts,
+    )
 
 
 def split_ray_artifact_columns(dataframe: Any) -> tuple[Any, Any, dict[str, Any]]:
@@ -212,6 +213,30 @@ def split_ray_artifact_columns(dataframe: Any) -> tuple[Any, Any, dict[str, Any]
         processor_name: lazy.pd.DataFrame(columns) for processor_name, columns in processor_columns.items()
     }
     return lazy.pd.DataFrame(dataframe[final_columns]), lazy.pd.DataFrame(dropped_columns), processor_dataframes
+
+
+def _append_ray_artifact_columns(
+    dataframe: Any,
+    *,
+    raw_dataframe: Any,
+    final_dataframe: Any,
+    processor_artifacts: dict[str, Any],
+) -> Any:
+    output = dataframe.copy()
+    dropped_dataframe = _dropped_columns_dataframe(
+        raw_dataframe=raw_dataframe,
+        final_dataframe=final_dataframe,
+    )
+    if len(dropped_dataframe.columns) > 0:
+        output = _append_prefixed_dataframe_columns(output, dropped_dataframe, (_DROPPED_ARTIFACT_KIND,))
+
+    for processor_name, processor_dataframe in processor_artifacts.items():
+        output = _append_prefixed_dataframe_columns(
+            output,
+            processor_dataframe.reset_index(drop=True),
+            (_PROCESSOR_ARTIFACT_KIND, processor_name),
+        )
+    return output
 
 
 def _dropped_columns_dataframe(*, raw_dataframe: Any, final_dataframe: Any) -> Any:

--- a/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/worker_pipeline.py
@@ -31,7 +31,10 @@ from data_designer.engine.resources.person_reader import PersonReader
 from data_designer.engine.resources.seed_reader import SeedReader
 from data_designer.engine.secret_resolver import SecretResolver
 from data_designer.integrations.ray import seed_planning as ray_seed_planning
-from data_designer.integrations.ray.artifact_output import append_ray_artifact_columns
+from data_designer.integrations.ray.artifact_output import (
+    append_ray_artifact_chunk_columns,
+    append_ray_artifact_columns,
+)
 from data_designer.integrations.ray.errors import (
     RayBackendConfigurationError,
     RayBackendRowCountError,
@@ -212,8 +215,6 @@ class _RayWorkerGenerationPipeline:
     def should_stream_worker_output(self) -> bool:
         if self._execution_payload.output_chunk_rows is None:
             return False
-        if self._execution_payload.capture_artifacts:
-            return False
         return not (
             self._execution_payload.hidden_order_column is not None
             and not self._execution_payload.preserve_output_row_count
@@ -280,6 +281,8 @@ class _RayWorkerGenerationPipeline:
                 emitted_rows += len(output)
                 if self._observability_options.profile_workers:
                     profile.observe(output, input_frame=input_profile_frame)
+                if self._execution_payload.capture_artifacts:
+                    output = append_ray_artifact_chunk_columns(output, chunk)
                 yield output
 
             block_summary = stream.summary
@@ -380,7 +383,11 @@ class _RayWorkerGenerationPipeline:
             runtime_context=self._worker_options,
             input_frame=input_frame,
             num_records=worker_batch.num_records,
-            options=BlockExecutionOptions(use_async=True, dataset_name="ray-block"),
+            options=BlockExecutionOptions(
+                use_async=True,
+                dataset_name="ray-block",
+                capture_stream_artifacts=self._execution_payload.capture_artifacts,
+            ),
         )
 
     def complete_empty_batch(self, worker_batch: _RayWorkerBatch, batch_observer: _RayWorkerBatchObserver) -> Any:

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -514,6 +514,80 @@ def test_ray_backend_writes_dropped_columns_and_processor_artifacts_with_fake_ra
     }
 
 
+def test_ray_backend_streams_artifact_chunks_with_fake_ray(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    fake_ray = install_fake_ray(monkeypatch)
+    input_dataset = fake_ray.data.dataset(
+        [lazy.pd.DataFrame({"x": [1, 2, 3, 4, 5], "label": ["a", "b", "c", "d", "e"]})]
+    )
+    config_builder = _input_expression_config_builder(stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="kept_label", expr="{{ label }}"))
+    config_builder.add_processor(
+        SchemaTransformProcessorConfig(name="schema-transform", template={"combined": "{{ x_label }}"})
+    )
+    config_builder.add_processor(DropColumnsProcessorConfig(name="drop-x-label", column_names=["x_label"]))
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(batch_size=5, output_chunk_rows=2, write_artifacts=True),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset, num_records=5, dataset_name="ray-output")
+    artifact_storage = results.artifact_storage
+
+    assert artifact_storage is not None
+    assert input_dataset.map_batches_kwargs is not None
+    execution_payload = input_dataset.map_batches_kwargs["fn_constructor_kwargs"]["execution_payload"]
+    assert execution_payload.capture_artifacts is True
+    assert execution_payload.output_chunk_rows == 2
+    assert results.load_dataset().to_pandas().to_dict(orient="records") == [
+        {"x": 1, "label": "a", "kept_label": "a"},
+        {"x": 2, "label": "b", "kept_label": "b"},
+        {"x": 3, "label": "c", "kept_label": "c"},
+        {"x": 4, "label": "d", "kept_label": "d"},
+        {"x": 5, "label": "e", "kept_label": "e"},
+    ]
+    assert artifact_storage.load_dataset(batch_stage=BatchStage.DROPPED_COLUMNS).to_dict(orient="records") == [
+        {"x_label": "1-a"},
+        {"x_label": "2-b"},
+        {"x_label": "3-c"},
+        {"x_label": "4-d"},
+        {"x_label": "5-e"},
+    ]
+    assert results.load_processor_dataset("schema-transform").to_dict(orient="records") == [
+        {"combined": "1-a"},
+        {"combined": "2-b"},
+        {"combined": "3-c"},
+        {"combined": "4-d"},
+        {"combined": "5-e"},
+    ]
+
+    metadata = artifact_storage.read_metadata()
+    assert metadata["actual_num_records"] == 5
+    assert metadata["num_completed_batches"] == 3
+    assert metadata["file_paths"]["parquet-files"] == [
+        "parquet-files/batch_00000.parquet",
+        "parquet-files/batch_00001.parquet",
+        "parquet-files/batch_00002.parquet",
+    ]
+    assert metadata["file_paths"]["dropped-columns-parquet-files"] == [
+        "dropped-columns-parquet-files/batch_00000.parquet",
+        "dropped-columns-parquet-files/batch_00001.parquet",
+        "dropped-columns-parquet-files/batch_00002.parquet",
+    ]
+    assert metadata["file_paths"]["processor-files"]["schema-transform"] == [
+        "processors-files/schema-transform/batch_00000.parquet",
+        "processors-files/schema-transform/batch_00001.parquet",
+        "processors-files/schema-transform/batch_00002.parquet",
+    ]
+
+
 def test_ray_datasink_metadata_uses_aggregate_write_result_count(tmp_path: Path) -> None:
     datasink = DataDesignerRayDatasink(
         base_dataset_path=tmp_path,

--- a/packages/data-designer/tests/integrations/ray/test_real_smoke.py
+++ b/packages/data-designer/tests/integrations/ray/test_real_smoke.py
@@ -20,8 +20,10 @@ from data_designer.config.default_model_settings import (
     get_builtin_model_providers,
     resolve_seed_default_model_settings,
 )
+from data_designer.config.processors import DropColumnsProcessorConfig, SchemaTransformProcessorConfig
 from data_designer.config.seed_source import LocalFileSeedSource
 from data_designer.engine.secret_resolver import PlaintextResolver
+from data_designer.engine.storage.artifact_storage import BatchStage
 from data_designer.integrations.ray import RayBackend, RayDataContextOptions, RayExecutionResources, RayInputRepartition
 from data_designer.interface.data_designer import DataDesigner
 
@@ -199,6 +201,52 @@ def test_real_ray_data_designer_artifact_write_smoke(
     assert metadata["file_paths"]["parquet-files"]
     assert results.load_dataset().count() == 2
     assert sorted(artifact_storage.final_dataset_path.glob("*.parquet"))
+
+
+def test_real_ray_data_designer_artifact_write_output_chunks_smoke(
+    local_ray: Any,
+    real_ray_smoke_paths: Any,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    input_dataset = local_ray.data.from_pandas(lazy.pd.DataFrame({"x": [1, 2, 3, 4], "label": ["a", "b", "c", "d"]}))
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(ExpressionColumnConfig(name="x_label", expr="{{ x }}-{{ label }}"))
+    config_builder.add_column(ExpressionColumnConfig(name="kept_label", expr="{{ label }}"))
+    config_builder.add_processor(
+        SchemaTransformProcessorConfig(name="schema-transform", template={"combined": "{{ x_label }}"})
+    )
+    config_builder.add_processor(DropColumnsProcessorConfig(name="drop-x-label", column_names=["x_label"]))
+    designer = DataDesigner(
+        artifact_path=real_ray_smoke_paths.artifact_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=real_ray_smoke_paths.managed_assets_path,
+        backend=RayBackend(batch_size=4, output_chunk_rows=2, write_artifacts=True),
+    )
+
+    results = designer.create(config_builder, input_dataset=input_dataset, num_records=4, dataset_name="ray-chunks")
+    artifact_storage = results.artifact_storage
+
+    assert artifact_storage is not None
+    metadata = artifact_storage.read_metadata()
+    assert metadata["actual_num_records"] == 4
+    assert metadata["file_paths"]["parquet-files"]
+    assert metadata["file_paths"]["dropped-columns-parquet-files"]
+    assert metadata["file_paths"]["processor-files"]["schema-transform"]
+    assert results.load_dataset().count() == 4
+    assert artifact_storage.load_dataset(batch_stage=BatchStage.DROPPED_COLUMNS).to_dict(orient="records") == [
+        {"x_label": "1-a"},
+        {"x_label": "2-b"},
+        {"x_label": "3-c"},
+        {"x_label": "4-d"},
+    ]
+    assert results.load_processor_dataset("schema-transform").to_dict(orient="records") == [
+        {"combined": "1-a"},
+        {"combined": "2-b"},
+        {"combined": "3-c"},
+        {"combined": "4-d"},
+    ]
 
 
 def test_real_ray_input_dataset_repartition_smoke(


### PR DESCRIPTION
## 📋 Summary

Extends RayBackend `output_chunk_rows` streaming to `write_artifacts=True` runs. Engine row-group chunks now carry chunk-local processor artifacts, and Ray workers attach dropped-column and processor artifact payloads to each emitted chunk so the Ray datasink can persist artifact outputs without forcing a full worker-frame materialization.

## 🔗 Related Issue

Closes #129

## 🔄 Changes

- Adds chunk-local processor artifact payloads to the engine block stream API and avoids loading full processor artifact frames into the stream summary when chunk capture is active.
- Lets Ray workers stream artifact-capture chunks by packing dropped-column and processor artifact columns per emitted chunk.
- Preserves materialized fallback correctness by assigning chunk-local batch numbers when the engine cannot row-group stream.
- Adds fake Ray and real-Ray coverage for `write_artifacts=True` with `output_chunk_rows`, including dropped-column and schema-transform processor artifacts.
- Updates the Ray backend docs to describe artifact-aware streaming chunks.

## 🧪 Testing

- [ ] `make test` passes — not run; targeted merge-train gates below were run.
- [x] Unit tests added/updated
- [x] E2E tests added/updated

Additional validation:

- [x] `ruff check` on touched implementation and tests
- [x] `ruff format --check` on touched Python files
- [x] `pytest packages/data-designer-engine/tests/engine/dataset_builders/test_block_execution.py packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_streams_artifact_chunks_with_fake_ray -q`
- [x] `pytest packages/data-designer/tests/integrations/ray -m "ray_fake or ray_worker_boundary or ray_benchmark" -q` (`262 passed, 1 skipped, 8 deselected`)
- [x] `DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 pytest packages/data-designer/tests/integrations/ray/test_real_smoke.py -m "ray_real_smoke and not ray_live_provider" -q` (`7 passed, 1 deselected`)
- [x] `git diff --check`

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)
