### PR TITLE
fix(ray): harden Ray Data LLM execution boundary

### DIFF
--- a/packages/data-designer/src/data_designer/integrations/ray/backend.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/backend.py
@@ -125,7 +125,7 @@ class RayJobPlan:
 
     dataset_source: RayDatasetSource
     block_plan: Any | None
-    worker_payload: _RayExecutionPayload
+    worker_payload: _RayExecutionPayload | None
     map_batches_kwargs: dict[str, Any]
     ordering_mode: RayOrderingMode
     metrics_collector: Any | None
@@ -133,6 +133,7 @@ class RayJobPlan:
     observability_options: _RayObservabilityOptions
     llm_stage_plan: RayDataLLMStagePlan
     llm_stage_config_builder: DataDesignerConfigBuilder
+    llm_stage_jinja_rendering_engine: Any
     output: RayOutputMode
     num_records: int
     input_blocks: int | None
@@ -463,6 +464,7 @@ class RayBackend:
                 preserve_input_columns=plan.dataset_source.use_input_dataset,
                 hidden_order_column=plan.ordering_mode.hidden_order_column,
                 range_order_column=ray_seed_planning.RAY_RANGE_ID_COLUMN,
+                jinja_rendering_engine=plan.llm_stage_jinja_rendering_engine,
             )
         else:
             try:
@@ -485,14 +487,20 @@ class RayBackend:
             return mapped, mapped, None
 
         try:
+            if plan.llm_stage_plan.should_execute and plan.output == "dataset":
+                result_dataset = _materialize_ray_data_llm_dataset(mapped)
+                return result_dataset, result_dataset, None
             output = mapped.to_arrow_refs() if plan.output == "arrow_refs" else None
             result_dataset = _dataset_from_arrow_refs(ray, output) if output is not None else mapped
         except RayDatasetGenerationError:
             raise
         except Exception as exc:
