### PR TITLE
feat(ray): add Ray Data LLM vLLM benchmark

### DIFF
--- a/architecture/ray-data-llm.md
+++ b/architecture/ray-data-llm.md
@@ -2,7 +2,7 @@
 
 Issue: [#52](https://github.com/eric-tramel/DataDesigner/issues/52)  
 Date: 2026-04-25  
-Status: planning hook implemented; narrow opt-in execution prototype implemented
+Status: planning hook implemented; narrow opt-in execution prototype implemented; live benchmark harness added
 
 ## Decision
 
@@ -17,7 +17,7 @@ The safe slice is a capability and planning hook plus a tightly bounded executio
 - vLLM engine arguments own GPU execution details such as tensor/pipeline parallelism and distributed executor backend selection. See <https://docs.vllm.ai/en/latest/configuration/engine_args/>.
 - vLLM and Ray Serve can expose OpenAI-compatible HTTP APIs; those already fit DataDesigner through `ModelProvider(provider_type="openai")`. See <https://docs.vllm.ai/en/latest/serving/openai_compatible_server/>.
 
-Local package introspection for this evaluation found `ray` and `vllm` were not installed in the worker environment, so no live GPU benchmark was run.
+Local package introspection for the original execution prototype found `ray.data.llm` optional dependencies and `vllm` were not installed in the worker environment, so no live GPU benchmark was run in PR #132.
 
 ## Fit Analysis
 
@@ -83,8 +83,33 @@ The Ray Data LLM processor preprocess function builds OpenAI-style chat messages
 - No planner rewrite or GPU benchmark in this PR.
 - No usage-stat parity, trace parity, MCP/tool loop support, structured parsing, or processor support in the execution prototype.
 
+## Benchmark Harness
+
+`scripts/benchmarks/benchmark_ray_data_llm_vllm.py` now provides the explicit verification harness for [issue #118](https://github.com/eric-tramel/DataDesigner/issues/118). It compares:
+
+- `ray-openai-vllm`: existing `RayBackend` worker execution through `ModelFacade` and an OpenAI-compatible local vLLM server/provider.
+- `ray-data-llm`: `RayBackend` with `RayDataLLMStageOptions(enabled=True, execute=True)` using a Ray Data LLM `vLLMEngineProcessorConfig`.
+
+The harness is live opt-in through `--run-live` or `DATA_DESIGNER_RUN_RAY_DATA_LLM_VLLM_BENCHMARK=1`, probes optional `ray.data.llm` and `vllm` imports before execution, can require visible NVIDIA GPUs with `--require-gpu`, and can either fail or emit a skipped JSON report when prerequisites are missing. CI covers the command behavior with fake Ray Data LLM and fake OpenAI-compatible provider wiring, so base installs still do not require vLLM.
+
+Example live run:
+
+```bash
+DATA_DESIGNER_RUN_RAY_DATA_LLM_VLLM_BENCHMARK=1 \
+uv run --all-packages --extra ray python scripts/benchmarks/benchmark_ray_data_llm_vllm.py \
+  --model-source meta-llama/Llama-3.1-8B-Instruct \
+  --provider-endpoint http://127.0.0.1:8000/v1 \
+  --provider-model meta-llama/Llama-3.1-8B-Instruct \
+  --num-records 128 \
+  --batch-size 16 \
+  --ray-data-llm-concurrency 1,2 \
+  --engine-kwargs-json '{"tensor_parallel_size": 1}' \
+  --require-gpu \
+  --output-json /tmp/dd-ray-data-llm-vllm-benchmark.json
+```
+
 ## Follow-Up Recommendation
 
-[Issue #118](https://github.com/eric-tramel/DataDesigner/issues/118) tracks a RayBackend-only proof of concept and benchmark. The POC should compare the existing RayBackend plus OpenAI-compatible vLLM server path against a Ray Data LLM processor stage for a single independent text column, then expand only if the result preserves usage stats, errors, ordering, dropped-row behavior, and observability.
+[Issue #118](https://github.com/eric-tramel/DataDesigner/issues/118) should be closable after this harness is run in a real GPU/vLLM environment and records a successful comparison, or if any live-only parity gaps discovered by that run are split into concrete follow-up issues.
 
 The remaining validation step needs an environment with `ray.data.llm` optional dependencies, vLLM, GPU resources, and a real local model source. Local package introspection on the current development environment found `ray.data.llm` imports fail because optional dependencies such as `boto3` are absent, so local tests use a fake Ray Data LLM processor and the real path fails fast when those optional dependencies are unavailable.

--- a/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
+++ b/packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py
@@ -5,15 +5,26 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import json
 import sys
+import types
 from pathlib import Path
 from types import ModuleType
 from typing import Any
 
 import pytest
+from fake_ray_harness import FakeRayDataset, install_fake_ray
 
 import data_designer.lazy_heavy_imports as lazy
+from data_designer.engine.models.clients.adapters.openai_compatible import OpenAICompatibleClient
+from data_designer.engine.models.clients.types import (
+    AssistantMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    Usage,
+)
 from data_designer.integrations.ray import RayDatasetAnalysis, RayDatasetStats, RayTraceEvent, RayWorkerProfile
+from data_designer.integrations.ray import llm as ray_llm_module
 
 pytestmark = pytest.mark.ray_benchmark
 
@@ -54,6 +65,133 @@ def test_ray_benchmark_scripts_import_with_shared_helpers() -> None:
     assert modules["benchmark_ray_openai"].RESULT_PREFIX == "RAY_OPENAI_BENCHMARK_RESULT="
     assert modules["benchmark_ray_mock_provider"].RESULT_PREFIX == "RAY_MOCK_PROVIDER_BENCHMARK_RESULT="
     assert modules["benchmark_ray_streaming_out_of_core"].RESULT_PREFIX == "RAY_STREAMING_OUT_OF_CORE_RESULT="
+    assert modules["benchmark_ray_data_llm_vllm"].RESULT_PREFIX == "RAY_DATA_LLM_VLLM_BENCHMARK_RESULT="
+
+
+def test_ray_data_llm_vllm_benchmark_requires_live_opt_in() -> None:
+    module = _load_benchmark_module(
+        "benchmark_ray_data_llm_vllm_opt_in",
+        _benchmark_dir() / "benchmark_ray_data_llm_vllm.py",
+    )
+
+    with pytest.raises(SystemExit, match="live vLLM execution"):
+        module.main(["--skip-provider-health-check"])
+
+
+def test_ray_data_llm_vllm_benchmark_skips_missing_prereqs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_benchmark_module(
+        "benchmark_ray_data_llm_vllm_skip",
+        _benchmark_dir() / "benchmark_ray_data_llm_vllm.py",
+    )
+    output_json = tmp_path / "skip-report.json"
+    unavailable_capabilities = module.RayDataLLMCapabilities(
+        available=False,
+        ray_version=None,
+        missing_symbols=("build_processor", "vLLMEngineProcessorConfig"),
+        has_build_processor=False,
+        has_vllm_engine_processor=False,
+        has_http_request_processor=False,
+        has_serve_deployment_processor=False,
+        import_error="ModuleNotFoundError: boto3",
+    )
+
+    monkeypatch.setattr(module, "probe_ray_data_llm_capabilities", lambda: unavailable_capabilities)
+    monkeypatch.setattr(module, "_module_importable", lambda module_name: False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main(
+            [
+                "--run-live",
+                "--skip-missing-prereqs",
+                "--skip-provider-health-check",
+                "--model-source",
+                "local-model",
+                "--provider-model",
+                "local-model",
+                "--output-json",
+                str(output_json),
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    report = json.loads(output_json.read_text())
+    assert report["summary"]["status"] == "skipped"
+    assert any("ray.data.llm" in failure for failure in report["summary"]["preflight"]["failures"])
+    assert any("vLLM is not importable" in failure for failure in report["summary"]["preflight"]["failures"])
+
+
+def test_ray_data_llm_vllm_benchmark_runs_fake_provider_and_processor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_benchmark_module(
+        "benchmark_ray_data_llm_vllm_fake",
+        _benchmark_dir() / "benchmark_ray_data_llm_vllm.py",
+    )
+    fake_ray = install_fake_ray(monkeypatch)
+    fake_ray.init = lambda **_: None
+    fake_ray.shutdown = lambda: None
+    processor_calls = _install_fake_ray_data_llm(monkeypatch)
+    provider_requests: list[ChatCompletionRequest] = []
+
+    def fake_completion(_: OpenAICompatibleClient, request: ChatCompletionRequest) -> ChatCompletionResponse:
+        provider_requests.append(request)
+        prompt = request.messages[-1]["content"]
+        return ChatCompletionResponse(
+            message=AssistantMessage(content=f"fake-provider:{prompt}"),
+            usage=Usage(input_tokens=2, output_tokens=3, total_tokens=5),
+        )
+
+    async def fake_acompletion(_: OpenAICompatibleClient, request: ChatCompletionRequest) -> ChatCompletionResponse:
+        return fake_completion(_, request)
+
+    monkeypatch.setattr(OpenAICompatibleClient, "completion", fake_completion)
+    monkeypatch.setattr(OpenAICompatibleClient, "acompletion", fake_acompletion)
+    output_json = tmp_path / "benchmark-report.json"
+
+    module.main(
+        [
+            "--run-live",
+            "--skip-provider-health-check",
+            "--skip-gpu-check",
+            "--model-source",
+            "local-model",
+            "--provider-model",
+            "local-model",
+            "--prompt",
+            "Say hello.",
+            "--num-records",
+            "2",
+            "--batch-size",
+            "1",
+            "--max-parallel-requests",
+            "2",
+            "--iterations",
+            "1",
+            "--artifact-root",
+            str(tmp_path / "artifacts"),
+            "--managed-assets-path",
+            str(tmp_path / "managed-assets"),
+            "--output-json",
+            str(output_json),
+        ]
+    )
+
+    report = json.loads(output_json.read_text())
+    backends = {result["backend"] for result in report["results"]}
+    ray_data_llm_result = next(result for result in report["results"] if result["backend"] == "ray-data-llm")
+
+    assert backends == {"ray-openai-vllm", "ray-data-llm"}
+    assert report["summary"]["all_output_valid"] is True
+    assert report["summary"]["baseline_backend"] == "ray-openai-vllm"
+    assert "comparisons_vs_ray_openai_vllm" in report["summary"]
+    assert ray_data_llm_result["llm_stage_plan"]["status"] == "eligible"
+    assert ray_data_llm_result["llm_stage_plan"]["should_execute"] is True
+    assert len(processor_calls) == 1
+    assert len(provider_requests) == 2
 
 
 def test_streaming_benchmark_summarizes_worker_memory_profiles() -> None:
@@ -313,3 +451,66 @@ def _benchmark_result(
             "throttle_count": 0,
         },
     }
+
+
+def _install_fake_ray_data_llm(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    processor_calls: list[dict[str, Any]] = []
+
+    class FakeVLLMEngineProcessorConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class FakeRayDataLLMProcessor:
+        def __init__(self, *, preprocess: Any, postprocess: Any) -> None:
+            self._preprocess = preprocess
+            self._postprocess = postprocess
+
+        def __call__(self, dataset: FakeRayDataset) -> FakeRayDataset:
+            def preprocess_row(row: dict[str, Any]) -> dict[str, Any]:
+                output = dict(row)
+                output.update(self._preprocess(row))
+                return output
+
+            def run_vllm_batch(batch: lazy.pd.DataFrame) -> lazy.pd.DataFrame:
+                rows: list[dict[str, Any]] = []
+                for row in batch.to_dict(orient="records"):
+                    messages = row["messages"]
+                    row["generated_text"] = f"fake-vllm:{messages[-1]['content']}"
+                    rows.append(row)
+                return lazy.pd.DataFrame(rows)
+
+            return dataset.map(preprocess_row).map_batches(run_vllm_batch, batch_format="pandas").map(self._postprocess)
+
+    def build_processor(
+        config: FakeVLLMEngineProcessorConfig,
+        preprocess: Any,
+        postprocess: Any,
+        **kwargs: Any,
+    ) -> FakeRayDataLLMProcessor:
+        processor_calls.append(
+            {
+                "config": config,
+                "preprocess": preprocess,
+                "postprocess": postprocess,
+                "kwargs": kwargs,
+            }
+        )
+        return FakeRayDataLLMProcessor(preprocess=preprocess, postprocess=postprocess)
+
+    fake_ray_data_llm = types.SimpleNamespace(
+        build_processor=build_processor,
+        vLLMEngineProcessorConfig=FakeVLLMEngineProcessorConfig,
+        HttpRequestProcessorConfig=object(),
+        ServeDeploymentProcessorConfig=object(),
+    )
+    original_import_module = ray_llm_module.importlib.import_module
+
+    def import_module(name: str) -> Any:
+        if name == "ray.data.llm":
+            return fake_ray_data_llm
+        if name == "vllm":
+            return types.SimpleNamespace()
+        return original_import_module(name)
+
+    monkeypatch.setattr(ray_llm_module.importlib, "import_module", import_module)
+    return processor_calls

--- a/scripts/benchmarks/benchmark_ray_data_llm_vllm.py
+++ b/scripts/benchmarks/benchmark_ray_data_llm_vllm.py
@@ -1,0 +1,709 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare Ray Data LLM/vLLM execution with the RayBackend OpenAI-compatible path.
+
+Live vLLM execution is intentionally opt-in:
+
+    DATA_DESIGNER_RUN_RAY_DATA_LLM_VLLM_BENCHMARK=1 \
+        uv run --all-packages --extra ray python scripts/benchmarks/benchmark_ray_data_llm_vllm.py \
+        --model-source meta-llama/Llama-3.1-8B-Instruct \
+        --provider-endpoint http://127.0.0.1:8000/v1 \
+        --provider-model meta-llama/Llama-3.1-8B-Instruct \
+        --require-gpu
+
+The benchmark uses one independent plain LLM text column so the
+``RayDataLLMStageOptions(execute=True)`` prototype and the existing RayBackend
++ OpenAI-compatible vLLM server/provider path can be compared directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import subprocess
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import ray_benchmark_common as benchmark_common
+
+from data_designer.config.column_configs import LLMTextColumnConfig
+from data_designer.config.config_builder import DataDesignerConfigBuilder
+from data_designer.config.models import ChatCompletionInferenceParams, ModelConfig, ModelProvider
+from data_designer.integrations.ray import RayBackend, RayDataLLMStageOptions
+from data_designer.integrations.ray.llm import (
+    RayDataLLMCapabilities,
+    RayDataLLMStagePlan,
+    probe_ray_data_llm_capabilities,
+)
+from data_designer.interface.data_designer import DataDesigner
+
+RESULT_PREFIX = "RAY_DATA_LLM_VLLM_BENCHMARK_RESULT="
+LIVE_RUN_ENV = "DATA_DESIGNER_RUN_RAY_DATA_LLM_VLLM_BENCHMARK"
+MODEL_SOURCE_ENV = "DATA_DESIGNER_RAY_DATA_LLM_MODEL_SOURCE"
+VLLM_MODEL_ENV = "DATA_DESIGNER_VLLM_MODEL"
+VLLM_ENDPOINT_ENV = "DATA_DESIGNER_VLLM_ENDPOINT"
+DEFAULT_PROVIDER_NAME = "local-vllm"
+DEFAULT_PROVIDER_ENDPOINT = "http://127.0.0.1:8000/v1"
+DEFAULT_MODEL_ALIAS = "vllm-text"
+DEFAULT_OUTPUT_COLUMN = "completion"
+DEFAULT_PROMPT = "Write one concise sentence about synthetic dataset generation."
+DEFAULT_NUM_RECORDS = 32
+DEFAULT_BATCH_SIZE = 8
+DEFAULT_ITERATIONS = 1
+DEFAULT_RAY_CPUS = 4
+DEFAULT_MAX_TOKENS = 32
+DEFAULT_SEED = 118
+
+BenchmarkBackendName = Literal["ray-openai-vllm", "ray-data-llm"]
+ALL_BACKENDS: tuple[BenchmarkBackendName, ...] = ("ray-openai-vllm", "ray-data-llm")
+BASELINE_BACKEND: BenchmarkBackendName = "ray-openai-vllm"
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Prerequisite check result for a live Ray Data LLM/vLLM benchmark run."""
+
+    ok: bool
+    failures: tuple[str, ...]
+    capabilities: RayDataLLMCapabilities
+    gpu_count: int | None
+    provider_checked: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "failures": list(self.failures),
+            "capabilities": _capabilities_payload(self.capabilities),
+            "gpu_count": self.gpu_count,
+            "provider_checked": self.provider_checked,
+        }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-source", default=os.environ.get(MODEL_SOURCE_ENV) or os.environ.get(VLLM_MODEL_ENV))
+    parser.add_argument("--provider-model", default=os.environ.get(VLLM_MODEL_ENV))
+    parser.add_argument("--provider-endpoint", default=os.environ.get(VLLM_ENDPOINT_ENV, DEFAULT_PROVIDER_ENDPOINT))
+    parser.add_argument("--provider-name", default=DEFAULT_PROVIDER_NAME)
+    parser.add_argument("--provider-api-key-env", default=None)
+    parser.add_argument("--model-alias", default=DEFAULT_MODEL_ALIAS)
+    parser.add_argument("--output-column", default=DEFAULT_OUTPUT_COLUMN)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--system-prompt", default=None)
+    parser.add_argument("--num-records", type=int, default=DEFAULT_NUM_RECORDS)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--max-parallel-requests", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=None)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--ray-cpus", type=int, default=DEFAULT_RAY_CPUS)
+    parser.add_argument("--ray-address", default=None)
+    parser.add_argument("--ray-data-llm-batch-size", type=int, default=None)
+    parser.add_argument("--ray-data-llm-concurrency", default=None)
+    parser.add_argument("--engine-kwargs-json", default=None)
+    parser.add_argument(
+        "--backends",
+        default="all",
+        help="Comma-separated subset of: ray-openai-vllm,ray-data-llm, or all.",
+    )
+    parser.add_argument("--artifact-root", type=Path, default=Path("/tmp/dd-ray-data-llm-vllm-benchmark-artifacts"))
+    parser.add_argument(
+        "--managed-assets-path",
+        type=Path,
+        default=Path("/tmp/dd-ray-data-llm-vllm-benchmark-managed-assets"),
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument(
+        "--run-live",
+        action="store_true",
+        default=False,
+        help=f"Allow live vLLM execution. Also accepted when {LIVE_RUN_ENV}=1.",
+    )
+    parser.add_argument(
+        "--skip-missing-prereqs",
+        action="store_true",
+        default=False,
+        help="Exit 0 with a skipped JSON payload when live prerequisites are missing.",
+    )
+    parser.add_argument(
+        "--allow-failures",
+        action="store_true",
+        default=False,
+        help="Exit 0 even if one compared backend fails or produces invalid output.",
+    )
+    parser.add_argument(
+        "--require-gpu",
+        action="store_true",
+        default=False,
+        help="Require a visible NVIDIA GPU before running the benchmark.",
+    )
+    parser.add_argument(
+        "--skip-gpu-check",
+        action="store_true",
+        default=False,
+        help="Do not verify GPU visibility during preflight.",
+    )
+    parser.add_argument(
+        "--skip-provider-health-check",
+        action="store_true",
+        default=False,
+        help="Do not probe the OpenAI-compatible /models endpoint before running.",
+    )
+    parser.add_argument(
+        "--sandbox-safe-ray-init",
+        action="store_true",
+        default=False,
+        help="Patch Ray process discovery for local macOS sandbox benchmark runs.",
+    )
+    parser.add_argument(
+        "--set-uv-runtime-env",
+        action="store_true",
+        default=False,
+        help="Set RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 before Ray initialization.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    _validate_args(args)
+    _require_live_opt_in(run_live=args.run_live)
+
+    selected_backends = _parse_backends(args.backends)
+    provider_model = _provider_model(args)
+    expected_columns = [args.output_column]
+    preflight = _preflight(args=args, provider_model=provider_model)
+    if not preflight.ok:
+        _handle_preflight_failure(args=args, preflight=preflight)
+        return
+
+    args.artifact_root.mkdir(parents=True, exist_ok=True)
+    args.managed_assets_path.mkdir(parents=True, exist_ok=True)
+    setup_config = _build_config(args=args, provider_model=provider_model)
+
+    setup = {
+        "model_source": args.model_source,
+        "provider_model": provider_model,
+        "provider_endpoint": args.provider_endpoint,
+        "provider_name": args.provider_name,
+        "model_alias": args.model_alias,
+        "output_column": args.output_column,
+        "num_records": args.num_records,
+        "batch_size": args.batch_size,
+        "max_parallel_requests": args.max_parallel_requests,
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+        "iterations": args.iterations,
+        "seed": args.seed,
+        "ray_cpus": args.ray_cpus,
+        "ray_address": args.ray_address,
+        "backends": selected_backends,
+        "preflight": preflight.to_dict(),
+        "model_configs": _model_config_summary(setup_config.model_configs),
+        "expected_columns": expected_columns,
+        "live_run_env": LIVE_RUN_ENV,
+        "allow_failures": args.allow_failures,
+    }
+    _emit({"type": "setup", **setup})
+
+    model_providers = [_provider_config(args)]
+    results: list[dict[str, Any]] = []
+    for iteration in range(1, args.iterations + 1):
+        iteration_seed = args.seed + iteration - 1
+        for backend in selected_backends:
+            start = time.perf_counter()
+            try:
+                result = _run_backend(
+                    backend=backend,
+                    iteration=iteration,
+                    seed=iteration_seed,
+                    args=args,
+                    provider_model=provider_model,
+                    model_providers=model_providers,
+                    expected_columns=expected_columns,
+                )
+            except Exception as exc:
+                result = benchmark_common.failure_payload(
+                    backend=cast(benchmark_common.BackendName, backend),
+                    iteration=iteration,
+                    seed=iteration_seed,
+                    elapsed_seconds=time.perf_counter() - start,
+                    exc=exc,
+                    batch_size=args.batch_size,
+                    max_parallel_requests=args.max_parallel_requests,
+                    expected_columns=expected_columns,
+                    include_retry_throttle=True,
+                )
+                result["backend"] = backend
+                result["error_context"] = "benchmark backend execution failed"
+            results.append(result)
+            _emit({"type": "backend_result", **result})
+
+    summary = _build_summary(results)
+    _emit({"type": "summary", **summary})
+    report = {"setup": setup, "results": results, "summary": summary}
+    if args.output_json is not None:
+        benchmark_common.write_json_report(args.output_json, report, sort_keys=True, trailing_newline=True)
+    benchmark_common.fail_on_invalid_summary(summary=summary, allow_failures=args.allow_failures)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.num_records < 1:
+        raise ValueError("--num-records must be >= 1.")
+    if args.batch_size < 1:
+        raise ValueError("--batch-size must be >= 1.")
+    if args.max_parallel_requests < 1:
+        raise ValueError("--max-parallel-requests must be >= 1.")
+    if args.max_tokens < 1:
+        raise ValueError("--max-tokens must be >= 1.")
+    if args.iterations < 1:
+        raise ValueError("--iterations must be >= 1.")
+    if args.ray_cpus < 1:
+        raise ValueError("--ray-cpus must be >= 1.")
+    if args.ray_data_llm_batch_size is not None and args.ray_data_llm_batch_size < 1:
+        raise ValueError("--ray-data-llm-batch-size must be >= 1 when provided.")
+    _parse_concurrency(args.ray_data_llm_concurrency)
+    _parse_engine_kwargs(args.engine_kwargs_json)
+    _parse_backends(args.backends)
+
+
+def _require_live_opt_in(*, run_live: bool) -> None:
+    if run_live or os.environ.get(LIVE_RUN_ENV) == "1":
+        return
+    raise SystemExit(
+        f"This benchmark performs live vLLM execution. Re-run with --run-live or set {LIVE_RUN_ENV}=1 to opt in."
+    )
+
+
+def _parse_backends(value: str) -> list[BenchmarkBackendName]:
+    if value.strip() == "all":
+        return list(ALL_BACKENDS)
+    backends: list[BenchmarkBackendName] = []
+    seen: set[str] = set()
+    for raw_backend in value.split(","):
+        backend = raw_backend.strip()
+        if backend not in ALL_BACKENDS:
+            raise ValueError(f"Unsupported backend {backend!r}. Expected one of {', '.join(ALL_BACKENDS)} or all.")
+        if backend not in seen:
+            backends.append(cast(BenchmarkBackendName, backend))
+            seen.add(backend)
+    if not backends:
+        raise ValueError("At least one backend must be selected.")
+    return backends
+
+
+def _provider_model(args: argparse.Namespace) -> str:
+    provider_model = args.provider_model or args.model_source
+    return str(provider_model or "")
+
+
+def _preflight(*, args: argparse.Namespace, provider_model: str) -> PreflightResult:
+    failures: list[str] = []
+    if not args.model_source:
+        failures.append(
+            f"--model-source is required for Ray Data LLM execution; set it or {MODEL_SOURCE_ENV}/{VLLM_MODEL_ENV}."
+        )
+    if not provider_model:
+        failures.append("--provider-model is required for the OpenAI-compatible vLLM server path.")
+
+    capabilities = probe_ray_data_llm_capabilities()
+    if not capabilities.supports_local_vllm:
+        detail = f" import failed with {capabilities.import_error}" if capabilities.import_error else ""
+        failures.append(
+            "ray.data.llm local vLLM processor APIs are unavailable"
+            f" (ray_version={capabilities.ray_version!r}, missing={capabilities.missing_symbols!r}).{detail}"
+        )
+
+    if not _module_importable("vllm"):
+        failures.append("vLLM is not importable on the driver. Install vLLM in the benchmark environment.")
+    if not _module_importable("ray"):
+        failures.append("Ray is not importable. Install DataDesigner with the ray extra.")
+
+    gpu_count: int | None = None
+    if args.require_gpu and not args.skip_gpu_check:
+        gpu_count = _visible_nvidia_gpu_count()
+        if gpu_count is None:
+            failures.append("GPU availability could not be verified with CUDA_VISIBLE_DEVICES or nvidia-smi.")
+        elif gpu_count < 1:
+            failures.append("No visible NVIDIA GPU was found.")
+
+    provider_checked = False
+    if not args.skip_provider_health_check:
+        provider_checked = True
+        try:
+            _check_provider_endpoint(args=args)
+        except RuntimeError as exc:
+            failures.append(str(exc))
+
+    return PreflightResult(
+        ok=not failures,
+        failures=tuple(failures),
+        capabilities=capabilities,
+        gpu_count=gpu_count,
+        provider_checked=provider_checked,
+    )
+
+
+def _handle_preflight_failure(*, args: argparse.Namespace, preflight: PreflightResult) -> None:
+    payload = {
+        "status": "skipped" if args.skip_missing_prereqs else "failed",
+        "type": "preflight",
+        "preflight": preflight.to_dict(),
+    }
+    _emit(payload)
+    if args.output_json is not None:
+        benchmark_common.write_json_report(
+            args.output_json,
+            {"setup": {"live_run_env": LIVE_RUN_ENV}, "results": [], "summary": payload},
+            sort_keys=True,
+            trailing_newline=True,
+        )
+    if args.skip_missing_prereqs:
+        raise SystemExit(0)
+    reasons = "; ".join(preflight.failures)
+    raise SystemExit(f"Ray Data LLM/vLLM benchmark prerequisites are missing: {reasons}")
+
+
+def _module_importable(module_name: str) -> bool:
+    try:
+        importlib.import_module(module_name)
+    except Exception:
+        return False
+    return True
+
+
+def _visible_nvidia_gpu_count() -> int | None:
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cuda_visible_devices is not None:
+        normalized = cuda_visible_devices.strip()
+        if normalized in {"", "-1", "none", "None"}:
+            return 0
+        return len([device for device in normalized.split(",") if device.strip()])
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "-L"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return sum(1 for line in result.stdout.splitlines() if line.strip().startswith("GPU "))
+
+
+def _check_provider_endpoint(*, args: argparse.Namespace) -> None:
+    endpoint = str(args.provider_endpoint).rstrip("/")
+    url = f"{endpoint}/models"
+    headers: dict[str, str] = {}
+    api_key = _provider_api_key_value(args)
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = Request(url, headers=headers, method="GET")
+    try:
+        with urlopen(request, timeout=10) as response:
+            status = getattr(response, "status", 200)
+            if status >= 400:
+                raise RuntimeError(f"OpenAI-compatible vLLM endpoint health check failed with HTTP {status}: {url}")
+    except HTTPError as exc:
+        raise RuntimeError(f"OpenAI-compatible vLLM endpoint health check failed with HTTP {exc.code}: {url}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"OpenAI-compatible vLLM endpoint is not reachable at {url}: {exc.reason}") from exc
+    except TimeoutError as exc:
+        raise RuntimeError(f"OpenAI-compatible vLLM endpoint timed out at {url}.") from exc
+
+
+def _provider_api_key_value(args: argparse.Namespace) -> str | None:
+    if args.provider_api_key_env is None:
+        return None
+    value = os.environ.get(args.provider_api_key_env)
+    if not value:
+        raise RuntimeError(f"Provider API key environment variable {args.provider_api_key_env!r} is not set.")
+    return value
+
+
+def _provider_config(args: argparse.Namespace) -> ModelProvider:
+    return ModelProvider(
+        name=args.provider_name,
+        endpoint=args.provider_endpoint,
+        provider_type="openai",
+        api_key=args.provider_api_key_env,
+    )
+
+
+def _build_config(*, args: argparse.Namespace, provider_model: str) -> DataDesignerConfigBuilder:
+    config_builder = DataDesignerConfigBuilder(
+        model_configs=[
+            ModelConfig(
+                alias=args.model_alias,
+                model=provider_model,
+                provider=args.provider_name,
+                skip_health_check=True,
+                inference_parameters=ChatCompletionInferenceParams(
+                    max_parallel_requests=args.max_parallel_requests,
+                    max_tokens=args.max_tokens,
+                    temperature=args.temperature,
+                    top_p=args.top_p,
+                ),
+            )
+        ]
+    )
+    config_builder.add_column(
+        LLMTextColumnConfig(
+            name=args.output_column,
+            prompt=args.prompt,
+            system_prompt=args.system_prompt,
+            model_alias=args.model_alias,
+        )
+    )
+    return config_builder
+
+
+def _run_backend(
+    *,
+    backend: BenchmarkBackendName,
+    iteration: int,
+    seed: int,
+    args: argparse.Namespace,
+    provider_model: str,
+    model_providers: list[ModelProvider],
+    expected_columns: list[str],
+) -> dict[str, Any]:
+    config_builder = _build_config(args=args, provider_model=provider_model)
+    artifact_path = args.artifact_root / f"{backend}-iter-{iteration:02d}"
+    if backend == "ray-openai-vllm":
+        return _run_ray_openai_vllm_backend(
+            backend=backend,
+            iteration=iteration,
+            seed=seed,
+            args=args,
+            config_builder=config_builder,
+            model_providers=model_providers,
+            artifact_path=artifact_path,
+            expected_columns=expected_columns,
+        )
+    return _run_ray_data_llm_backend(
+        backend=backend,
+        iteration=iteration,
+        seed=seed,
+        args=args,
+        config_builder=config_builder,
+        model_providers=model_providers,
+        artifact_path=artifact_path,
+        expected_columns=expected_columns,
+    )
+
+
+def _run_ray_openai_vllm_backend(
+    *,
+    backend: BenchmarkBackendName,
+    iteration: int,
+    seed: int,
+    args: argparse.Namespace,
+    config_builder: DataDesignerConfigBuilder,
+    model_providers: list[ModelProvider],
+    artifact_path: Path,
+    expected_columns: list[str],
+) -> dict[str, Any]:
+    result = benchmark_common.run_ray_backend_benchmark(
+        backend=cast(benchmark_common.BackendName, backend),
+        ray_output="dataset",
+        iteration=iteration,
+        seed=seed,
+        config_builder=config_builder,
+        num_records=args.num_records,
+        batch_size=args.batch_size,
+        max_parallel_requests=args.max_parallel_requests,
+        ray_cpus=args.ray_cpus,
+        artifact_path=artifact_path,
+        managed_assets_path=args.managed_assets_path,
+        model_providers=model_providers,
+        expected_columns=expected_columns,
+        sandbox_safe_ray_init=args.sandbox_safe_ray_init,
+        ray_address=args.ray_address,
+        set_uv_runtime_env=args.set_uv_runtime_env,
+        include_retry_throttle=True,
+    )
+    result["backend"] = backend
+    result["comparison_role"] = "ray-backend-openai-compatible-vllm-server"
+    return result
+
+
+def _run_ray_data_llm_backend(
+    *,
+    backend: BenchmarkBackendName,
+    iteration: int,
+    seed: int,
+    args: argparse.Namespace,
+    config_builder: DataDesignerConfigBuilder,
+    model_providers: list[ModelProvider],
+    artifact_path: Path,
+    expected_columns: list[str],
+) -> dict[str, Any]:
+    benchmark_common.seed_everything(seed)
+    with benchmark_common.ray_session(
+        ray_cpus=args.ray_cpus,
+        sandbox_safe_ray_init=args.sandbox_safe_ray_init,
+        ray_address=args.ray_address,
+        set_uv_runtime_env=args.set_uv_runtime_env,
+    ):
+        designer = DataDesigner(
+            artifact_path=artifact_path,
+            managed_assets_path=args.managed_assets_path,
+            model_providers=model_providers,
+            backend=RayBackend(
+                batch_size=args.batch_size,
+                output="dataset",
+                preflight_model_health_check=False,
+                llm_stage_options=RayDataLLMStageOptions(
+                    enabled=True,
+                    execute=True,
+                    model_source=args.model_source,
+                    column_names=(args.output_column,),
+                    batch_size=args.ray_data_llm_batch_size or args.batch_size,
+                    concurrency=_parse_concurrency(args.ray_data_llm_concurrency),
+                    engine_kwargs=_parse_engine_kwargs(args.engine_kwargs_json),
+                    allow_model_facade_fallback=False,
+                ),
+            ),
+        )
+        designer.set_run_config(benchmark_common.run_config(args.batch_size))
+        start = time.perf_counter()
+        results = designer.create(config_builder, num_records=args.num_records)
+        output = results.load_dataset().to_pandas()
+        metrics = results.load_metrics().to_dict()
+        ray_diagnostics = benchmark_common.load_ray_diagnostics_payload(results)
+        elapsed_seconds = time.perf_counter() - start
+        payload = benchmark_common.result_payload(
+            backend=cast(benchmark_common.BackendName, backend),
+            iteration=iteration,
+            seed=seed,
+            output=output,
+            elapsed_seconds=elapsed_seconds,
+            metrics=metrics,
+            artifact_path=artifact_path,
+            output_mode="dataset",
+            batch_size=args.batch_size,
+            max_parallel_requests=args.max_parallel_requests,
+            expected_columns=expected_columns,
+            expected_rows=args.num_records,
+            include_retry_throttle=True,
+        )
+        payload["backend"] = backend
+        payload["comparison_role"] = "ray-data-llm-vllm-engine-processor"
+        payload["llm_stage_plan"] = _llm_stage_plan_payload(results.llm_stage_plan)
+        payload["ray_diagnostics"] = ray_diagnostics
+        return payload
+
+
+def _parse_concurrency(value: str | None) -> int | tuple[int, int] | None:
+    if value is None or value == "":
+        return None
+    parts = [part.strip() for part in value.split(",")]
+    if len(parts) == 1:
+        concurrency = int(parts[0])
+        if concurrency < 1:
+            raise ValueError("--ray-data-llm-concurrency must be >= 1.")
+        return concurrency
+    if len(parts) == 2:
+        minimum, maximum = (int(part) for part in parts)
+        if minimum < 1 or maximum < minimum:
+            raise ValueError("--ray-data-llm-concurrency tuple must satisfy 1 <= min <= max.")
+        return (minimum, maximum)
+    raise ValueError("--ray-data-llm-concurrency must be an integer or min,max.")
+
+
+def _parse_engine_kwargs(value: str | None) -> dict[str, Any] | None:
+    if value is None or value == "":
+        return None
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise ValueError("--engine-kwargs-json must decode to a JSON object.")
+    return dict(parsed)
+
+
+def _build_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = benchmark_common.build_summary(
+        results,
+        all_backends=cast(tuple[benchmark_common.BackendName, ...], ALL_BACKENDS),
+        baseline_backend=cast(benchmark_common.BackendName, BASELINE_BACKEND),
+        include_requests_per_minute=True,
+        include_retry_throttle=True,
+    )
+    summary["comparisons_vs_ray_openai_vllm"] = summary.pop("comparisons_vs_local_sync")
+    summary["baseline_backend"] = BASELINE_BACKEND
+    summary["ray_data_llm_usage_stats_note"] = (
+        "Ray Data LLM execution currently does not report ModelFacade token/request usage stats."
+    )
+    return summary
+
+
+def _model_config_summary(model_configs: list[ModelConfig]) -> list[dict[str, Any]]:
+    return [
+        {
+            "alias": model_config.alias,
+            "model": model_config.model,
+            "provider": model_config.provider,
+            "max_tokens": getattr(model_config.inference_parameters, "max_tokens", None),
+            "max_parallel_requests": model_config.inference_parameters.max_parallel_requests,
+            "skip_health_check": model_config.skip_health_check,
+        }
+        for model_config in model_configs
+    ]
+
+
+def _capabilities_payload(capabilities: RayDataLLMCapabilities) -> dict[str, Any]:
+    return {
+        "available": capabilities.available,
+        "ray_version": capabilities.ray_version,
+        "missing_symbols": list(capabilities.missing_symbols),
+        "has_build_processor": capabilities.has_build_processor,
+        "has_vllm_engine_processor": capabilities.has_vllm_engine_processor,
+        "has_http_request_processor": capabilities.has_http_request_processor,
+        "has_serve_deployment_processor": capabilities.has_serve_deployment_processor,
+        "supports_local_vllm": capabilities.supports_local_vllm,
+        "supports_openai_compatible_endpoint": capabilities.supports_openai_compatible_endpoint,
+        "import_error": capabilities.import_error,
+    }
+
+
+def _llm_stage_plan_payload(plan: RayDataLLMStagePlan | None) -> dict[str, Any] | None:
+    if plan is None:
+        return None
+    return {
+        "status": plan.status,
+        "enabled": plan.enabled,
+        "should_execute": plan.should_execute,
+        "disabled_reason": plan.disabled_reason,
+        "selected_candidate": None
+        if plan.selected_candidate is None
+        else {
+            "column_name": plan.selected_candidate.column_name,
+            "model_alias": plan.selected_candidate.model_alias,
+            "task_type": plan.selected_candidate.task_type,
+            "model_source": plan.selected_candidate.model_source,
+            "blocked_reasons": list(plan.selected_candidate.blocked_reasons),
+        },
+        "capabilities": None if plan.capabilities is None else _capabilities_payload(plan.capabilities),
+    }
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    benchmark_common.emit_result(RESULT_PREFIX, payload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📋 Summary

Adds a live opt-in benchmark and verification harness for the remaining #118 measurement gap. The harness compares `RayDataLLMStageOptions(execute=True)` against the existing `RayBackend` + OpenAI-compatible local vLLM server/provider path, while failing or skipping clearly when optional Ray Data LLM, vLLM, provider, or GPU prerequisites are unavailable.

## 🔗 Related Issue

Refs #118

## 🔄 Changes

- Adds `scripts/benchmarks/benchmark_ray_data_llm_vllm.py` with live opt-in, prerequisite preflight, JSON result output, and paired `ray-openai-vllm` / `ray-data-llm` backends.
- Extends Ray benchmark tests with fake Ray Data LLM and fake OpenAI-compatible provider wiring so CI can validate command behavior without vLLM or GPU dependencies.
- Updates `architecture/ray-data-llm.md` with the new harness, an example live command, and the remaining closure condition for #118.

## 🔍 Attention Areas

- [benchmark_ray_data_llm_vllm.py](https://github.com/eric-tramel/DataDesigner/blob/worker-p-ray-data-llm-benchmark/scripts/benchmarks/benchmark_ray_data_llm_vllm.py) — new live benchmark command and prerequisite handling.

## 🧪 Testing

- [ ] `make test` passes — not run; focused benchmark tests were run instead.
- [x] Unit tests added/updated: `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-p uv run --all-packages pytest packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py -q -m ray_benchmark` (15 passed)
- [ ] E2E tests added/updated (N/A — live vLLM/GPU execution remains opt-in)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-p uv run --all-packages ruff check scripts/benchmarks/benchmark_ray_data_llm_vllm.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py architecture/ray-data-llm.md` (All checks passed)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-p uv run --all-packages ruff format --check scripts/benchmarks/benchmark_ray_data_llm_vllm.py packages/data-designer/tests/integrations/ray/test_benchmark_ray_openai.py` (2 files already formatted)
- [x] `UV_CACHE_DIR=/tmp/uv-cache-dd-worker-p uv run --all-packages python scripts/benchmarks/benchmark_ray_data_llm_vllm.py --run-live --skip-missing-prereqs --skip-provider-health-check --model-source local-model --provider-model local-model --output-json /tmp/dd-ray-data-llm-vllm-skip-smoke.json` (exited 0 with skipped preflight: Ray/vLLM unavailable)

## ✅ Checklist

- [x] Follows commit message conventions
- [x] Commits are signed off (DCO)
- [x] Architecture docs updated (if applicable)