-            raise RayDatasetGenerationError(
-                "RayBackend failed while materializing Ray output blocks for output='arrow_refs'."
-            ) from exc
+            message = (
+                "RayBackend Ray Data LLM execution failed while materializing Ray output blocks."
+                if plan.llm_stage_plan.should_execute
+                else "RayBackend failed while materializing Ray output blocks for output='arrow_refs'."
+            )
+            raise RayDatasetGenerationError(message) from exc
         return result_dataset, mapped, output
 
     def _write_artifacts(
@@ -627,16 +635,6 @@ class RayDriverPlanner:
             validate_ray_safe_processors(config_builder, allow_dataset_artifacts=self._backend.write_artifacts)
         row_count_preserving = _is_row_count_preserving_config(config_builder)
 
-        model_aliases = _model_health_check_aliases(config_builder)
-        if self._backend.preflight_model_health_check:
-            _run_driver_model_health_check(runtime_context, config_builder, model_aliases)
-        execution_options = self._backend.execution_options.resolve_actor_pool_defaults(
-            model_configs=config_builder.model_configs,
-            model_providers=list(runtime_context.model_providers),
-            default_provider_name=runtime_context.default_provider_name,
-            model_aliases=model_aliases,
-        )
-
         block_plan = self._backend.block_planning.resolve(num_records=num_records) if input_dataset is None else None
         dataset = self._backend._resolve_input_dataset(
             self._ray,
@@ -675,7 +673,6 @@ class RayDriverPlanner:
             max_worker_profiles=self._backend.max_worker_profiles,
             max_throttle_snapshots=self._backend.max_throttle_snapshots,
         )
-        throttle_manager = self._create_throttle_manager(runtime_context, config_builder)
         llm_stage_plan = plan_ray_data_llm_stage(
             config_builder=config_builder,
             options=self._backend.llm_stage_options,
@@ -687,55 +684,73 @@ class RayDriverPlanner:
             dataset_source_kind=dataset_source_kind,
             output_chunk_rows=self._backend.output_chunk_rows,
         )
-        worker_config_builder = _clone_config_builder_for_worker(
-            config_builder,
-            worker_model_health_checks=self._backend.worker_model_health_checks,
-        )
-        worker_seed_readers = (
-            ray_seed_planning.input_dataset_seed_readers()
-            if use_input_dataset
-            else ray_seed_planning.clone_seed_readers_for_worker(runtime_context.seed_readers)
-        )
-        worker_options = _RayWorkerOptions(
-            model_providers=list(runtime_context.model_providers),
-            default_provider_name=runtime_context.default_provider_name,
-            secret_resolver=runtime_context.secret_resolver,
-            seed_readers=worker_seed_readers,
-            managed_assets_path=str(runtime_context.managed_assets_path),
-            person_reader=runtime_context.person_reader,
-            mcp_providers=list(runtime_context.mcp_providers),
-            run_config=runtime_context.run_config,
-            throttle_manager=throttle_manager,
-        )
-        execution_payload = _compile_ray_execution_payload(
-            config_builder=worker_config_builder,
-            worker_options=worker_options,
-            use_input_dataset=use_input_dataset,
-            seed_window=seed_window,
-            range_input_columns=_range_input_columns_for_config(
-                config_builder,
-                dataset_source_kind=dataset_source_kind,
-            ),
-            hidden_order_column=ordering_mode.hidden_order_column,
-            preserve_output_row_count=row_count_preserving,
-            output_chunk_rows=self._backend.output_chunk_rows,
-            capture_artifacts=self._backend.write_artifacts,
+        llm_stage_executes = llm_stage_plan.should_execute
+        model_aliases = [] if llm_stage_executes else _model_health_check_aliases(config_builder)
+        if self._backend.preflight_model_health_check and not llm_stage_executes:
+            _run_driver_model_health_check(runtime_context, config_builder, model_aliases)
+        throttle_manager = (
+            None if llm_stage_executes else self._create_throttle_manager(runtime_context, config_builder)
         )
 
-        map_batches_kwargs: dict[str, Any] = {
-            "fn_constructor_kwargs": {
-                "execution_payload": execution_payload,
-                "metrics_collector": metrics_collector,
-                "observability_options": observability_options,
-            },
-            "batch_size": self._backend.batch_size
-            if self._backend.batch_size is not None
-            else runtime_context.run_config.buffer_size,
-            "batch_format": "pandas",
-            "zero_copy_batch": self._backend.zero_copy_batch,
-        }
-        map_batches_kwargs.update(execution_options.to_map_batches_kwargs(self._ray))
-        map_batches_kwargs["udf_modifying_row_count"] = not row_count_preserving
+        batch_size = (
+            self._backend.batch_size if self._backend.batch_size is not None else runtime_context.run_config.buffer_size
+        )
+        execution_payload: _RayExecutionPayload | None = None
+        map_batches_kwargs: dict[str, Any] = {"batch_size": batch_size}
+        if not llm_stage_executes:
+            execution_options = self._backend.execution_options.resolve_actor_pool_defaults(
+                model_configs=config_builder.model_configs,
+                model_providers=list(runtime_context.model_providers),
+                default_provider_name=runtime_context.default_provider_name,
+                model_aliases=model_aliases,
+            )
+            worker_config_builder = _clone_config_builder_for_worker(
+                config_builder,
+                worker_model_health_checks=self._backend.worker_model_health_checks,
+            )
+            worker_seed_readers = (
+                ray_seed_planning.input_dataset_seed_readers()
+                if use_input_dataset
+                else ray_seed_planning.clone_seed_readers_for_worker(runtime_context.seed_readers)
+            )
+            worker_options = _RayWorkerOptions(
+                model_providers=list(runtime_context.model_providers),
+                default_provider_name=runtime_context.default_provider_name,
+                secret_resolver=runtime_context.secret_resolver,
+                seed_readers=worker_seed_readers,
+                managed_assets_path=str(runtime_context.managed_assets_path),
+                person_reader=runtime_context.person_reader,
+                mcp_providers=list(runtime_context.mcp_providers),
+                run_config=runtime_context.run_config,
+                throttle_manager=throttle_manager,
+            )
+            execution_payload = _compile_ray_execution_payload(
+                config_builder=worker_config_builder,
+                worker_options=worker_options,
+                use_input_dataset=use_input_dataset,
+                seed_window=seed_window,
+                range_input_columns=_range_input_columns_for_config(
+                    config_builder,
+                    dataset_source_kind=dataset_source_kind,
+                ),
+                hidden_order_column=ordering_mode.hidden_order_column,
+                preserve_output_row_count=row_count_preserving,
+                output_chunk_rows=self._backend.output_chunk_rows,
+                capture_artifacts=self._backend.write_artifacts,
+            )
+            map_batches_kwargs.update(
+                {
+                    "fn_constructor_kwargs": {
+                        "execution_payload": execution_payload,
+                        "metrics_collector": metrics_collector,
+                        "observability_options": observability_options,
+                    },
+                    "batch_format": "pandas",
+                    "zero_copy_batch": self._backend.zero_copy_batch,
+                    "udf_modifying_row_count": not row_count_preserving,
+                }
+            )
+            map_batches_kwargs.update(execution_options.to_map_batches_kwargs(self._ray))
 
         return RayJobPlan(
             dataset_source=RayDatasetSource(
@@ -753,6 +768,7 @@ class RayDriverPlanner:
             observability_options=observability_options,
             llm_stage_plan=llm_stage_plan,
             llm_stage_config_builder=config_builder,
+            llm_stage_jinja_rendering_engine=runtime_context.run_config.jinja_rendering_engine,
             output=self._backend.output,
             num_records=num_records,
             input_blocks=_get_num_blocks(dataset),
@@ -846,6 +862,22 @@ def _create_driver_metrics(
         blocks=output_blocks or plan.input_blocks or planned_blocks or 0,
         elapsed_seconds=elapsed_seconds,
     )
+
+
+def _materialize_ray_data_llm_dataset(dataset: Any) -> Any:
+    """Materialize the opt-in Ray Data LLM stage inside the RayBackend error boundary."""
+    materialize = getattr(dataset, "materialize", None)
+    try:
+        if callable(materialize):
+            return materialize()
+        count = getattr(dataset, "count", None)
+        if callable(count):
+            count()
+        return dataset
+    except RayDatasetGenerationError:
+        raise
+    except Exception as exc:
+        raise RayDatasetGenerationError("RayBackend Ray Data LLM execution failed while materializing output.") from exc
 
 
 def _validate_ray_backend_batch_size(batch_size: int | None) -> None:

--- a/packages/data-designer/src/data_designer/integrations/ray/llm.py
+++ b/packages/data-designer/src/data_designer/integrations/ray/llm.py
@@ -12,6 +12,12 @@ from typing import Any, Literal
 from data_designer.config.column_configs import EmbeddingColumnConfig, LLMTextColumnConfig, TraceType
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.models import ChatCompletionInferenceParams, ModelConfig
+from data_designer.engine.column_generators.utils.prompt_renderer import (
+    PromptType,
+    RecordBasedPromptRenderer,
+    create_response_recipe,
+)
+from data_designer.engine.processing.utils import deserialize_json_values
 from data_designer.integrations.ray.errors import RayBackendConfigurationError, RayDatasetGenerationError
 
 RayDataLLMPlacement = Literal["ray-backend-stage-optimization"]
@@ -210,8 +216,8 @@ class _RayDataLLMExecutionAPI:
 
 @dataclass(frozen=True, slots=True)
 class _RayDataLLMTextPreprocessor:
-    prompt: str
-    system_prompt: str | None
+    column_config: LLMTextColumnConfig
+    jinja_rendering_engine: Any
     sampling_params: Mapping[str, Any]
     preserve_input_columns: bool
     hidden_order_column: str | None
@@ -224,10 +230,30 @@ class _RayDataLLMTextPreprocessor:
                 original_row[self.hidden_order_column] = row[self.hidden_order_column]
             elif self.range_order_column in row:
                 original_row[self.hidden_order_column] = row[self.range_order_column]
+        deserialized_record = deserialize_json_values(dict(row))
+        renderer = RecordBasedPromptRenderer(
+            response_recipe=create_response_recipe(self.column_config),
+            error_message_context={
+                "column_name": self.column_config.name,
+                "column_type": self.column_config.column_type,
+                "model_alias": str(self.column_config.model_alias),
+            },
+            jinja_rendering_engine=self.jinja_rendering_engine,
+        )
+        prompt = renderer.render(
+            record=deserialized_record,
+            prompt_template=self.column_config.prompt,
+            prompt_type=PromptType.USER_PROMPT,
+        )
+        system_prompt = renderer.render(
+            record=deserialized_record,
+            prompt_template=self.column_config.system_prompt,
+            prompt_type=PromptType.SYSTEM_PROMPT,
+        )
         messages: list[dict[str, str]] = []
-        if self.system_prompt is not None:
-            messages.append({"role": "system", "content": self.system_prompt})
-        messages.append({"role": "user", "content": self.prompt})
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt or ""})
         output: dict[str, Any] = {
             _ORIGINAL_ROW_KEY: original_row,
             "messages": messages,
@@ -409,6 +435,7 @@ def apply_ray_data_llm_stage(
     config_builder: DataDesignerConfigBuilder,
     plan: RayDataLLMStagePlan,
     preserve_input_columns: bool,
+    jinja_rendering_engine: Any,
     hidden_order_column: str | None = None,
     range_order_column: str = _RAY_RANGE_ID_COLUMN,
 ) -> Any:
@@ -425,8 +452,8 @@ def apply_ray_data_llm_stage(
         processor = execution_api.build_processor(
             processor_config,
             preprocess=_RayDataLLMTextPreprocessor(
-                prompt=column_config.prompt,
-                system_prompt=column_config.system_prompt,
+                column_config=column_config,
+                jinja_rendering_engine=jinja_rendering_engine,
                 sampling_params=_sampling_params_from_model_config(model_config),
                 preserve_input_columns=preserve_input_columns,
                 hidden_order_column=hidden_order_column,

--- a/packages/data-designer/tests/integrations/ray/test_backend.py
+++ b/packages/data-designer/tests/integrations/ray/test_backend.py
@@ -122,7 +122,11 @@ def _map_batches_call_for(fake_ray: Any, fn: Any) -> FakeMapBatchesCall:
     raise AssertionError(f"fake Ray did not record map_batches call for {fn!r}")
 
 
-def _install_fake_ray_data_llm(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+def _install_fake_ray_data_llm(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    include_vllm: bool = True,
+) -> list[dict[str, Any]]:
     processor_calls: list[dict[str, Any]] = []
 
     class FakeVLLMEngineProcessorConfig:
@@ -144,6 +148,7 @@ def _install_fake_ray_data_llm(monkeypatch: pytest.MonkeyPatch) -> list[dict[str
                 rows: list[dict[str, Any]] = []
                 for row in batch.to_dict(orient="records"):
                     messages = row["messages"]
+                    processor_calls[-1].setdefault("messages", []).append(messages)
                     row["generated_text"] = f"fake-vllm:{messages[-1]['content']}"
                     rows.append(row)
                 return lazy.pd.DataFrame(rows)
@@ -178,11 +183,47 @@ def _install_fake_ray_data_llm(monkeypatch: pytest.MonkeyPatch) -> list[dict[str
         if name == "ray.data.llm":
             return fake_ray_data_llm
         if name == "vllm":
+            if not include_vllm:
+                raise ModuleNotFoundError("No module named 'vllm'")
             return types.SimpleNamespace()
         return original_import_module(name)
 
     monkeypatch.setattr(ray_llm_module.importlib, "import_module", import_module)
     return processor_calls
+
+
+def _install_lazy_failing_ray_data_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeVLLMEngineProcessorConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class LazyFailureDataset:
+        def materialize(self) -> None:
+            raise RuntimeError("lazy vllm execution failed")
+
+    def build_processor(
+        config: FakeVLLMEngineProcessorConfig,
+        preprocess: Any,
+        postprocess: Any,
+        **kwargs: Any,
+    ) -> Any:
+        del config, preprocess, postprocess, kwargs
+        return lambda dataset: LazyFailureDataset()
+
+    fake_ray_data_llm = types.SimpleNamespace(
+        build_processor=build_processor,
+        vLLMEngineProcessorConfig=FakeVLLMEngineProcessorConfig,
+    )
+    original_import_module = ray_llm_module.importlib.import_module
+
+    def import_module(name: str) -> Any:
+        if name == "ray.data.llm":
+            return fake_ray_data_llm
+        if name == "vllm":
+            return types.SimpleNamespace()
+        return original_import_module(name)
+
+    monkeypatch.setattr(ray_llm_module.importlib, "import_module", import_module)
 
 
 @custom_column_generator(required_columns=["x"])
@@ -1447,7 +1488,7 @@ def test_ray_backend_executes_opt_in_ray_data_llm_stage_with_fake_processor(
     stub_model_configs: Any,
     stub_model_providers: Any,
 ) -> None:
-    install_fake_ray(monkeypatch)
+    fake_ray = install_fake_ray(monkeypatch)
     processor_calls = _install_fake_ray_data_llm(monkeypatch)
     input_dataset = FakeRayDataset(
         [
@@ -1502,7 +1543,82 @@ def test_ray_backend_executes_opt_in_ray_data_llm_stage_with_fake_processor(
     assert processor_calls[0]["config"].kwargs["model_source"] == "local-model"
     assert processor_calls[0]["config"].kwargs["batch_size"] == 4
     assert processor_calls[0]["config"].kwargs["concurrency"] == (1, 2)
-    assert all(call.fn is not ray_backend_module._RayBatchWorker for call in input_dataset.map_batches_calls)
+    assert all(call.fn is not ray_backend_module._RayBatchWorker for call in fake_ray.data.map_batches_calls)
+
+
+def test_ray_backend_ray_data_llm_execution_skips_unused_model_facade_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    _install_fake_ray_data_llm(monkeypatch)
+    input_dataset = FakeRayDataset([lazy.pd.DataFrame({"id": [0]})])
+
+    def fail_preflight(*_: Any) -> None:
+        raise AssertionError("ModelFacade preflight should not run for Ray Data LLM execution")
+
+    monkeypatch.setattr(ray_backend_module, "_run_driver_model_health_check", fail_preflight)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                execute=True,
+                model_source="local-model",
+                column_names=("text",),
+            ),
+        ),
+    )
+
+    results = designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
+
+    assert results.load_dataset().to_pandas().to_dict(orient="records") == [{"id": 0, "text": "fake-vllm:Say hello."}]
+    assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_backend_ray_data_llm_execution_renders_prompts_like_model_facade(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    processor_calls = _install_fake_ray_data_llm(monkeypatch)
+    config_builder = DataDesignerConfigBuilder(model_configs=stub_model_configs)
+    config_builder.add_column(
+        LLMTextColumnConfig(
+            name="text",
+            prompt="Say {{ 2 + 2 }}.",
+            system_prompt="",
+            model_alias="stub-model",
+        )
+    )
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                execute=True,
+                model_source="local-model",
+                column_names=("text",),
+            ),
+        ),
+    )
+
+    results = designer.create(config_builder, num_records=1)
+
+    assert results.load_dataset().to_pandas().to_dict(orient="records") == [{"text": "fake-vllm:Say 4."}]
+    assert processor_calls[0]["messages"] == [[{"role": "user", "content": "Say 4."}]]
 
 
 def test_ray_backend_ray_data_llm_stage_drops_range_id_for_from_scratch_jobs(
@@ -1568,6 +1684,62 @@ def test_ray_backend_ray_data_llm_execution_requires_optional_dependencies(
         designer.create(_llm_config_builder(stub_model_configs), input_dataset=input_dataset)
 
     assert input_dataset.map_batches_kwargs is None
+
+
+def test_ray_backend_ray_data_llm_execution_requires_vllm_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    _install_fake_ray_data_llm(monkeypatch, include_vllm=False)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                execute=True,
+                model_source="local-model",
+                column_names=("text",),
+            ),
+        ),
+    )
+
+    with pytest.raises(RayDatasetGenerationError, match="requires vLLM"):
+        designer.create(_llm_config_builder(stub_model_configs), num_records=1)
+
+
+def test_ray_backend_ray_data_llm_lazy_execution_failures_are_normalized(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stub_model_configs: Any,
+    stub_model_providers: Any,
+) -> None:
+    install_fake_ray(monkeypatch)
+    _install_lazy_failing_ray_data_llm(monkeypatch)
+    designer = DataDesigner(
+        artifact_path=tmp_path,
+        model_providers=stub_model_providers,
+        secret_resolver=PlaintextResolver(),
+        managed_assets_path=_managed_assets_path(tmp_path),
+        backend=RayBackend(
+            batch_size=1,
+            llm_stage_options=RayDataLLMStageOptions(
+                enabled=True,
+                execute=True,
+                model_source="local-model",
+                column_names=("text",),
+            ),
+        ),
+    )
+
+    with pytest.raises(RayDatasetGenerationError, match="Ray Data LLM execution failed while materializing output"):
+        designer.create(_llm_config_builder(stub_model_configs), num_records=1)
 
 
 def test_ray_backend_default_llm_stage_planning_does_not_execute_ray_data_llm(


### PR DESCRIPTION
## Summary

Follow-up hotfix after the #132 review findings. This tightens the opt-in Ray Data LLM execution boundary before we continue the merge train.

## Changes

- Skips unused ModelFacade preflight, provider throttling actor setup, and worker payload construction when `RayDataLLMStageOptions(execute=True)` selects the Ray Data LLM path.
- Renders Ray Data LLM prompts through the same record-based prompt renderer used by the ModelFacade LLM text generator, including empty-system-prompt behavior.
- Materializes default dataset output for Ray Data LLM execution inside the RayBackend boundary so lazy Ray/vLLM failures normalize as `RayDatasetGenerationError`.
- Strengthens fake coverage for bypassing `_RayBatchWorker`, missing `vllm`, prompt rendering parity, and lazy execution failure normalization.

## Related

Follow-up to #132 and #118.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache-dd-hotfix uv run --all-packages pytest packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_executes_opt_in_ray_data_llm_stage_with_fake_processor packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_ray_data_llm_execution_skips_unused_model_facade_preflight packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_ray_data_llm_execution_renders_prompts_like_model_facade packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_ray_data_llm_execution_requires_optional_dependencies packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_ray_data_llm_execution_requires_vllm_dependency packages/data-designer/tests/integrations/ray/test_backend.py::test_ray_backend_ray_data_llm_lazy_execution_failures_are_normalized -q` (6 passed)
- `UV_CACHE_DIR=/tmp/uv-cache-dd-hotfix uv run --all-packages pytest packages/data-designer/tests/integrations/ray/test_llm.py packages/data-designer/tests/integrations/ray/test_backend.py -q -m ray_fake` (102 passed)
- `UV_CACHE_DIR=/tmp/uv-cache-dd-hotfix-broad uv run --all-packages pytest packages/data-designer/tests/integrations/ray -m "ray_fake or ray_worker_boundary or ray_benchmark" -q` (270 passed, 1 skipped, 7 deselected)
- `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 DATA_DESIGNER_RUN_REAL_RAY_SMOKE=1 UV_CACHE_DIR=/tmp/uv-cache-dd-hotfix-real uv run --all-packages --extra ray --group dev --group recipes pytest packages/data-designer/tests/integrations/ray/test_real_smoke.py -m "ray_real_smoke and not ray_live_provider" -q` (6 passed, 1 deselected)
- `ruff check` and `ruff format --check` on touched files
- `git diff --check`